### PR TITLE
Center content and fix banners

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -28,9 +28,6 @@ const styles = {
     position: "fixed",
     top: "3.5%",
     left: "2.5%"
-  },
-  headerSpace: {
-    paddingBottom: 40
   }
 };
 
@@ -107,7 +104,6 @@ class App extends Component {
               </div>
             </div>
           </nav>
-          <div style={styles.headerSpace} />
           <Route exact path={PATH.home} component={Home} />
           <Route path={PATH.prototype} component={Prototype} />
           <Route path={PATH.status} component={Status} />

--- a/frontend/src/Home.jsx
+++ b/frontend/src/Home.jsx
@@ -7,7 +7,7 @@ const Home = () => {
   return (
     <div className="app">
       <img src={big_welcome_banner} alt={LOCALIZE.homePage.welcomeMsg} />
-      <ContentContainer>
+      <ContentContainer hideBanner={true}>
         <h1 id="home-page-paragraph">{LOCALIZE.homePage.title}</h1>
       </ContentContainer>
     </div>

--- a/frontend/src/Home.jsx
+++ b/frontend/src/Home.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import big_welcome_banner from "./images/big_welcome_banner.png";
 import LOCALIZE from "./text_resources";
 import ContentContainer from "./components/commons/ContentContainer";
 

--- a/frontend/src/Home.jsx
+++ b/frontend/src/Home.jsx
@@ -1,12 +1,15 @@
 import React from "react";
 import big_welcome_banner from "./images/big_welcome_banner.png";
 import LOCALIZE from "./text_resources";
+import ContentContainer from "./components/commons/ContentContainer";
 
 const Home = () => {
   return (
     <div className="app">
-      <h1 id="home-page-paragraph">{LOCALIZE.homePage.title}</h1>
       <img src={big_welcome_banner} alt={LOCALIZE.homePage.welcomeMsg} />
+      <ContentContainer>
+        <h1 id="home-page-paragraph">{LOCALIZE.homePage.title}</h1>
+      </ContentContainer>
     </div>
   );
 };

--- a/frontend/src/Home.jsx
+++ b/frontend/src/Home.jsx
@@ -6,9 +6,9 @@ import ContentContainer from "./components/commons/ContentContainer";
 const Home = () => {
   return (
     <div className="app">
-      <img src={big_welcome_banner} alt={LOCALIZE.homePage.welcomeMsg} />
-      <ContentContainer hideBanner={true}>
-        <h1 id="home-page-paragraph">{LOCALIZE.homePage.title}</h1>
+      <ContentContainer>
+        <h1>{LOCALIZE.homePage.title}</h1>
+        <p>{LOCALIZE.homePage.description}</p>
       </ContentContainer>
     </div>
   );

--- a/frontend/src/Prototype.jsx
+++ b/frontend/src/Prototype.jsx
@@ -1,9 +1,10 @@
 import React from "react";
 import LOCALIZE from "./text_resources";
+import ContentContainer from "./components/commons/ContentContainer";
 
 const Prototype = () => {
   return (
-    <div className="app">
+    <ContentContainer>
       <h2>{LOCALIZE.prototypePage.title}</h2>
       <p>{LOCALIZE.prototypePage.welcomeMsg}</p>
 
@@ -12,7 +13,7 @@ const Prototype = () => {
           {LOCALIZE.prototypePage.startEmibSampleTest}
         </button>
       </form>
-    </div>
+    </ContentContainer>
   );
 };
 

--- a/frontend/src/Status.jsx
+++ b/frontend/src/Status.jsx
@@ -6,12 +6,9 @@ import getIeVersion from "./helpers/getIeVersion";
 import getScreenResolution from "./helpers/getScreenResolution";
 import logo from "./images/logo.png";
 import LOCALIZE from "./text_resources";
+import ContentContainer from "./components/commons/ContentContainer";
 
 const styles = {
-  container: {
-    width: "50%",
-    margin: "0 auto"
-  },
   logo: {
     margin: 20,
     width: 30,
@@ -116,7 +113,7 @@ class Status extends Component {
       screenResolutionStatus
     } = this.state;
     return (
-      <div style={styles.container}>
+      <ContentContainer>
         <div className={"jumbotron"}>
           <h1>{LOCALIZE.statusPage.title}</h1>
           <p>{LOCALIZE.statusPage.welcomeMsg}</p>
@@ -207,7 +204,7 @@ class Status extends Component {
             </table>
           </div>
         </div>
-      </div>
+      </ContentContainer>
     );
   }
 }

--- a/frontend/src/components/commons/ContentContainer.jsx
+++ b/frontend/src/components/commons/ContentContainer.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+const styles = {
+  container: {
+    maxWidth: 1140,
+    margin: "0px auto",
+    textAlign: "left"
+  }
+};
+
+const ContentContainer = props => {
+  return <div style={styles.container}>{props.children}</div>;
+};
+
+export default ContentContainer;

--- a/frontend/src/components/commons/ContentContainer.jsx
+++ b/frontend/src/components/commons/ContentContainer.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import mini_banner from "./../../images/mini_banner.png";
 
 const styles = {
@@ -10,6 +11,8 @@ const styles = {
   }
 };
 
+// Manages displaying content within correct width and with a banner.
+// Should be used whenever adding a new view to CAT.
 const ContentContainer = props => {
   return (
     <div>
@@ -17,6 +20,11 @@ const ContentContainer = props => {
       <div style={styles.container}>{props.children}</div>
     </div>
   );
+};
+
+ContentContainer.propTypes = {
+  children: PropTypes.node,
+  hideBanner: PropTypes.bool
 };
 
 export default ContentContainer;

--- a/frontend/src/components/commons/ContentContainer.jsx
+++ b/frontend/src/components/commons/ContentContainer.jsx
@@ -1,15 +1,22 @@
 import React from "react";
+import mini_banner from "./../../images/mini_banner.png";
 
 const styles = {
   container: {
     maxWidth: 1140,
     margin: "0px auto",
-    textAlign: "left"
+    textAlign: "left",
+    paddingTop: 20
   }
 };
 
 const ContentContainer = props => {
-  return <div style={styles.container}>{props.children}</div>;
+  return (
+    <div>
+      {!props.hideBanner && <img src={mini_banner} alt="" className="banner" />}
+      <div style={styles.container}>{props.children}</div>
+    </div>
+  );
 };
 
 export default ContentContainer;

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -3,7 +3,6 @@ import Confirmation from "./Confirmation";
 import HowTo from "./HowTo";
 import EmibTabs from "./EmibTabs";
 import LOCALIZE from "../../text_resources";
-import mini_banner from "./../../images/mini_banner.png";
 import ContentContainer from "../commons/ContentContainer";
 
 const PAGES = {
@@ -33,8 +32,7 @@ class Emib extends Component {
   render() {
     return (
       <div className="app">
-        {this.state.curPage === PAGES.howTo && <img src={mini_banner} alt="" className="banner" />}
-        <ContentContainer>
+        <ContentContainer hideBanner={this.state.curPage === PAGES.emibTabs}>
           {this.state.curPage === PAGES.howTo && (
             <HowTo
               inTest={false}

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -4,6 +4,7 @@ import HowTo from "./HowTo";
 import EmibTabs from "./EmibTabs";
 import LOCALIZE from "../../text_resources";
 import mini_banner from "./../../images/mini_banner.png";
+import ContentContainer from "../commons/ContentContainer";
 
 const PAGES = {
   howTo: "howTo",
@@ -32,9 +33,9 @@ class Emib extends Component {
   render() {
     return (
       <div className="app">
-        {this.state.curPage === PAGES.howTo && (
-          <div>
-            <img src={mini_banner} alt="" className="banner" />
+        {this.state.curPage === PAGES.howTo && <img src={mini_banner} alt="" className="banner" />}
+        <ContentContainer>
+          {this.state.curPage === PAGES.howTo && (
             <HowTo
               inTest={false}
               exitButton={
@@ -43,15 +44,15 @@ class Emib extends Component {
                 </button>
               }
             />
-          </div>
-        )}
-        {this.state.curPage === PAGES.emibTabs && <EmibTabs />}
-        {this.state.curPage === PAGES.confirm && <Confirmation />}
-        {this.state.curPage === PAGES.emibTabs && (
-          <button type="button" className="btn btn-primary" onClick={this.changePage}>
-            {LOCALIZE.commons.submitTestButton}
-          </button>
-        )}
+          )}
+          {this.state.curPage === PAGES.emibTabs && <EmibTabs />}
+          {this.state.curPage === PAGES.confirm && <Confirmation />}
+          {this.state.curPage === PAGES.emibTabs && (
+            <button type="button" className="btn btn-primary" onClick={this.changePage}>
+              {LOCALIZE.commons.submitTestButton}
+            </button>
+          )}
+        </ContentContainer>
       </div>
     );
   }

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -46,13 +46,6 @@ Home Page
 Formatting of eMIB Sample Test
 */
 
-/*Text Zone Formatting*/
-.emib-text-zone {
-  text-align: left;
-  padding-left: 25%;
-  padding-right: 25%;
-}
-
 /*Section Titles Formatting*/
 .emib-section-titles {
   color: #137991;

--- a/frontend/src/tests/Home.test.js
+++ b/frontend/src/tests/Home.test.js
@@ -7,13 +7,13 @@ import LOCALIZE from "../text_resources";
 it("renders Home Page Title in English", () => {
   LOCALIZE.setLanguage(LANGUAGES.english);
   const wrapper = shallow(<Home />);
-  const homePageTitle = <h1 id="home-page-paragraph">{LOCALIZE.homePage.title}</h1>;
+  const homePageTitle = <h1>{LOCALIZE.homePage.title}</h1>;
   expect(wrapper.contains(homePageTitle)).toEqual(true);
 });
 
 it("renders Home Page Title in French", () => {
   LOCALIZE.setLanguage(LANGUAGES.french);
   const wrapper = shallow(<Home />);
-  const homePageTitle = <h1 id="home-page-paragraph">{LOCALIZE.homePage.title}</h1>;
+  const homePageTitle = <h1>{LOCALIZE.homePage.title}</h1>;
   expect(wrapper.contains(homePageTitle)).toEqual(true);
 });

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -12,7 +12,9 @@ let LOCALIZE = new LocalizedStrings({
     //Home Page
     homePage: {
       title: "The Public Service Commission's Competency Assessment Tool",
-      welcomeMsg: "Welcome to the Compotency Assessment Tool."
+      welcomeMsg: "Welcome to the Compotency Assessment Tool.",
+      description:
+        "Code for Canada and PSC are working on this tool to help assess managerial canadiates for the federal public service. It is in the alpha phase which means it is currently going through product testing and is subject to change."
     },
 
     //Prototype Page
@@ -230,7 +232,9 @@ let LOCALIZE = new LocalizedStrings({
     homePage: {
       title:
         "Outil d'évaluation des compétences de la Commission de la fonction publique du Canada",
-      welcomeMsg: "Bienvenue dans l'outil d'évaluation des compétences."
+      welcomeMsg: "Bienvenue dans l'outil d'évaluation des compétences.",
+      description:
+        "FR Code for Canada and PSC are working on this tool to help assess managerial canadiates for the federal public service. It is in the alpha phase which means it is currently going through product testing and is subject to change."
     },
 
     //Prototype Page


### PR DESCRIPTION
# Description

Went through the application with Joey this morning. We decided to add the banner to a few more places to make things look consistent (basically everywhere except within the actual eMIB).

I also talked to Michael this morning about how it might be good to have a consistent way to center and left align content. We decided to follow what canada.ca does with `max-width: 1140px` and auto margins. 

I did all this by making a component called `ContentContainer` that conditionally shows the banner and centers all it's content.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Code cleanliness or refactor

## Screenshot

![image](https://user-images.githubusercontent.com/4640747/53347740-beba6c00-38e7-11e9-90ba-953dfe3ba897.png)


# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Go to all pages.
2.  Notice the banners and content centering.

Any concerns that need to be addressed in product usability testing:

- We'll have to re-add a better home page banner, but we took it out for now since it wasn't translated properly

Screenshot of unit tests run passing:
![image](https://user-images.githubusercontent.com/4640747/53349868-06db8d80-38ec-11e9-970f-b1235652c060.png)


# Checklist

Applicable for all code changes.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new compiler warnings
- [ ] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
