### PR TITLE
Fix to remove warning from Emib.jsx file

### DIFF
--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -47,7 +47,11 @@ class Emib extends Component {
         {this.state.curPage === PAGES.inbox && <Inbox />}
         {this.state.curPage === PAGES.confirm && <Confirmation />}
 
-        {this.state.curPage !== PAGES.confirm && <div onClick={this.changePage}>Next</div>}
+        {this.state.curPage !== PAGES.confirm && (
+          <div style={{ color: "blue" }} onClick={this.changePage}>
+            Next
+          </div>
+        )}
       </div>
     );
   }

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -47,11 +47,7 @@ class Emib extends Component {
         {this.state.curPage === PAGES.inbox && <Inbox />}
         {this.state.curPage === PAGES.confirm && <Confirmation />}
 
-        {this.state.curPage !== PAGES.confirm && (
-          <a href onClick={this.changePage}>
-            <div>Next</div>
-          </a>
-        )}
+        {this.state.curPage !== PAGES.confirm && <div onClick={this.changePage}>Next</div>}
       </div>
     );
   }

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -48,7 +48,7 @@ class Emib extends Component {
         {this.state.curPage === PAGES.confirm && <Confirmation />}
 
         {this.state.curPage !== PAGES.confirm && (
-          <a onClick={this.changePage}>
+          <a href onClick={this.changePage}>
             <div>Next</div>
           </a>
         )}


### PR DESCRIPTION
Adding a fix to remove the following warning.
Fixed bug by replacing `<a>` with `<div>` and coloring `<div>` to look like an `<a>` (This will eventually be replaced with a button anyway)

The warning (as reported by @fnormand01 ):
![image](https://user-images.githubusercontent.com/2746350/52479451-a96ae100-2b76-11e9-8845-d32f61162dd3.png)
