### PR TITLE
Nginx Version: nginx 1.15.8

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:latest
+FROM nginx:1.15.8
 
 # Make /var/cache/nginx/ writable by non-root users
 RUN chgrp nginx /var/cache/nginx/


### PR DESCRIPTION
Locking nginx version to 1.15.8. Technically we were already using this, but now it is locked so that if a new version is released we can make sure that it works rather than suddenly having a new version one day.