### PR TITLE
SNYK Script update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 build 
 
 .DS_Store
+
+snyk_results_*.html

--- a/SETUP.md
+++ b/SETUP.md
@@ -48,6 +48,9 @@ Ensure that you have docker and docker-compose installed on your machine, as wel
        7. Click [here](https://eslint.org/) for more details about **ESLint** or [here](https://github.com/airbnb/javascript/tree/master/react#basic-rules) to know more about the Airbnb React style
  * Snyk
    * Run 'npm install -g snyk' in a terminal
+   * Run 'npm install -g snyk-to-html' in a terminal
+     * This allows for clean output to html files when snyk is run locally
+     * Locally detected vulnerabilities can be documented in the repo and version controlled
    * Add the npm directory containing snyk to the path system environment variable (usually "C:\Users\<name>\AppData\Roaming\npm")
      * Note: You may need to restart your computer for this change to take effect
    * Create an account on snyk.io

--- a/SETUP.md
+++ b/SETUP.md
@@ -51,6 +51,7 @@ Ensure that you have docker and docker-compose installed on your machine, as wel
    * Run 'npm install -g snyk-to-html' in a terminal
      * This allows for clean output to html files when snyk is run locally
      * Locally detected vulnerabilities can be documented in the repo and version controlled
+   * See [snyk.md](docs/snyk.md) for an explanation of why snyk is installed locally rather than in the containers
    * Add the npm directory containing snyk to the path system environment variable (usually "C:\Users\<name>\AppData\Roaming\npm")
      * Note: You may need to restart your computer for this change to take effect
    * Create an account on snyk.io

--- a/docs/snyk.md
+++ b/docs/snyk.md
@@ -54,6 +54,18 @@ To enable this:
 
 # Other Notes on snyk
 
+## Why Snyk is installed locally on a dev machine
+
+In [Setup](../SETUP.md), there are steps outlining how to install snyk locally rather pre-installing it inside the containers
+
+There are a few reasons for this
+  * Npm is currently not installed (nor is it needed) in the backend container
+  * Snyk uses an individual developer's account, rather than a centralized one
+    * Each developer can run snyk 200x in a given month for free
+    * Because each dev runs their own test, and PRs are run against a different account, we can run more tests in a given month
+  * The docker containers need to be build, but they do not need to be running for snyk to be run locally
+    * This means a faster turn around time for checking the results of a security patch locally
+
 ## How to run snyk test locally
 
 Running Snyk online is very effective at catching vulnerabilities added by new dependencies within a single docker container. This run can be automated to run wth each PR, or on demand.

--- a/run-snyk-tests.sh
+++ b/run-snyk-tests.sh
@@ -7,9 +7,9 @@ NC='\033[0m' # No Color
 docker-compose build
 # Test the backened
 printf "**** ${BLUE}Begin backend snyk tests${NC} ***\n"
-snyk test backend/ --json | snyk-to-html -o snyk_results/backend.html
+snyk test backend/ --json | snyk-to-html -o snyk_results_backend.html
 printf "**** Complete backend snyk tests ***\n"
 # Test the frontend
 printf "**** ${BLUE}Begin frontend snyk tests${NC} ***\n"
-snyk test frontend/ --json | snyk-to-html -o snyk_results/frontend.html
+snyk test frontend/ --json | snyk-to-html -o snyk_results_frontend.html
 printf "**** Complete frontend snyk tests ***\n"

--- a/run-snyk-tests.sh
+++ b/run-snyk-tests.sh
@@ -4,13 +4,12 @@
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 # Build docker (can comment out if already built)
-docker build -t backend_snyk_test backend/
-docker build -t frontend_snyk_test frontend/
+docker-compose build
 # Test the backened
 printf "**** ${BLUE}Begin backend snyk tests${NC} ***\n"
-snyk test --docker backend_snyk_test --file=backend/Dockerfile
+snyk test backend/ --json | snyk-to-html -o snyk_results/backend.html
 printf "**** Complete backend snyk tests ***\n"
 # Test the frontend
 printf "**** ${BLUE}Begin frontend snyk tests${NC} ***\n"
-snyk test --docker frontend_snyk_test --file=frontend/Dockerfile
+snyk test frontend/ --json | snyk-to-html -o snyk_results/frontend.html
 printf "**** Complete frontend snyk tests ***\n"


### PR DESCRIPTION
Script now runs snyk inside the container (as it does online for PRs) and outputs to two git-ignored hmtl files for ease of viewing.

* Added steps in SETUP.md
  * How to install snyk-to-html
  * **Script will not run without this step, please run the command locally**
* Updated run-skyn-test script
  * Run snyk within containers
  * Output results to
    * snyk_results_backend.html
    * snyk_results_frontend.html
* Updated gitignore (to ignore the files)