### PR TITLE
[How To Page] Building the Evaluation Section

### DIFF
--- a/frontend/src/components/eMIB/Evaluation.jsx
+++ b/frontend/src/components/eMIB/Evaluation.jsx
@@ -1,8 +1,88 @@
 import React, { Component } from "react";
+import "../../css/lib/aurora.min.css";
+import LOCALIZE from "../../text_resources";
+import "../../css/App.css";
 
 class Evaluation extends Component {
   render() {
-    return <div>STUBBED Evaluation Component</div>;
+    return (
+      <div className="emib-text-zone">
+        <div>
+          <h2 className="emib-section-titles">{LOCALIZE.emibTest.howToPage.evaluation.title}</h2>
+          <div>
+            <ul>
+              <li>{LOCALIZE.emibTest.howToPage.evaluation.bullet1}</li>
+              <li>
+                {LOCALIZE.emibTest.howToPage.evaluation.bullet2}
+                <a href="">{LOCALIZE.emibTest.howToPage.evaluation.bullet2Link}</a>.
+              </li>
+              <li>{LOCALIZE.emibTest.howToPage.evaluation.bullet3}</li>
+              <li>{LOCALIZE.emibTest.howToPage.evaluation.bullet4}</li>
+              <li>{LOCALIZE.emibTest.howToPage.evaluation.bullet5}</li>
+            </ul>
+          </div>
+          <div>
+            <h3>{LOCALIZE.emibTest.howToPage.evaluation.keyLeadershipCompetenciesSection.title}</h3>
+            <div>
+              <p>
+                <span className="font-weight-bold">
+                  {
+                    LOCALIZE.emibTest.howToPage.evaluation.keyLeadershipCompetenciesSection
+                      .para1Title
+                  }
+                </span>
+                {LOCALIZE.emibTest.howToPage.evaluation.keyLeadershipCompetenciesSection.para1}
+              </p>
+              <p>
+                <span className="font-weight-bold">
+                  {
+                    LOCALIZE.emibTest.howToPage.evaluation.keyLeadershipCompetenciesSection
+                      .para2Title
+                  }
+                </span>
+                {LOCALIZE.emibTest.howToPage.evaluation.keyLeadershipCompetenciesSection.para2}
+              </p>
+              <p>
+                <span className="font-weight-bold">
+                  {
+                    LOCALIZE.emibTest.howToPage.evaluation.keyLeadershipCompetenciesSection
+                      .para3Title
+                  }
+                </span>
+                {LOCALIZE.emibTest.howToPage.evaluation.keyLeadershipCompetenciesSection.para3}
+              </p>
+              <p>
+                <span className="font-weight-bold">
+                  {
+                    LOCALIZE.emibTest.howToPage.evaluation.keyLeadershipCompetenciesSection
+                      .para4Title
+                  }
+                </span>
+                {LOCALIZE.emibTest.howToPage.evaluation.keyLeadershipCompetenciesSection.para4}
+              </p>
+              <p>
+                <span className="font-weight-bold">
+                  {
+                    LOCALIZE.emibTest.howToPage.evaluation.keyLeadershipCompetenciesSection
+                      .para5Title
+                  }
+                </span>
+                {LOCALIZE.emibTest.howToPage.evaluation.keyLeadershipCompetenciesSection.para5}
+              </p>
+              <p>
+                <span className="font-weight-bold">
+                  {
+                    LOCALIZE.emibTest.howToPage.evaluation.keyLeadershipCompetenciesSection
+                      .para6Title
+                  }
+                </span>
+                {LOCALIZE.emibTest.howToPage.evaluation.keyLeadershipCompetenciesSection.para6}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
   }
 }
 

--- a/frontend/src/components/eMIB/Evaluation.jsx
+++ b/frontend/src/components/eMIB/Evaluation.jsx
@@ -14,14 +14,17 @@ class Evaluation extends Component {
               <li>{LOCALIZE.emibTest.howToPage.evaluation.bullet1}</li>
               <li>
                 {LOCALIZE.emibTest.howToPage.evaluation.bullet2}
-                <a href="">{LOCALIZE.emibTest.howToPage.evaluation.bullet2Link}</a>.
+                <a href="#keyLeadershipCompetencies">
+                  {LOCALIZE.emibTest.howToPage.evaluation.bullet2Link}
+                </a>
+                .
               </li>
               <li>{LOCALIZE.emibTest.howToPage.evaluation.bullet3}</li>
               <li>{LOCALIZE.emibTest.howToPage.evaluation.bullet4}</li>
               <li>{LOCALIZE.emibTest.howToPage.evaluation.bullet5}</li>
             </ul>
           </div>
-          <div>
+          <div id="keyLeadershipCompetencies">
             <h3>{LOCALIZE.emibTest.howToPage.evaluation.keyLeadershipCompetenciesSection.title}</h3>
             <div>
               <p>

--- a/frontend/src/components/eMIB/Overview.jsx
+++ b/frontend/src/components/eMIB/Overview.jsx
@@ -11,7 +11,10 @@ class Overview extends Component {
           <h2 className="emib-section-titles">{LOCALIZE.emibTest.howToPage.overview.title}</h2>
           <p>
             {LOCALIZE.emibTest.howToPage.overview.description}
-            <a href="">{LOCALIZE.emibTest.howToPage.overview.descriptionLink}</a>.
+            <a href="#keyLeadershipCompetencies">
+              {LOCALIZE.emibTest.howToPage.overview.descriptionLink}
+            </a>
+            .
           </p>
         </div>
         <div>

--- a/frontend/src/components/eMIB/TipsOnTest.jsx
+++ b/frontend/src/components/eMIB/TipsOnTest.jsx
@@ -11,7 +11,9 @@ class TipsOnTest extends Component {
           <h2 className="emib-section-titles">{LOCALIZE.emibTest.howToPage.tipsOnTest.title}</h2>
           <p>
             {LOCALIZE.emibTest.howToPage.tipsOnTest.descriptionPart1}
-            <a href="">{LOCALIZE.emibTest.howToPage.tipsOnTest.descriptionLink}</a>
+            <a href="#keyLeadershipCompetencies">
+              {LOCALIZE.emibTest.howToPage.tipsOnTest.descriptionLink}
+            </a>
             {LOCALIZE.emibTest.howToPage.tipsOnTest.descriptionPart2}
           </p>
           <ul>

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -87,6 +87,41 @@ let LOCALIZE = new LocalizedStrings({
             "Use only the information provided in the emails and the background information. Do not make any inferences based on the culture of your own organization. Avoid making assumptions that are not reasonably supported by either the background information or the emails.",
           bullet4: "You can answer the emails in any order you want.",
           bullet5: "You are responsible for managing your own time."
+        },
+        evaluation: {
+          title: "Evaluation",
+          bullet1:
+            "You will be scored on the responses contained in your emails, task list and Reasons for Action. Information left in your Notepad will not be evaluated.",
+          bullet2:
+            "Both the actions you take and the explanations you give will be considered when evaluating your performance on each of the Key Leadership Competencies (described below). You will be assessed on the extent to which your actions demonstrate the ",
+          bullet2Link: "Key Leadership Competencies",
+          bullet3:
+            "Your actions will be rated on effectiveness. Effectiveness is measured by whether your actions would have a positive or a negative impact in resolving the situations presented, and how widespread that impact would be.",
+          bullet4:
+            "Your responses will also be evaluated for how well they meet the organizational objectives presented in the background information.",
+          bullet5:
+            "You will not be scored on your writing. No points will be deducted for spelling, grammar, punctuation errors or for incomplete sentences. However, your writing will need to be clear enough to ensure that the assessors understand which situation you are responding to and your main points.",
+          keyLeadershipCompetenciesSection: {
+            title: "Key Leadership Competencies",
+            para1Title: "Create Vision and Strategy: ",
+            para1:
+              "Managers help to define the future and chart a path forward. To do so, they take into account context. They leverage their knowledge and seek and integrate information from diverse sources to implement concrete activities. They consider different perspectives and consult as needed. Managers balance organizational priorities and improve outcomes.",
+            para2Title: "Mobilize People: ",
+            para2:
+              "Managers inspire and motivate the people they lead. They manage their employee’s performance, provide constructive and respectful feedback to encourage and enable performance excellence. They lead by example, setting goals for themselves that are more demanding than those that they set for others.",
+            para3Title: "Uphold Integrity and Respect: ",
+            para3:
+              "Managers exemplify ethical practices, professionalism and personal integrity, acting in the interest of Canada and Canadians. They create respectful, inclusive and trusting work environments where sound advice is valued. They encourage the expression of diverse opinions and perspectives, while fostering collegiality.",
+            para4Title: "Collaborate with Partners and Stakeholders: ",
+            para4:
+              "Managers are deliberate and resourceful about seeking a wide spectrum of perspectives. In building partnerships, they manage expectations and aim to reach consensus. They demonstrate openness and flexibility to improve outcomes and bring a whole-of-organization perspective to their interactions. Managers acknowledge the role of partners in achieving outcomes.",
+            para5Title: "Promote Innovation and Guide Change: ",
+            para5:
+              "Managers create an environment that supports bold thinking, experimentation and intelligent risk taking. When implementing change, managers maintain momentum, address resistance and anticipate consequences. They use setbacks as a valuable source of insight and learning.",
+            para6Title: "Achieve Results: ",
+            para6:
+              "Managers ensure that they meet team objectives by managing resources. They anticipate, plan, monitor progress and adjust as needed. They demonstrate awareness of the context when making decisions. Managers take personal responsibility for their actions and outcomes of their decisions."
+          }
         }
       },
 
@@ -223,6 +258,41 @@ let LOCALIZE = new LocalizedStrings({
             "Utilisez uniquement l’information fournie dans les courriels et les informations contextuelles. Ne tirez aucune conclusion fondée sur la culture de votre propre organisation. Évitez de faire des suppositions qui ne sont pas raisonnablement corroborées par l’information contextuelle ou les courriels.",
           bullet4: "Vous pouvez répondre aux courriels dans l’ordre que vous désirez.",
           bullet5: "Vous êtes responsable de la gestion de votre temps."
+        },
+        evaluation: {
+          title: "Évaluation",
+          bullet1:
+            "Vous serez évalués en fonction des réponses aux courriels, des tâches et des justifications des mesures prises. Le contenu du bloc-notes ne sera pas évalué.",
+          bullet2:
+            "Les mesures que vous prenez et les explications que vous donnez seront prises en compte dans l’évaluation de votre rendement pour chacune des compétences clés en leadership (décrites ci-dessous). Vous serez évalué sur la façon dont les mesures que vous avez prises démontrent les ",
+          bullet2Link: "compétences clés en leadership",
+          bullet3:
+            "Les mesures que vous avez prises seront évaluées quant à leur efficacité. Le niveau d’efficacité d’une mesure prise est déterminé par l’effet, positif ou négatif, que cette mesure aura sur la résolution des situations présentées dans les courriels de même que par l’étendue de cet effet.",
+          bullet4:
+            "Vos réponses seront également évaluées en fonction de leur contribution à l’atteinte des objectifs organisationnels, lesquels sont présentés dans l’information contextuelle.",
+          bullet5:
+            "Vous ne serez pas évalué sur votre rédaction. Aucun point ne sera enlevé pour les fautes d’orthographe, de grammaire, de ponctuation ou pour les phrases incomplètes. Votre rédaction devra toutefois être suffisamment claire pour que les évaluateurs comprennent la situation que vous traitez et vos principaux arguments.",
+          keyLeadershipCompetenciesSection: {
+            title: "Compétences clés en leadership",
+            para1Title: "Créer une vision et une stratégie : ",
+            para1:
+              "Les gestionnaires contribuent à définir l’avenir et à tracer la voie à suivre. Pour ce faire, ils tiennent compte du contexte. Ils tirent parti de leurs connaissances. Ils obtiennent et intègrent de l’information provenant de diverses sources pour la mise en œuvre d’activités concrètes. Ils considèrent divers points de vue et consultent d’autres personnes, au besoin. Les gestionnaires assurent l’équilibre entre les priorités organisationnelles et contribuent à améliorer les résultats.",
+            para2Title: "Mobiliser les personnes : ",
+            para2:
+              "Les gestionnaires inspirent et motivent les personnes qu’ils dirigent. Ils gèrent le rendement de leurs employés et leur offrent de la rétroaction constructive et respectueuse pour encourager et rendre possible l’excellence en matière de rendement. Ils dirigent en donnant l’exemple et se fixent des objectifs personnels qui sont plus exigeants que ceux qu’ils établissent pour les autres.",
+            para3Title: "Préserver l’intégrité et le respect : ",
+            para3:
+              "Les gestionnaires donnent l’exemple sur le plan des pratiques éthiques, du professionnalisme et de l’intégrité personnelle, en agissant dans l’intérêt du Canada, des Canadiens et des Canadiennes. Ils créent des environnements de travail inclusifs, empreints de respect et de confiance, où les conseils judicieux sont valorisés. Ils encouragent les autres à faire part de leurs points de vue, tout en encourageant la collégialité.",
+            para4Title: "Collaborer avec les partenaires et les intervenants : ",
+            para4:
+              "Les gestionnaires cherchent à obtenir, de façon délibérée et ingénieuse, un grand éventail de perspectives. Lorsqu’ils établissent des partenariats, ils gèrent les attentes et tentent de trouver un consensus. Ils font preuve d’ouverture et de souplesse afin d’améliorer les résultats et apportent une perspective globale de l’organisation à leurs interactions. Les gestionnaires reconnaissent le rôle des partenaires dans l’obtention des résultats.",
+            para5Title: "Promouvoir l’innovation et orienter le changement : ",
+            para5:
+              "Les gestionnaires créent un environnement propice aux idées audacieuses, à l’expérimentation et à la prise de risques en toute connaissance de cause. Lors de la mise en œuvre d’un changement, ils maintiennent l’élan, surmontent la résistance et anticipent les conséquences. Ils perçoivent les revers comme une bonne occasion de comprendre et d’apprendre.",
+            para6Title: "Obtenir des résultats : ",
+            para6:
+              "Les gestionnaires s’assurent de répondre aux objectifs de l’équipe en gérant les ressources. Ils prévoient, planifient et surveillent les progrès, et font des ajustements au besoin. Ils démontrent leur connaissance du contexte lors de la prise de décisions. Les gestionnaires assument la responsabilité personnelle à l’égard de leurs actions et des résultats de leurs décisions."
+          }
         }
       },
 


### PR DESCRIPTION
# Description

Added the content of Evaluation in its respective component and format everything. 

I also updated the links in Overview and Tips on Taking the eMIB, since these links refer to **Key Leadership Competencies** section in Evaluation component. All the warnings are now gone.

## Type of change

- New feature (non-breaking change which adds functionality)
- Code cleanliness or refactor

## Screenshot

Important Section Added [ENGLISH]:

![image](https://user-images.githubusercontent.com/23021242/53181659-f8c4fe80-35c5-11e9-80d1-aabde9a0d3eb.png)
![image](https://user-images.githubusercontent.com/23021242/53181685-05495700-35c6-11e9-9801-482e81b704e5.png)

Important Section Added [FRENCH]:

![image](https://user-images.githubusercontent.com/23021242/53181717-1abe8100-35c6-11e9-9d3e-6faa5318194c.png)
![image](https://user-images.githubusercontent.com/23021242/53181736-21e58f00-35c6-11e9-916a-6cf6d4309749.png)

# Testing

Manual steps to reproduce this functionality:

1. Go to Prototype tab.
2. Click _Start eMIB Sample Test_.
3. Click _Next_.
4. Make sure that Evaluation section looks good and is the same as the wireframes (except the content itself).

Screenshot of unit tests run passing:

![image](https://user-images.githubusercontent.com/23021242/53181888-6cffa200-35c6-11e9-96e9-52f14bc4ee4f.png)

# Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
