### PR TITLE
Updated the header and the sample test mini banner, so it looks the s…

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,7 +19,18 @@ const PATH = {
 
 const styles = {
   navBar: {
-    paddingBottom: 15
+    paddingBottom: 105
+  },
+  tabs: {
+    paddingTop: 68
+  },
+  pscImage: {
+    position: "fixed",
+    top: "3.5%",
+    left: "2.5%"
+  },
+  headerSpace: {
+    paddingBottom: 40
   }
 };
 
@@ -70,10 +81,10 @@ class App extends Component {
             className="fixed-top bg-white navbar navbar-expand"
             role="banner"
           >
-            <div id="psc-image">
+            <div style={styles.pscImage} id="psc-image">
               <img src={psc_header} alt={LOCALIZE.commons.psc} />
             </div>
-            <div className="fixed-top nav nav-tabs">
+            <div style={styles.tabs} className="fixed-top nav nav-tabs">
               <ul id="navigation-tabs" className="mx-auto nav-site nav nav-tabs nav-item">
                 <li className="bg-white">
                   <NavLink isActive={isHomeActive} className="nav-link" to={PATH.home}>
@@ -95,8 +106,8 @@ class App extends Component {
                 <Translation updateLanguageOnPage={this.updateLanguage} />
               </div>
             </div>
-            <br />
           </nav>
+          <div style={styles.headerSpace} />
           <Route exact path={PATH.home} component={Home} />
           <Route path={PATH.prototype} component={Prototype} />
           <Route path={PATH.status} component={Status} />

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -2,10 +2,13 @@
   text-align: center;
 }
 
+/*
+Formatting for English/French button
+*/
 .translation-button {
-  position: absolute;
-  right: 0;
-  padding: 4px 4px 0 0;
+  position: fixed;
+  right: 2%;
+  top: 3.5%;
 }
 
 /*
@@ -23,6 +26,7 @@ Home Page
 #home-page-paragraph {
   background-color: black;
   color: white;
+  font-size: 38px;
 }
 
 /*


### PR DESCRIPTION
# Description

I updated the header and the eMIB sample test mini banner, so it looks the same as the wireframes.

## Type of change

- Code cleanliness or refactor

## Screenshot

**Before:**

![image](https://user-images.githubusercontent.com/23021242/53116202-163a8f80-3516-11e9-927f-6da4e4d85dfc.png)

![image](https://user-images.githubusercontent.com/23021242/53116238-2a7e8c80-3516-11e9-91ba-e5188294d8cd.png)


**After:**

![image](https://user-images.githubusercontent.com/23021242/53115344-fa35ee80-3513-11e9-9608-8ee31d1da4de.png)

![image](https://user-images.githubusercontent.com/23021242/53115542-76c8cd00-3514-11e9-8b8a-474914994d45.png)


# Testing

Applicable for all code changes.
- Only visual changes, so just make sure that the main tabs and the eMIB sample test Home and How To pages look good


Screenshot of unit tests run passing:

![image](https://user-images.githubusercontent.com/23021242/53115817-200fc300-3515-11e9-8e32-8183e33d654f.png)


# Checklist

Applicable for all code changes.

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 10+, Firefox, and Chrome
