### PR TITLE
Look and feel - consistency

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -23,7 +23,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>CAT - PSC</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "CAT",
+  "name": "Compotency Assessment Tool",
   "icons": [
     {
       "src": "favicon.ico",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -8,14 +8,12 @@
 }
 
 .App-header {
-  background-color: #282c34;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   font-size: calc(10px + 2vmin);
-  color: white;
 }
 
 .App-link {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -5,6 +5,7 @@
 .App-logo {
   animation: App-logo-spin infinite 20s linear;
   height: 40vmin;
+  margin-top: 20px;
 }
 
 .App-header {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,7 +15,7 @@ class App extends Component {
             <div>
               <Link to="/">Home</Link>
               <span> </span>
-              <Link to="/experiment">Experiment</Link>
+              <Link to="/experiment">Prototype</Link>
               <span> </span>
               <Link to="/status">Status</Link>
             </div>

--- a/frontend/src/Experiment.jsx
+++ b/frontend/src/Experiment.jsx
@@ -5,7 +5,7 @@ class Experiment extends Component {
   render() {
     return (
       <div>
-        <h2>Prototypes</h2>
+        <h2>Prototype</h2>
         <p>
           This page will be used to test out experimental UIs.
         </p>

--- a/frontend/src/Experiment.jsx
+++ b/frontend/src/Experiment.jsx
@@ -1,12 +1,11 @@
 /* eslint-disable class-methods-use-this */
 import React, { Component } from 'react';
-import './App.css';
 
 class Experiment extends Component {
   render() {
     return (
       <div>
-        <h2>Experiment</h2>
+        <h2>Prototypes</h2>
         <p>
           This page will be used to test out experimental UIs.
         </p>

--- a/frontend/src/Home.jsx
+++ b/frontend/src/Home.jsx
@@ -2,40 +2,17 @@ import React, { Component } from 'react';
 import logo from './logo.png';
 import './App.css';
 
-const headers = new Headers({
-  Accept: 'application/json',
-  'Content-Type': 'application/json',
-});
-
 class Home extends Component {
-  componentWillMount() {
-    this.testBackend();
-  }
-
-  state = {
-    test: 'nothing.',
-  }
-
-  testBackend = async () => {
-    const test = await fetch('http://localhost:80/api/', {
-      method: 'GET',
-      headers,
-      cache: 'default',
-    });
-    const testJson = await test.json();
-    if (testJson && testJson.status) {
-      this.setState({ test: testJson.status });
-    }
-  }
-
+  // eslint-disable-next-line class-methods-use-this
   render() {
     return (
-      <header className='App-header'>
-        <img src={logo} className='App-logo' alt='logo' />
+      <div>
+        <h2>Home</h2>
         <p>
-          The backend says: {this.state.test}
+          Welcome to the Compotency Assessment Tool.
         </p>
-      </header>
+        <img src={logo} className='App-logo' alt='logo' />
+      </div>
     );
   }
 }

--- a/frontend/src/Home.test.js
+++ b/frontend/src/Home.test.js
@@ -9,12 +9,8 @@ it('renders without crashing', () => {
   ReactDOM.unmountComponentAtNode(div);
 });
 
-it('renders without crashing', () => {
-  shallow(<Home />);
-});
-
 it('renders initial message from backend', () => {
   const wrapper = shallow(<Home />);
-  const initialMessage = <p>The backend says: nothing.</p>;
+  const initialMessage = <p>Welcome to the Compotency Assessment Tool.</p>;
   expect(wrapper.contains(initialMessage)).toEqual(true);
 });

--- a/frontend/src/Status.jsx
+++ b/frontend/src/Status.jsx
@@ -106,7 +106,7 @@ class Status extends Component {
     return (
       <div style={styles.container}>
         <Jumbotron>
-          <h1>CAT Health</h1>
+          <h1>CAT Status</h1>
           <p>
             Internal status page to quickly determine the status / health
             of the Compotency Assessment Tool.


### PR DESCRIPTION
This PR does some look and feel prep for the project panel.
 - uses `Prototype` over `Experiment` to be consistent with how we talk about building
 - removes API call from the home page because it's not needed now that we have a status page
 - makes all the backgrounds white to match /status
 - spelling of competency (screenshot outdated)

![image](https://user-images.githubusercontent.com/4640747/51858584-12df2a00-2303-11e9-9b3e-030b4a87fcd2.png)
