### PR TITLE
[Pre-Test Information] Progress Bar Language Toggle Bug Fixed

### DIFF
--- a/frontend/src/components/eMIB/HowTo.jsx
+++ b/frontend/src/components/eMIB/HowTo.jsx
@@ -8,7 +8,8 @@ import Evaluation from "./Evaluation";
 import ProgressPane from "../commons/ProgressPane";
 import SideNavigation from "../commons/SideNavigation";
 
-export const specsDefinition = () => {
+//Returns array where each item indicates specifications related to How To Page including the title and the body
+export const getHowToPages = () => {
   return [
     { id: 0, text: LOCALIZE.emibTest.howToPage.overview.title, body: <Overview /> },
     { id: 1, text: LOCALIZE.emibTest.howToPage.tipsOnTest.title, body: <TipsOnTest /> },
@@ -28,7 +29,7 @@ class HowTo extends Component {
   };
 
   render() {
-    const SPECS = specsDefinition();
+    const SPECS = getHowToPages();
 
     return (
       <div>

--- a/frontend/src/components/eMIB/HowTo.jsx
+++ b/frontend/src/components/eMIB/HowTo.jsx
@@ -8,12 +8,18 @@ import Evaluation from "./Evaluation";
 import ProgressPane from "../commons/ProgressPane";
 import SideNavigation from "../commons/SideNavigation";
 
-const SPECS = [
-  { id: 0, text: LOCALIZE.emibTest.howToPage.overview.title, body: <Overview /> },
-  { id: 1, text: LOCALIZE.emibTest.howToPage.tipsOnTest.title, body: <TipsOnTest /> },
-  { id: 2, text: LOCALIZE.emibTest.howToPage.testInstructions.title, body: <TestInstructions /> },
-  { id: 3, text: LOCALIZE.emibTest.howToPage.evaluation.title, body: <Evaluation /> }
-];
+export const specsDefinition = () => {
+  return [
+    { id: 0, text: LOCALIZE.emibTest.howToPage.overview.title, body: <Overview /> },
+    { id: 1, text: LOCALIZE.emibTest.howToPage.tipsOnTest.title, body: <TipsOnTest /> },
+    {
+      id: 2,
+      text: LOCALIZE.emibTest.howToPage.testInstructions.title,
+      body: <TestInstructions />
+    },
+    { id: 3, text: LOCALIZE.emibTest.howToPage.evaluation.title, body: <Evaluation /> }
+  ];
+};
 
 class HowTo extends Component {
   static propTypes = {
@@ -22,6 +28,8 @@ class HowTo extends Component {
   };
 
   render() {
+    const SPECS = specsDefinition();
+
     return (
       <div>
         {!this.props.inTest && (
@@ -39,5 +47,3 @@ class HowTo extends Component {
 }
 
 export default HowTo;
-
-export { SPECS };

--- a/frontend/src/tests/components/eMIB/HowTo.test.js
+++ b/frontend/src/tests/components/eMIB/HowTo.test.js
@@ -1,12 +1,12 @@
 import React from "react";
 import { shallow } from "enzyme";
-import HowTo, { specsDefinition } from "../../../components/eMIB/HowTo";
+import HowTo, { getHowToPages } from "../../../components/eMIB/HowTo";
 import { LANGUAGES } from "../../../components/commons/Translation";
 import ProgressPane from "../../../components/commons/ProgressPane";
 import SideNavigation from "../../../components/commons/SideNavigation";
 import LOCALIZE from "../../../text_resources";
 
-const SPECS = specsDefinition();
+const SPECS = getHowToPages();
 
 it("renders ProgressPane within HowTo when inTest=false", () => {
   LOCALIZE.setLanguage(LANGUAGES.english);

--- a/frontend/src/tests/components/eMIB/HowTo.test.js
+++ b/frontend/src/tests/components/eMIB/HowTo.test.js
@@ -1,14 +1,16 @@
 import React from "react";
-import { mount } from "enzyme";
-import HowTo, { SPECS } from "../../../components/eMIB/HowTo";
+import { shallow } from "enzyme";
+import HowTo, { specsDefinition } from "../../../components/eMIB/HowTo";
 import { LANGUAGES } from "../../../components/commons/Translation";
 import ProgressPane from "../../../components/commons/ProgressPane";
 import SideNavigation from "../../../components/commons/SideNavigation";
 import LOCALIZE from "../../../text_resources";
 
+const SPECS = specsDefinition();
+
 it("renders ProgressPane within HowTo when inTest=false", () => {
   LOCALIZE.setLanguage(LANGUAGES.english);
-  const wrapper = mount(<HowTo inTest={false} />);
+  const wrapper = shallow(<HowTo inTest={false} />);
   const progressPane = (
     <ProgressPane
       progressSpecs={SPECS}
@@ -21,7 +23,7 @@ it("renders ProgressPane within HowTo when inTest=false", () => {
 
 it("renders SideNavigation within HowTo when in test=true", () => {
   LOCALIZE.setLanguage(LANGUAGES.english);
-  const wrapper = mount(<HowTo inTest={true} />);
+  const wrapper = shallow(<HowTo inTest={true} />);
   const sideNavigation = <SideNavigation navSpecs={SPECS} currentNode={0} />;
   expect(wrapper.contains(sideNavigation)).toEqual(true);
 });


### PR DESCRIPTION
# Description

Fixed the progress bar language toggle bug. Now the translation is also applied to the progress bar.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

**Page in English:**

![image](https://user-images.githubusercontent.com/23021242/53491323-24336780-3a64-11e9-9868-ce76bff9ecc2.png)

**Page in French:**

![image](https://user-images.githubusercontent.com/23021242/53491345-331a1a00-3a64-11e9-9bb0-d809bcfc198f.png)

# Testing

Manual steps to reproduce this functionality:

1.  Go to Prototype tab.
2.  Click _Start eMIB Sample Test_.
3.  Make sure that the progress bar is also translated when you hit 'English/French' button

Screenshot of unit tests run passing:

![image](https://user-images.githubusercontent.com/23021242/53491473-83917780-3a64-11e9-9f06-3933e42dccd6.png)

# Checklist

Applicable for all code changes.

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 10+, Firefox, and Chrome
