### PR TITLE
Next Button Navigation patch

### DIFF
--- a/frontend/src/Experiment.jsx
+++ b/frontend/src/Experiment.jsx
@@ -6,7 +6,12 @@ const Experiment = () => {
     <div className="app">
       <h2>{LOCALIZE.prototypePage.title}</h2>
       <p>{LOCALIZE.prototypePage.welcomeMsg}</p>
-      <a href="/emib-sample">{LOCALIZE.prototypePage.startEmibSampleTest}</a>
+
+      <form method="get" action="/emib-sample">
+        <button type="submit" class="btn btn-primary">
+          {LOCALIZE.prototypePage.startEmibSampleTest}
+        </button>
+      </form>
     </div>
   );
 };

--- a/frontend/src/components/eMIB/Confirmation.jsx
+++ b/frontend/src/components/eMIB/Confirmation.jsx
@@ -6,9 +6,11 @@ class Confirmation extends Component {
     return (
       <div>
         <p>{LOCALIZE.emibTest.confirmationPage.submissionConfirmed}</p>
-        <a style={{ color: "blue" }} href="/experiment">
-          {LOCALIZE.commons.exitTest}
-        </a>
+        <form method="get" action="/experiment">
+          <button type="submit" className="btn btn-primary">
+            {LOCALIZE.commons.exitTest}
+          </button>
+        </form>
       </div>
     );
   }

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -42,11 +42,13 @@ class Emib extends Component {
         {this.state.curPage === PAGES.confirm && <Confirmation />}
 
         {this.state.curPage !== PAGES.confirm && (
-          <div style={{ color: "blue", cursor: "pointer" }} onClick={this.changePage}>
-            {this.state.curPage === PAGES.welcome && <p>{LOCALIZE.commons.nextButton}</p>}
-            {this.state.curPage === PAGES.howTo && <p>{LOCALIZE.commons.startTest}</p>}
-            {this.state.curPage === PAGES.emibTabs && <p>{LOCALIZE.commons.submitTestButton}</p>}
-          </div>
+          <button type="button" className="btn btn-primary" onClick={this.changePage}>
+            {this.state.curPage === PAGES.welcome && <span>{LOCALIZE.commons.nextButton}</span>}
+            {this.state.curPage === PAGES.howTo && <span>{LOCALIZE.commons.startTest}</span>}
+            {this.state.curPage === PAGES.emibTabs && (
+              <span>{LOCALIZE.commons.submitTestButton}</span>
+            )}
+          </button>
         )}
       </div>
     );

--- a/frontend/src/tests/components/eMIB/Emib.test.js
+++ b/frontend/src/tests/components/eMIB/Emib.test.js
@@ -36,7 +36,7 @@ it("renders Next in English", () => {
   LOCALIZE.setLanguage(LANGUAGES.english);
   const wrapper = mount(<Emib />);
   wrapper.setState({ curPage: PAGES.welcome });
-  const nextButton = <p>{LOCALIZE.commons.nextButton}</p>;
+  const nextButton = <span>{LOCALIZE.commons.nextButton}</span>;
   expect(wrapper.contains(nextButton)).toEqual(true);
 });
 
@@ -44,6 +44,6 @@ it("renders Next in French", () => {
   LOCALIZE.setLanguage(LANGUAGES.french);
   const wrapper = mount(<Emib />);
   wrapper.setState({ curPage: PAGES.welcome });
-  const nextButton = <p>{LOCALIZE.commons.nextButton}</p>;
+  const nextButton = <span>{LOCALIZE.commons.nextButton}</span>;
   expect(wrapper.contains(nextButton)).toEqual(true);
 });


### PR DESCRIPTION
# Description

Changed look and feel of "Start Test", "Next", and "Exit Test" buttons to use Aurora.
Updated relevant tests.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshot

Please provide if applicable.
![image](https://user-images.githubusercontent.com/2746350/52796145-3dd6b700-3041-11e9-89a5-d9572d84d3b5.png)

![image](https://user-images.githubusercontent.com/2746350/52796159-45965b80-3041-11e9-94ee-f7415bd41dc9.png)

![image](https://user-images.githubusercontent.com/2746350/52796185-5050f080-3041-11e9-8022-8594aa6a6acf.png)

![image](https://user-images.githubusercontent.com/2746350/52796204-58a92b80-3041-11e9-87cc-46479fe8d2e8.png)

![image](https://user-images.githubusercontent.com/2746350/52796216-5f37a300-3041-11e9-9645-ae68061295f3.png)



# Testing

Manual steps to test this functionality:

- Start up the application
- Navigate through the tests, start to finish, using only `Tab` and `Enter` keys

Screenshot of unit tests run passing:
![image](https://user-images.githubusercontent.com/2746350/52797463-f30a6e80-3043-11e9-934c-e4cd6139ee5f.png)

NOTE: Merged Master into branch to get the fix from PR #69

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new compiler warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have researched WCAG2.1 standards and met them in this PR
- [x] My changes look good on IE
