### PR TITLE
Bug fix: entrypoint.sh change broke master

### DIFF
--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 yarn
+yarn build
 yarn start


### PR DESCRIPTION
In a previous PR, I broke master by replacing `yarn build` with `yarn start` so make sure the front end container stays up. For now, we also need `yarn build` because nginx points to the built version.