### PR TITLE
Adding space to fix bug with StatusCheck and SystemCheck tests

### DIFF
--- a/frontend/src/tests/components/status/StatusCheck.test.js
+++ b/frontend/src/tests/components/status/StatusCheck.test.js
@@ -3,8 +3,8 @@ import { shallow } from "enzyme";
 import StatusCheck from "../../../components/status/StatusCheck";
 import LOCALIZE from "../../../text_resources";
 
-const failingMessage = <span>{LOCALIZE.commons.failStatus}</span>;
-const passingMessage = <span>{LOCALIZE.commons.passStatus}</span>;
+const failingMessage = <span> {LOCALIZE.commons.failStatus}</span>;
+const passingMessage = <span> {LOCALIZE.commons.passStatus}</span>;
 
 it("renders description", () => {
   const wrapper = shallow(<StatusCheck isPassing={false} description="hello world" />);

--- a/frontend/src/tests/components/status/SystemCheck.test.js
+++ b/frontend/src/tests/components/status/SystemCheck.test.js
@@ -3,8 +3,8 @@ import { shallow } from "enzyme";
 import SystemCheck from "../../../components/status/SystemCheck";
 import LOCALIZE from "../../../text_resources";
 
-const failingMessage = <span>{LOCALIZE.commons.failStatus}</span>;
-const passingMessage = <span>{LOCALIZE.commons.passStatus}</span>;
+const failingMessage = <span> {LOCALIZE.commons.failStatus}</span>;
+const passingMessage = <span> {LOCALIZE.commons.passStatus}</span>;
 
 it("renders description", () => {
   const wrapper = shallow(


### PR DESCRIPTION
# Description

Small patch to fix StatusCheck and SystemCheck tests (addition of space in constants within the test)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Testing

Run tests to verify that they all pass

Screenshot of unit tests run passing:
![image](https://user-images.githubusercontent.com/2746350/52796927-bb4ef700-3042-11e9-8c19-64629ca5d5ef.png)


# Checklist:

- [x] New and existing unit tests pass locally with my changes
