### PR TITLE
CSS Cleanup

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -26,8 +26,13 @@ const styles = {
   },
   pscImage: {
     position: "fixed",
-    top: "3.5%",
-    left: "2.5%"
+    top: 20,
+    left: 20
+  },
+  languageButton: {
+    position: "fixed",
+    right: 15,
+    top: 15
   }
 };
 
@@ -99,7 +104,7 @@ class App extends Component {
                   </NavLink>
                 </li>
               </ul>
-              <div id="translation-button" className="translation-button">
+              <div style={styles.languageButton}>
                 <Translation updateLanguageOnPage={this.updateLanguage} />
               </div>
             </div>

--- a/frontend/src/components/commons/BackToTop.jsx
+++ b/frontend/src/components/commons/BackToTop.jsx
@@ -6,8 +6,8 @@ const styles = {
   displayedButton: {
     display: "block",
     position: "fixed",
-    bottom: "5%",
-    right: "3%"
+    bottom: 20,
+    right: 20
   }
 };
 

--- a/frontend/src/components/commons/ContentContainer.jsx
+++ b/frontend/src/components/commons/ContentContainer.jsx
@@ -8,6 +8,9 @@ const styles = {
     margin: "0px auto",
     textAlign: "left",
     paddingTop: 20
+  },
+  banner: {
+    width: "100%"
   }
 };
 
@@ -16,7 +19,7 @@ const styles = {
 const ContentContainer = props => {
   return (
     <div>
-      {!props.hideBanner && <img src={mini_banner} alt="" className="banner" />}
+      {!props.hideBanner && <img src={mini_banner} alt="" style={styles.banner} />}
       <div style={styles.container}>{props.children}</div>
     </div>
   );

--- a/frontend/src/components/commons/ProgressPane.jsx
+++ b/frontend/src/components/commons/ProgressPane.jsx
@@ -23,7 +23,7 @@ class ProgressPane extends Component {
 
   render() {
     return (
-      <div className="progress-pane emib-text-zone">
+      <div className="progress-pane">
         <div aria-label="progress" className="step-indicator">
           <ul className="steps">
             {this.props.progressSpecs.map(tab => (
@@ -36,7 +36,7 @@ class ProgressPane extends Component {
             ))}
           </ul>
         </div>
-        {this.props.paneTitle ? <h1 className="progress-pane">{this.props.paneTitle}</h1> : null}
+        {this.props.paneTitle ? <h1 className="green-divider">{this.props.paneTitle}</h1> : null}
         {this.state.currentBody}
         {this.state.currentNode < this.props.progressSpecs.length - 1 && (
           <div className="centeredButtons">

--- a/frontend/src/components/commons/ProgressPane.jsx
+++ b/frontend/src/components/commons/ProgressPane.jsx
@@ -39,17 +39,17 @@ class ProgressPane extends Component {
         {this.props.paneTitle ? <h1 className="green-divider">{this.props.paneTitle}</h1> : null}
         {this.state.currentBody}
         {this.state.currentNode < this.props.progressSpecs.length - 1 && (
-          <div className="centeredButtons">
+          <div className="centered-buttons">
             <button type="button" className="btn btn-primary" onClick={() => this.changeNode(1)}>
               {LOCALIZE.commons.nextButton}
             </button>
           </div>
         )}
         {this.state.currentNode === this.props.progressSpecs.length - 1 && (
-          <div className="centeredButtons">{this.props.exitButton}</div>
+          <div className="centered-buttons">{this.props.exitButton}</div>
         )}
         {this.state.currentNode > 0 && (
-          <div className="centeredButtons">
+          <div className="centered-buttons">
             <button type="button" className="btn btn-secondary" onClick={() => this.changeNode(-1)}>
               {LOCALIZE.commons.backButton}
             </button>

--- a/frontend/src/components/commons/ProgressPane.jsx
+++ b/frontend/src/components/commons/ProgressPane.jsx
@@ -40,7 +40,7 @@ class ProgressPane extends Component {
               ))}
             </ul>
           </div>
-          {this.props.paneTitle && <h1 className="progress-pane">{this.props.paneTitle}</h1>}
+          {this.props.paneTitle && <h1 className="green-divider">{this.props.paneTitle}</h1>}
           {this.state.currentBody}
           {this.state.currentNode < this.props.progressSpecs.length - 1 && (
             <div className="centered-buttons">

--- a/frontend/src/components/commons/ProgressPane.jsx
+++ b/frontend/src/components/commons/ProgressPane.jsx
@@ -23,7 +23,7 @@ class ProgressPane extends Component {
 
   render() {
     return (
-      <div className="progress-pane">
+      <div>
         <div aria-label="progress" className="step-indicator">
           <ul className="steps">
             {this.props.progressSpecs.map(tab => (
@@ -40,7 +40,11 @@ class ProgressPane extends Component {
         {this.state.currentBody}
         {this.state.currentNode < this.props.progressSpecs.length - 1 && (
           <div className="centered-buttons">
-            <button type="button" className="btn btn-primary" onClick={() => this.changeNode(1)}>
+            <button
+              type="button"
+              className="btn btn-primary btn-wide"
+              onClick={() => this.changeNode(1)}
+            >
               {LOCALIZE.commons.nextButton}
             </button>
           </div>
@@ -50,7 +54,11 @@ class ProgressPane extends Component {
         )}
         {this.state.currentNode > 0 && (
           <div className="centered-buttons">
-            <button type="button" className="btn btn-secondary" onClick={() => this.changeNode(-1)}>
+            <button
+              type="button"
+              className="btn btn-secondary btn-wide"
+              onClick={() => this.changeNode(-1)}
+            >
               {LOCALIZE.commons.backButton}
             </button>
           </div>

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -37,7 +37,11 @@ class Emib extends Component {
             <HowTo
               inTest={false}
               exitButton={
-                <button type="button" className="btn btn-primary" onClick={this.changePage}>
+                <button
+                  type="button"
+                  className="btn btn-primary btn-wide"
+                  onClick={this.changePage}
+                >
                   {LOCALIZE.commons.startTest}
                 </button>
               }

--- a/frontend/src/components/eMIB/Evaluation.jsx
+++ b/frontend/src/components/eMIB/Evaluation.jsx
@@ -8,7 +8,7 @@ class Evaluation extends Component {
     return (
       <div>
         <div>
-          <h2 className="emib-section-titles">{LOCALIZE.emibTest.howToPage.evaluation.title}</h2>
+          <h2>{LOCALIZE.emibTest.howToPage.evaluation.title}</h2>
           <div>
             <ul>
               <li>{LOCALIZE.emibTest.howToPage.evaluation.bullet1}</li>

--- a/frontend/src/components/eMIB/Overview.jsx
+++ b/frontend/src/components/eMIB/Overview.jsx
@@ -8,7 +8,7 @@ class Overview extends Component {
     return (
       <div>
         <div>
-          <h2 className="emib-section-titles">{LOCALIZE.emibTest.howToPage.overview.title}</h2>
+          <h2>{LOCALIZE.emibTest.howToPage.overview.title}</h2>
           <div>
             <p>
               {LOCALIZE.emibTest.howToPage.overview.description}

--- a/frontend/src/components/eMIB/TestInstructions.jsx
+++ b/frontend/src/components/eMIB/TestInstructions.jsx
@@ -20,9 +20,7 @@ class TestInstructions extends Component {
     return (
       <div>
         <div>
-          <h2 className="emib-section-titles">
-            {LOCALIZE.emibTest.howToPage.testInstructions.title}
-          </h2>
+          <h2>{LOCALIZE.emibTest.howToPage.testInstructions.title}</h2>
           <div>
             <p>{LOCALIZE.emibTest.howToPage.testInstructions.para1}</p>
           </div>

--- a/frontend/src/components/eMIB/TestInstructions.jsx
+++ b/frontend/src/components/eMIB/TestInstructions.jsx
@@ -9,6 +9,12 @@ import option_1_emib_sample_test_example_en from "../../images/option_1_emib_sam
 import option_2_emib_sample_test_example_en from "../../images/option_2_emib_sample_test_example_en.png";
 // import option_2_emib_sample_test_example_fr from "../../images/option_2_emib_sample_test_example_fr.png";
 
+const styles = {
+  testImage: {
+    maxWidth: 600
+  }
+};
+
 class TestInstructions extends Component {
   render() {
     return (
@@ -62,7 +68,7 @@ class TestInstructions extends Component {
               <img
                 src={original_email_emib_sample_test_example_en}
                 alt={LOCALIZE.emibTest.howToPage.testInstructions.step2Section.example.part1Title}
-                className="test-instruction-image"
+                style={styles.testImage}
               />
             </p>
             <p>
@@ -75,7 +81,7 @@ class TestInstructions extends Component {
               <img
                 src={option_1_emib_sample_test_example_en}
                 alt={LOCALIZE.emibTest.howToPage.testInstructions.step2Section.example.part2Title}
-                className="test-instruction-image"
+                style={styles.testImage}
               />
             </p>
             <p className="font-weight-bold underline">
@@ -85,7 +91,7 @@ class TestInstructions extends Component {
               <img
                 src={option_2_emib_sample_test_example_en}
                 alt={LOCALIZE.emibTest.howToPage.testInstructions.step2Section.example.part3Title}
-                className="test-instruction-image"
+                style={styles.testImage}
               />
             </p>
           </div>

--- a/frontend/src/components/eMIB/TipsOnTest.jsx
+++ b/frontend/src/components/eMIB/TipsOnTest.jsx
@@ -8,7 +8,7 @@ class TipsOnTest extends Component {
     return (
       <div>
         <div>
-          <h2 className="emib-section-titles">{LOCALIZE.emibTest.howToPage.tipsOnTest.title}</h2>
+          <h2>{LOCALIZE.emibTest.howToPage.tipsOnTest.title}</h2>
           <p>
             {LOCALIZE.emibTest.howToPage.tipsOnTest.descriptionPart1}
             <a href="#keyLeadershipCompetencies">

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -16,16 +16,6 @@ h1.progress-pane:after {
 }
 
 /*
-Home Page
-*/
-
-#home-page-paragraph {
-  background-color: black;
-  color: white;
-  font-size: 38px;
-}
-
-/*
 Formatting of eMIB Sample Test
 */
 

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -16,14 +16,6 @@ h1.progress-pane:after {
 }
 
 /*
-Formatting for banner image
-*/
-
-img.banner {
-  width: 100%;
-}
-
-/*
 Home Page
 */
 
@@ -96,14 +88,6 @@ Override steps colors
 .progress-pane > div > button {
   width: 400px;
   margin-bottom: 10px;
-}
-
-/*
-Formatting for banner image
-*/
-
-img.banner {
-  width: 100%;
 }
 
 /*

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -24,11 +24,6 @@ Formatting of eMIB Sample Test
   color: #137991;
 }
 
-/*Images from Test Instructions formatting*/
-.test-instruction-image {
-  width: 100%;
-}
-
 /*
 Override steps colors
 */

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -11,11 +11,11 @@ All component specific CSS lives in the React file with the component.
   text-decoration: underline;
 }
 
+/* Headers */
 h3 {
   color: #009fae;
 }
 
-/* Headers */
 /* h1: add green line underneath */
 h1.green-divider:after {
   content: " ";

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -15,12 +15,7 @@ h1.progress-pane:after {
   border: 2px solid #c7e68c;
 }
 
-/*
-Formatting of eMIB Sample Test
-*/
-
-/*Section Titles Formatting*/
-.emib-section-titles {
+h2 {
   color: #137991;
 }
 

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -63,8 +63,7 @@ Override steps colors
   border-color: #00565e;
 }
 
-/* override button width when inside ProgressPane */
-.progress-pane > div > button {
+.btn-wide {
   width: 400px;
   margin-bottom: 10px;
 }

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -6,9 +6,8 @@
   text-decoration: underline;
 }
 
-/*
-h1: add green line underneath
-*/
+/* Headers */
+/* h1: add green line underneath */
 h1.green-divider:after {
   content: " ";
   display: block;
@@ -19,12 +18,27 @@ h2 {
   color: #137991;
 }
 
+/* Buttons */
+.btn-primary {
+  background-color: #00565e;
+}
+
+.btn-secondary {
+  color: #00565e;
+  border-color: #00565e;
+}
+
+.btn-wide {
+  width: 400px;
+  margin-bottom: 10px;
+}
+
 .centered-buttons {
   text-align: center;
 }
 
 /*
-Override steps colors
+Progess Steps
 */
 
 /* override color of text in active li*/
@@ -51,21 +65,6 @@ Override steps colors
 /* override line color of completed li to active li */
 .step-indicator .steps li.complete + li:after {
   background-color: #009fae;
-}
-
-/* override primary and secondary button colors */
-.btn-primary {
-  background-color: #00565e;
-}
-
-.btn-secondary {
-  color: #00565e;
-  border-color: #00565e;
-}
-
-.btn-wide {
-  width: 400px;
-  margin-bottom: 10px;
 }
 
 /*

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -19,6 +19,10 @@ h2 {
   color: #137991;
 }
 
+.centered-buttons {
+  text-align: center;
+}
+
 /*
 Override steps colors
 */
@@ -47,11 +51,6 @@ Override steps colors
 /* override line color of completed li to active li */
 .step-indicator .steps li.complete + li:after {
   background-color: #009fae;
-}
-
-/* class to re-center any buttons contained within */
-.centeredButtons {
-  text-align: center;
 }
 
 /* override primary and secondary button colors */

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -7,9 +7,9 @@
 }
 
 /*
-Header 1: add green line underneath
+h1: add green line underneath
 */
-h1.progress-pane:after {
+h1.green-divider:after {
   content: " ";
   display: block;
   border: 2px solid #c7e68c;

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -7,15 +7,6 @@
 }
 
 /*
-Formatting for English/French button
-*/
-.translation-button {
-  position: fixed;
-  right: 2%;
-  top: 3.5%;
-}
-
-/*
 Header 1: add green line underneath
 */
 h1.progress-pane:after {

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -1,3 +1,8 @@
+/*
+App.css is used for overrides of existing CSS class names, tags, or in very specific cases where we'd want to add a new class.
+All component specific CSS lives in the React file with the component. 
+*/
+
 .app {
   text-align: center;
 }

--- a/frontend/src/tests/components/eMIB/Emib.test.js
+++ b/frontend/src/tests/components/eMIB/Emib.test.js
@@ -9,7 +9,7 @@ import LOCALIZE from "../../../text_resources";
 
 it("renders howToPage page", () => {
   const wrapper = mount(<Emib />);
-  const emibTitle = <h1 className="progress-pane">{LOCALIZE.emibTest.homePage.testTitle}</h1>;
+  const emibTitle = <h1 className="green-divider">{LOCALIZE.emibTest.homePage.testTitle}</h1>;
   expect(wrapper.contains(emibTitle)).toEqual(true);
   expect(wrapper.state("curPage")).toEqual(PAGES.howTo);
 });
@@ -17,7 +17,7 @@ it("renders howToPage page", () => {
 it("renders howTo page when state changed", () => {
   const wrapper = mount(<Emib />);
   wrapper.setState({ curPage: PAGES.howTo });
-  const emibTitle = <h1 className="progress-pane">{LOCALIZE.emibTest.homePage.testTitle}</h1>;
+  const emibTitle = <h1 className="green-divider">{LOCALIZE.emibTest.homePage.testTitle}</h1>;
   expect(wrapper.contains(emibTitle)).toEqual(true);
 });
 


### PR DESCRIPTION
# Description

From now on, CSS that is specific to a component should live in that components file. 
App.css should be used for overrides of existing CSS class names, tags, or in very specific cases where we'd want to add a new class. For example, a h1 with a green line after it: `h1.green-divider:after`

If you want an easier way to review this, each commit addresses a specific item of CSS and has a description that should make it easier to read. 

## Type of change

- Code cleanliness or refactor

## Screenshot

No visual changes.

# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality: Clean through entire app, you should see no changes.

Screenshot of unit tests run passing:
![image](https://user-images.githubusercontent.com/4640747/53363678-246c1f80-390b-11e9-8c50-e27cf9670ac4.png)


# Checklist

Applicable for all code changes.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
