### PR TITLE
Documentation update: How to view your JS changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ When killing the server, be sure to cleanup your containers.
 docker-compose down
 ```
 
+If you want to make JS changes, you must login to the front end container and build the JS.
+```shell
+docker exec -it containerid /bin/bash
+yarn build
+```
+
 ## Notes on docker
 
 To start docker without it taking over the command terminal, use the following (note, this iwll not display all the output, so you may not see error messages):

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ docker-compose down
 ```
 
 If you want to make JS changes, you must login to the front end container and build the JS.
+This is a temporary solution until we have hot-reloading setup for local development.
 ```shell
 docker exec -it containerid /bin/bash
 yarn build


### PR DESCRIPTION
Right now JS changes don't hot re-load, so you have to log into the front end container and run `yarn build` to see your changes. This PR adds documentation for this.

We're working on making hot re-loading work locally by following this tutorial: https://blog.bam.tech/developper-news/dockerize-your-app-and-keep-hot-reloading

The goal is, instead of this locally:
![image](https://user-images.githubusercontent.com/4640747/50858749-4ca1be00-135f-11e9-998c-e42e94b0e7f5.png)

We want this: 
![image](https://user-images.githubusercontent.com/4640747/50858775-5fb48e00-135f-11e9-814b-d9205b4a0e09.png)


