### PR TITLE
Emib tab restructure

### DIFF
--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -134,12 +134,12 @@ class Emib extends Component {
       <div>
         <div>
           {this.state.curLanguage === LANGUAGES.english && (
-            <div style={{ color: "blue" }} onClick={this.onSetLanguageToFrench}>
+            <div style={{ color: "blue", cursor: "pointer" }} onClick={this.onSetLanguageToFrench}>
               Français
             </div>
           )}
           {this.state.curLanguage === LANGUAGES.french && (
-            <div style={{ color: "blue" }} onClick={this.onSetLanguageToEnglish}>
+            <div style={{ color: "blue", cursor: "pointer" }} onClick={this.onSetLanguageToEnglish}>
               English
             </div>
           )}
@@ -151,7 +151,7 @@ class Emib extends Component {
         {this.state.curPage === PAGES.confirm && <Confirmation />}
 
         {this.state.curPage !== PAGES.confirm && (
-          <div style={{ color: "blue" }} onClick={this.changePage}>
+          <div style={{ color: "blue", cursor: "pointer" }} onClick={this.changePage}>
             {this.state.curPage === PAGES.welcome && <p>{STRINGS.nextButton}</p>}
             {this.state.curPage === PAGES.howTo && <p>{STRINGS.howToNextButton}</p>}
             {this.state.curPage === PAGES.testTabs && <p>{STRINGS.submitTestButton}</p>}

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -2,15 +2,12 @@ import React, { Component } from "react";
 import Confirmation from "./Confirmation";
 import HowTo from "./HowTo";
 import TestTabs from "./TestTabs";
-import Background from "./Background";
-import Inbox from "./Inbox";
 import LocalizedStrings from "react-localization";
 
 const PAGES = {
   welcome: "welcome",
   howTo: "howTo",
-  background: "background",
-  inbox: "inbox",
+  testTabs: "testTabs",
   confirm: "confirm"
 };
 
@@ -101,12 +98,9 @@ class Emib extends Component {
         this.setState({ curPage: PAGES.howTo });
         break;
       case PAGES.howTo:
-        this.setState({ curPage: PAGES.background });
+        this.setState({ curPage: PAGES.testTabs });
         break;
-      case PAGES.background:
-        this.setState({ curPage: PAGES.inbox });
-        break;
-      case PAGES.inbox:
+      case PAGES.testTabs:
         this.setState({ curPage: PAGES.confirm });
         break;
       default:
@@ -143,16 +137,14 @@ class Emib extends Component {
         <h2>{STRINGS.testTitle}</h2>
         {this.state.curPage === PAGES.welcome && <p>{STRINGS.welcomeMsg}</p>}
         {this.state.curPage === PAGES.howTo && <HowTo />}
-        {this.state.curPage === PAGES.background && <TestTabs lang={this.state.curLanguage} />}
-        {this.state.curPage === PAGES.inbox && <TestTabs lang={this.state.curLanguage} />}
+        {this.state.curPage === PAGES.testTabs && <TestTabs lang={this.state.curLanguage} />}
         {this.state.curPage === PAGES.confirm && <Confirmation />}
 
         {this.state.curPage !== PAGES.confirm && (
           <div style={{ color: "blue" }} onClick={this.changePage}>
             {this.state.curPage === PAGES.welcome && <p>{STRINGS.nextButton}</p>}
             {this.state.curPage === PAGES.howTo && <p>{STRINGS.howToNextButton}</p>}
-            {this.state.curPage === PAGES.background && <p>{STRINGS.nextButton}</p>}
-            {this.state.curPage === PAGES.inbox && <p>{STRINGS.submitTestButton}</p>}
+            {this.state.curPage === PAGES.testTabs && <p>{STRINGS.submitTestButton}</p>}
           </div>
         )}
       </div>

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -68,10 +68,10 @@ let STRINGS = new LocalizedStrings({
     howToNextButton: "Commencer le test",
 
     //Instructions Tab
-    instructionsTabTitle: "FR Instructions",
+    instructionsTabTitle: "Instructions",
 
     //Background Tab
-    backgroundTabTitle: "FR Contexte",
+    backgroundTabTitle: "Contexte",
     backgroundPageTitle: "Page de contexte",
     orgChart: "Organigramme",
     Scenarios: "Scénarios",

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -28,12 +28,17 @@ let STRINGS = new LocalizedStrings({
     taskInstructions: "Task Instuctions",
     howToNextButton: "Start timer and test",
 
-    //Background Page
+    //Instructions Tab
+    instructionsTabTitle: "Instructions",
+
+    //Background Tab
+    backgroundTabTitle: "Background",
     backgroundPageTitle: "Background Page",
     orgChart: "Org Chart",
     Scenarios: "Scenarios",
 
-    //Inbox
+    //Inbox Tab
+    inboxTabTitle: "Inbox",
     inboxPageTitle: "Inbox",
     taskList: "Tasks List",
     notePad: "NotePad",
@@ -62,12 +67,17 @@ let STRINGS = new LocalizedStrings({
     taskInstructions: "Instuctions pour les tâches",
     howToNextButton: "FR Start timer and test",
 
-    //Background Page
+    //Instructions Tab
+    instructionsTabTitle: "FR Instructions",
+
+    //Background Tab
+    backgroundTabTitle: "FR Contexte",
     backgroundPageTitle: "Page de contexte",
     orgChart: "Organigramme",
     Scenarios: "Scénarios",
 
-    //Inbox
+    //Inbox Tab
+    inboxTabTitle: "Boîte de réception",
     inboxPageTitle: "Boîte de réception",
     taskList: "Liste des tâches",
     notePad: "bloc-notes",
@@ -137,7 +147,7 @@ class Emib extends Component {
         <h2>{STRINGS.testTitle}</h2>
         {this.state.curPage === PAGES.welcome && <p>{STRINGS.welcomeMsg}</p>}
         {this.state.curPage === PAGES.howTo && <HowTo />}
-        {this.state.curPage === PAGES.testTabs && <TestTabs lang={this.state.curLanguage} />}
+        {this.state.curPage === PAGES.testTabs && <TestTabs />}
         {this.state.curPage === PAGES.confirm && <Confirmation />}
 
         {this.state.curPage !== PAGES.confirm && (

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import Confirmation from "./Confirmation";
 import HowTo from "./HowTo";
+import TestTabs from "./TestTabs";
 import Background from "./Background";
 import Inbox from "./Inbox";
 import LocalizedStrings from "react-localization";
@@ -142,8 +143,8 @@ class Emib extends Component {
         <h2>{STRINGS.testTitle}</h2>
         {this.state.curPage === PAGES.welcome && <p>{STRINGS.welcomeMsg}</p>}
         {this.state.curPage === PAGES.howTo && <HowTo />}
-        {this.state.curPage === PAGES.background && <Background />}
-        {this.state.curPage === PAGES.inbox && <Inbox />}
+        {this.state.curPage === PAGES.background && <TestTabs lang={this.state.curLanguage} />}
+        {this.state.curPage === PAGES.inbox && <TestTabs lang={this.state.curLanguage} />}
         {this.state.curPage === PAGES.confirm && <Confirmation />}
 
         {this.state.curPage !== PAGES.confirm && (

--- a/frontend/src/components/eMIB/Tab.jsx
+++ b/frontend/src/components/eMIB/Tab.jsx
@@ -15,10 +15,10 @@ class Tab extends Component {
     return (
       <span>
         {this.props.selected === UNSELECTED && (
-          <span style={{ color: "blue" }}>{this.props.tabName}</span>
+          <span style={{ color: "blue", cursor: "pointer" }}>{this.props.tabName}</span>
         )}
         {this.props.selected === SELECTED && (
-          <span style={{ color: "black" }}>{this.props.tabName}</span>
+          <span style={{ color: "black", cursor: "pointer" }}>{this.props.tabName}</span>
         )}
       </span>
     );

--- a/frontend/src/components/eMIB/Tab.jsx
+++ b/frontend/src/components/eMIB/Tab.jsx
@@ -1,0 +1,17 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+
+class Tab extends Component {
+  static propTypes = {
+    tabName: PropTypes.string.isRequired,
+    colour: PropTypes.string.isRequired
+  };
+
+  render() {
+    //this.setState({ curLanguage: lang });
+    return <span style={{ colour: this.props.colour }}>{this.props.tabName}</span>;
+    //TODO can we pass a function as a prop??
+  }
+}
+
+export default Tab;

--- a/frontend/src/components/eMIB/Tab.jsx
+++ b/frontend/src/components/eMIB/Tab.jsx
@@ -1,17 +1,31 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 
+const SELECTED = "true";
+
+const UNSELECTED = "false";
+
 class Tab extends Component {
   static propTypes = {
     tabName: PropTypes.string.isRequired,
-    colour: PropTypes.string.isRequired
+    selected: PropTypes.string.isRequired
   };
 
   render() {
-    //this.setState({ curLanguage: lang });
-    return <span style={{ colour: this.props.colour }}>{this.props.tabName}</span>;
+    return (
+      <span>
+        {this.props.selected === UNSELECTED && (
+          <span style={{ color: "blue" }}>{this.props.tabName}</span>
+        )}
+        {this.props.selected === SELECTED && (
+          <span style={{ color: "black" }}>{this.props.tabName}</span>
+        )}
+      </span>
+    );
     //TODO can we pass a function as a prop??
   }
 }
 
 export default Tab;
+
+export { SELECTED, UNSELECTED };

--- a/frontend/src/components/eMIB/TestTabs.jsx
+++ b/frontend/src/components/eMIB/TestTabs.jsx
@@ -1,0 +1,112 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import HowTo from "./HowTo";
+import Background from "./Background";
+import Inbox from "./Inbox";
+import LocalizedStrings from "react-localization";
+import Tab from "./Tab";
+
+const TABS = {
+  instructions: "instructions",
+  background: "background",
+  inbox: "inbox"
+};
+
+const COLOURS = {
+  unselected: "blue",
+  selected: "red"
+};
+
+const LANGUAGES = {
+  english: "en",
+  french: "fr"
+};
+
+let STRINGS = new LocalizedStrings({
+  en: {
+    //Instructions Tab
+    instructionsPageTitle: "Instructions",
+
+    //Background Tab
+    backgroundPageTitle: "Background",
+
+    //Inbox Tab
+    inboxPageTitle: "Inbox"
+  },
+  fr: {
+    //Instructions Tab
+    instructionsPageTitle: "FR Instructions",
+
+    //Background Tab
+    backgroundPageTitle: "FR Contexte",
+
+    //Inbox Tab
+    inboxPageTitle: "Boîte de réception"
+  }
+});
+
+class TestTabs extends Component {
+  static propTypes = {
+    lang: PropTypes.string.isRequired
+  };
+
+  state = {
+    curTab: TABS.background,
+    curLanguage: this.props.lang,
+    istrColour: COLOURS.unselected,
+    baskColour: COLOURS.selected,
+    inboxColour: COLOURS.unselected
+  };
+
+  switchInstr = () => {
+    this.setState({
+      curTab: TABS.instructions,
+      istrColour: COLOURS.selected,
+      backColour: COLOURS.unselected,
+      inboxColour: COLOURS.unselected
+    });
+  };
+
+  switchBKGD = () => {
+    this.setState({
+      curTab: TABS.background,
+      istrColour: COLOURS.unselected,
+      backColour: COLOURS.selected,
+      inboxColour: COLOURS.unselected
+    });
+  };
+
+  switchInbox = () => {
+    this.setState({
+      curTab: TABS.inbox,
+      istrColour: COLOURS.unselected,
+      backColour: COLOURS.unselected,
+      inboxColour: COLOURS.selected
+    });
+  };
+
+  render() {
+    return (
+      <div>
+        <div>
+          <span onClick={this.switchInstr}>
+            <Tab tabName={STRINGS.instructionsPageTitle} colour={this.state.istrColour} />
+          </span>
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          <span onClick={this.switchBKGD}>
+            <Tab tabName={STRINGS.backgroundPageTitle} colour={this.state.backColour} />
+          </span>
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          <span onClick={this.switchInbox}>
+            <Tab tabName={STRINGS.inboxPageTitle} colour={this.state.inboxColour} />
+          </span>
+        </div>
+        {this.state.curTab === TABS.instructions && <HowTo />}
+        {this.state.curTab === TABS.background && <Background />}
+        {this.state.curTab === TABS.inbox && <Inbox />}
+      </div>
+    );
+  }
+}
+
+export default TestTabs;

--- a/frontend/src/components/eMIB/TestTabs.jsx
+++ b/frontend/src/components/eMIB/TestTabs.jsx
@@ -1,10 +1,8 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 import HowTo from "./HowTo";
 import Background from "./Background";
 import Inbox from "./Inbox";
-import LocalizedStrings from "react-localization";
-import Tab from "./Tab";
+import Tab, { SELECTED, UNSELECTED } from "./Tab";
 import { STRINGS } from "./Emib";
 
 const TABS = {
@@ -13,43 +11,38 @@ const TABS = {
   inbox: "inbox"
 };
 
-const COLOURS = {
-  unselected: "blue",
-  selected: "red"
-};
-
 class TestTabs extends Component {
   state = {
     curTab: TABS.background,
-    istrColour: COLOURS.unselected,
-    baskColour: COLOURS.selected,
-    inboxColour: COLOURS.unselected
+    instructionSelected: UNSELECTED,
+    backgroundSelected: SELECTED,
+    inboxSelected: UNSELECTED
   };
 
   switchInstr = () => {
     this.setState({
       curTab: TABS.instructions,
-      istrColour: COLOURS.selected,
-      backColour: COLOURS.unselected,
-      inboxColour: COLOURS.unselected
+      instructionSelected: SELECTED,
+      backgroundSelected: UNSELECTED,
+      inboxSelected: UNSELECTED
     });
   };
 
   switchBKGD = () => {
     this.setState({
       curTab: TABS.background,
-      istrColour: COLOURS.unselected,
-      backColour: COLOURS.selected,
-      inboxColour: COLOURS.unselected
+      instructionSelected: UNSELECTED,
+      backgroundSelected: SELECTED,
+      inboxSelected: UNSELECTED
     });
   };
 
   switchInbox = () => {
     this.setState({
       curTab: TABS.inbox,
-      istrColour: COLOURS.unselected,
-      backColour: COLOURS.unselected,
-      inboxColour: COLOURS.selected
+      instructionSelected: UNSELECTED,
+      backgroundSelected: UNSELECTED,
+      inboxSelected: SELECTED
     });
   };
 
@@ -58,15 +51,15 @@ class TestTabs extends Component {
       <div>
         <div>
           <span onClick={this.switchInstr}>
-            <Tab tabName={STRINGS.instructionsTabTitle} colour={this.state.istrColour} />
+            <Tab tabName={STRINGS.instructionsTabTitle} selected={this.state.instructionSelected} />
           </span>
           &nbsp;&nbsp;&nbsp;&nbsp;
           <span onClick={this.switchBKGD}>
-            <Tab tabName={STRINGS.backgroundTabTitle} colour={this.state.backColour} />
+            <Tab tabName={STRINGS.backgroundTabTitle} selected={this.state.backgroundSelected} />
           </span>
           &nbsp;&nbsp;&nbsp;&nbsp;
           <span onClick={this.switchInbox}>
-            <Tab tabName={STRINGS.inboxTabTitle} colour={this.state.inboxColour} />
+            <Tab tabName={STRINGS.inboxTabTitle} selected={this.state.inboxSelected} />
           </span>
         </div>
         {this.state.curTab === TABS.instructions && <HowTo />}
@@ -78,3 +71,5 @@ class TestTabs extends Component {
 }
 
 export default TestTabs;
+
+export { TABS };

--- a/frontend/src/components/eMIB/TestTabs.jsx
+++ b/frontend/src/components/eMIB/TestTabs.jsx
@@ -5,6 +5,7 @@ import Background from "./Background";
 import Inbox from "./Inbox";
 import LocalizedStrings from "react-localization";
 import Tab from "./Tab";
+import { STRINGS } from "./Emib";
 
 const TABS = {
   instructions: "instructions",
@@ -17,42 +18,9 @@ const COLOURS = {
   selected: "red"
 };
 
-const LANGUAGES = {
-  english: "en",
-  french: "fr"
-};
-
-let STRINGS = new LocalizedStrings({
-  en: {
-    //Instructions Tab
-    instructionsPageTitle: "Instructions",
-
-    //Background Tab
-    backgroundPageTitle: "Background",
-
-    //Inbox Tab
-    inboxPageTitle: "Inbox"
-  },
-  fr: {
-    //Instructions Tab
-    instructionsPageTitle: "FR Instructions",
-
-    //Background Tab
-    backgroundPageTitle: "FR Contexte",
-
-    //Inbox Tab
-    inboxPageTitle: "Boîte de réception"
-  }
-});
-
 class TestTabs extends Component {
-  static propTypes = {
-    lang: PropTypes.string.isRequired
-  };
-
   state = {
     curTab: TABS.background,
-    curLanguage: this.props.lang,
     istrColour: COLOURS.unselected,
     baskColour: COLOURS.selected,
     inboxColour: COLOURS.unselected
@@ -90,15 +58,15 @@ class TestTabs extends Component {
       <div>
         <div>
           <span onClick={this.switchInstr}>
-            <Tab tabName={STRINGS.instructionsPageTitle} colour={this.state.istrColour} />
+            <Tab tabName={STRINGS.instructionsTabTitle} colour={this.state.istrColour} />
           </span>
           &nbsp;&nbsp;&nbsp;&nbsp;
           <span onClick={this.switchBKGD}>
-            <Tab tabName={STRINGS.backgroundPageTitle} colour={this.state.backColour} />
+            <Tab tabName={STRINGS.backgroundTabTitle} colour={this.state.backColour} />
           </span>
           &nbsp;&nbsp;&nbsp;&nbsp;
           <span onClick={this.switchInbox}>
-            <Tab tabName={STRINGS.inboxPageTitle} colour={this.state.inboxColour} />
+            <Tab tabName={STRINGS.inboxTabTitle} colour={this.state.inboxColour} />
           </span>
         </div>
         {this.state.curTab === TABS.instructions && <HowTo />}

--- a/frontend/src/test/Emib.test.js
+++ b/frontend/src/test/Emib.test.js
@@ -16,17 +16,10 @@ it("renders howTo page", () => {
   expect(wrapper.contains(initialMessage)).toEqual(true);
 });
 
-it("renders background page", () => {
+it("renders background page in test tabs", () => {
   const wrapper = mount(<Emib />);
-  wrapper.setState({ curPage: PAGES.background });
+  wrapper.setState({ curPage: PAGES.testTabs });
   const initialMessage = <h2>{STRINGS.backgroundPageTitle}</h2>;
-  expect(wrapper.contains(initialMessage)).toEqual(true);
-});
-
-it("renders inbox page", () => {
-  const wrapper = mount(<Emib />);
-  wrapper.setState({ curPage: PAGES.inbox });
-  const initialMessage = <h2>{STRINGS.inboxPageTitle}</h2>;
   expect(wrapper.contains(initialMessage)).toEqual(true);
 });
 

--- a/frontend/src/test/Tabs.test.js
+++ b/frontend/src/test/Tabs.test.js
@@ -4,12 +4,12 @@ import Tab, { SELECTED, UNSELECTED } from "../components/eMIB/Tab";
 
 it("renders selected tab", () => {
   const wrapper = shallow(<Tab tabName="Tab1" selected={SELECTED} />);
-  const initialMessage = <span style={{ color: "black" }}>Tab1</span>;
+  const initialMessage = <span style={{ color: "black", cursor: "pointer" }}>Tab1</span>;
   expect(wrapper.contains(initialMessage)).toEqual(true);
 });
 
 it("renders unselected tab", () => {
   const wrapper = shallow(<Tab tabName="Tab2" selected={UNSELECTED} />);
-  const initialMessage = <span style={{ color: "blue" }}>Tab2</span>;
+  const initialMessage = <span style={{ color: "blue", cursor: "pointer" }}>Tab2</span>;
   expect(wrapper.contains(initialMessage)).toEqual(true);
 });

--- a/frontend/src/test/Tabs.test.js
+++ b/frontend/src/test/Tabs.test.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { shallow } from "enzyme";
+import Tab, { SELECTED, UNSELECTED } from "../components/eMIB/Tab";
+
+it("renders selected tab", () => {
+  const wrapper = shallow(<Tab tabName="Tab1" selected={SELECTED} />);
+  const initialMessage = <span style={{ color: "black" }}>Tab1</span>;
+  expect(wrapper.contains(initialMessage)).toEqual(true);
+});
+
+it("renders unselected tab", () => {
+  const wrapper = shallow(<Tab tabName="Tab2" selected={UNSELECTED} />);
+  const initialMessage = <span style={{ color: "blue" }}>Tab2</span>;
+  expect(wrapper.contains(initialMessage)).toEqual(true);
+});

--- a/frontend/src/test/TestTabs.test.js
+++ b/frontend/src/test/TestTabs.test.js
@@ -1,0 +1,32 @@
+import React from "react";
+import { mount } from "enzyme";
+import TestTabs, { TABS } from "../components/eMIB/TestTabs";
+import { STRINGS } from "../components/eMIB/Emib";
+
+it("renders testTabs page", () => {
+  const wrapper = mount(<TestTabs />);
+  expect(wrapper.state("curTab")).toEqual(TABS.background);
+  const backgroundMessage = <h2>{STRINGS.backgroundPageTitle}</h2>;
+  expect(wrapper.contains(backgroundMessage)).toEqual(true);
+});
+
+it("renders instructions tab", () => {
+  const wrapper = mount(<TestTabs />);
+  wrapper.setState({ curTab: TABS.instructions });
+  const initialMessage = <h2>{STRINGS.howToPageTitle}</h2>;
+  expect(wrapper.contains(initialMessage)).toEqual(true);
+});
+
+it("renders background tab", () => {
+  const wrapper = mount(<TestTabs />);
+  wrapper.setState({ curTab: TABS.background });
+  const initialMessage = <h2>{STRINGS.backgroundPageTitle}</h2>;
+  expect(wrapper.contains(initialMessage)).toEqual(true);
+});
+
+it("renders inbox tab", () => {
+  const wrapper = mount(<TestTabs />);
+  wrapper.setState({ curTab: TABS.inbox });
+  const initialMessage = <h2>{STRINGS.inboxPageTitle}</h2>;
+  expect(wrapper.contains(initialMessage)).toEqual(true);
+});


### PR DESCRIPTION
Restructure of Emib and tests to include a component with 3 tabs for the test (instructions, background, and inbox) rather than managing 3 individual components within the Emib component.

Addition and update of relevant tests.

Also added "Tab" component, which can hopefully be reused elsewhere

Background Tab:
![image](https://user-images.githubusercontent.com/2746350/52568296-598d5380-2ddc-11e9-8a4a-49de8c104505.png)

Instructions Tab:
![image](https://user-images.githubusercontent.com/2746350/52568332-6f027d80-2ddc-11e9-9dcc-8c04cddec44e.png)

Inbox Tab:
![image](https://user-images.githubusercontent.com/2746350/52568341-79bd1280-2ddc-11e9-8aae-138728ca9557.png)

