### PR TITLE
[Test Instructions] Formatting Instructions and TestTabs

### DIFF
--- a/frontend/src/components/commons/SideNavigation.jsx
+++ b/frontend/src/components/commons/SideNavigation.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 
+//TODO fix fluctuating button width
 const styles = {
   sideNavPane: {
     display: "flex",
@@ -8,7 +9,8 @@ const styles = {
   },
   buttonList: {
     width: 550,
-    paddingRight: 25
+    paddingRight: 25,
+    marginTop: "18px"
   },
   button: {
     width: "100%",

--- a/frontend/src/components/commons/SideNavigation.jsx
+++ b/frontend/src/components/commons/SideNavigation.jsx
@@ -16,7 +16,7 @@ const styles = {
     width: "100%",
     marginBottom: 10,
     display: "flex",
-    justifyContent: "flext-start",
+    justifyContent: "center",
     textAlign: "center"
   },
   bodyContent: {

--- a/frontend/src/components/eMIB/TestInstructions.jsx
+++ b/frontend/src/components/eMIB/TestInstructions.jsx
@@ -28,18 +28,18 @@ class TestInstructions extends Component {
           <div>
             <h3>{LOCALIZE.emibTest.howToPage.testInstructions.step1Section.title}</h3>
             <p>{LOCALIZE.emibTest.howToPage.testInstructions.step1Section.description}</p>
-            <p className="font-weight-bold underline">
+            <h4 className="font-weight-bold underline">
               {LOCALIZE.emibTest.howToPage.testInstructions.step1Section.part1.title}
-            </p>
+            </h4>
             <p>{LOCALIZE.emibTest.howToPage.testInstructions.step1Section.part1.para1}</p>
             <p>{LOCALIZE.emibTest.howToPage.testInstructions.step1Section.part1.para2}</p>
-            <p className="font-weight-bold underline">
+            <h4 className="font-weight-bold underline">
               {LOCALIZE.emibTest.howToPage.testInstructions.step1Section.part2.title}
-            </p>
+            </h4>
             <p>{LOCALIZE.emibTest.howToPage.testInstructions.step1Section.part2.para1}</p>
-            <p className="font-weight-bold underline">
+            <h4 className="font-weight-bold underline">
               {LOCALIZE.emibTest.howToPage.testInstructions.step1Section.part3.title}
-            </p>
+            </h4>
             <p>{LOCALIZE.emibTest.howToPage.testInstructions.step1Section.part3.para1}</p>
             <ol>
               <li>{LOCALIZE.emibTest.howToPage.testInstructions.step1Section.part3.bullet1}</li>
@@ -55,9 +55,9 @@ class TestInstructions extends Component {
             <p className="font-weight-bold">
               {LOCALIZE.emibTest.howToPage.testInstructions.step2Section.example.title}
             </p>
-            <p className="font-weight-bold underline">
+            <h4 className="font-weight-bold underline">
               {LOCALIZE.emibTest.howToPage.testInstructions.step2Section.example.part1Title}
-            </p>
+            </h4>
             <p>
               {LOCALIZE.emibTest.howToPage.testInstructions.step2Section.example
                 .conditionToDisplayImage === LANGUAGES.english && (
@@ -79,9 +79,9 @@ class TestInstructions extends Component {
             <p>
               {LOCALIZE.emibTest.howToPage.testInstructions.step2Section.example.part1Description}
             </p>
-            <p className="font-weight-bold underline">
+            <h4 className="font-weight-bold underline">
               {LOCALIZE.emibTest.howToPage.testInstructions.step2Section.example.part2Title}
-            </p>
+            </h4>
             <p>
               {LOCALIZE.emibTest.howToPage.testInstructions.step2Section.example
                 .conditionToDisplayImage === LANGUAGES.english && (
@@ -100,9 +100,9 @@ class TestInstructions extends Component {
                 />
               )}
             </p>
-            <p className="font-weight-bold underline">
+            <h4 className="font-weight-bold underline">
               {LOCALIZE.emibTest.howToPage.testInstructions.step2Section.example.part3Title}
-            </p>
+            </h4>
             <p>
               {LOCALIZE.emibTest.howToPage.testInstructions.step2Section.example
                 .conditionToDisplayImage === LANGUAGES.english && (

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -107,17 +107,27 @@ Formatting for Tab and TabNavigation; based off of react-bootstrap
   padding-left: 0;
   margin-bottom: 0;
   list-style: none;
+  border-bottom: 1px solid #00565e;
 }
+
 .bootstrap-tabs > .nav > span > span > li {
   position: relative;
   display: block;
+  float: left;
+  margin-bottom: -1px;
 }
+
 .bootstrap-tabs > .nav > span > span > li > button {
   position: relative;
   display: block;
   padding: 10px 15px;
   background-color: transparent;
+  margin-right: 2px;
+  line-height: 1.42857143;
+  border: 1px solid transparent;
+  border-radius: 4px 4px 0 0;
 }
+
 .bootstrap-tabs > .nav > span > span > li > button:hover,
 .bootstrap-tabs > .nav > span > span > li > button:focus {
   text-decoration: none;
@@ -131,19 +141,6 @@ Formatting for Tab and TabNavigation; based off of react-bootstrap
 }
 .bootstrap-tabs > .nav > span > span > li > button > img {
   max-width: none;
-}
-.bootstrap-tabs > .nav {
-  border-bottom: 1px solid #00565e;
-}
-.bootstrap-tabs > .nav > span > span > li {
-  float: left;
-  margin-bottom: -1px;
-}
-.bootstrap-tabs > .nav > span > span > li > button {
-  margin-right: 2px;
-  line-height: 1.42857143;
-  border: 1px solid transparent;
-  border-radius: 4px 4px 0 0;
 }
 
 .bootstrap-tabs > .nav > span > span > li > button:hover {

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -123,12 +123,6 @@ Formatting for Tab and TabNavigation; based off of react-bootstrap
   background-color: #eeeeee;
 }
 
-.bootstrap-tabs > .nav .open > button,
-.bootstrap-tabs > .nav .open > button:hover,
-.bootstrap-tabs > .nav .open > button:focus {
-  background-color: #eeeeee;
-  border-color: #337ab7;
-}
 .bootstrap-tabs > .nav .nav-divider {
   height: 1px;
   margin: 9px 0;

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -38,6 +38,11 @@ h4 {
   margin-bottom: 12px;
 }
 
+p {
+  margin-top: 12px;
+  margin-bottom: 12px;
+}
+
 /* Buttons */
 .btn-primary {
   background-color: #00565e;

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -151,11 +151,10 @@ Formatting for Tab and TabNavigation; based off of react-bootstrap
 .bootstrap-tabs > .nav-tabs > span > span > li.active > button,
 .bootstrap-tabs > .nav-tabs > span > span > li.active > button:hover,
 .bootstrap-tabs > .nav-tabs > span > span > li.active > button:focus {
-  color: #555555;
-  cursor: default;
-  background-color: #ffffff;
-  border: 1px solid #dddddd;
-  border-bottom-color: transparent;
+  color: black;
+  background-color: white;
+  border: 2px solid #00565e;
+  border-bottom-color: white;
 }
 
 .bootstrap-tabs > .tab-content {

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -22,14 +22,20 @@ h1.green-divider:after {
 
 h2 {
   color: #137991;
+  margin-top: 12px;
+  margin-bottom: 12px;
 }
 
 h3 {
   color: #009fae;
+  margin-top: 12px;
+  margin-bottom: 12px;
 }
 
 h4 {
   color: #00565e;
+  margin-top: 12px;
+  margin-bottom: 12px;
 }
 
 /* Buttons */

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -133,7 +133,7 @@ Formatting for Tab and TabNavigation; based off of react-bootstrap
   max-width: none;
 }
 .bootstrap-tabs > .nav-tabs {
-  border-bottom: 1px solid #dddddd;
+  border-bottom: 1px solid #00565e;
 }
 .bootstrap-tabs > .nav-tabs > span > span > li {
   float: left;
@@ -153,7 +153,7 @@ Formatting for Tab and TabNavigation; based off of react-bootstrap
 .bootstrap-tabs > .nav-tabs > span > span > li.active > button:focus {
   color: black;
   background-color: white;
-  border: 2px solid #00565e;
+  border: 1px solid #00565e;
   border-bottom-color: white;
 }
 

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -132,25 +132,27 @@ Formatting for Tab and TabNavigation; based off of react-bootstrap
 .bootstrap-tabs > .nav > span > span > li > button > img {
   max-width: none;
 }
-.bootstrap-tabs > .nav-tabs {
+.bootstrap-tabs > .nav {
   border-bottom: 1px solid #00565e;
 }
-.bootstrap-tabs > .nav-tabs > span > span > li {
+.bootstrap-tabs > .nav > span > span > li {
   float: left;
   margin-bottom: -1px;
 }
-.bootstrap-tabs > .nav-tabs > span > span > li > button {
+.bootstrap-tabs > .nav > span > span > li > button {
   margin-right: 2px;
   line-height: 1.42857143;
   border: 1px solid transparent;
   border-radius: 4px 4px 0 0;
 }
-.bootstrap-tabs > .nav-tabs > span > span > li > button:hover {
+
+.bootstrap-tabs > .nav > span > span > li > button:hover {
   border-color: #eeeeee #eeeeee #dddddd;
 }
-.bootstrap-tabs > .nav-tabs > span > span > li.active > button,
-.bootstrap-tabs > .nav-tabs > span > span > li.active > button:hover,
-.bootstrap-tabs > .nav-tabs > span > span > li.active > button:focus {
+
+.bootstrap-tabs > .nav > span > span > li.active > button,
+.bootstrap-tabs > .nav > span > span > li.active > button:hover,
+.bootstrap-tabs > .nav > span > span > li.active > button:focus {
   color: black;
   background-color: white;
   border: 1px solid #00565e;

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -112,8 +112,16 @@ Formatting for Tab and TabNavigation; based off of react-bootstrap
   padding-left: 0;
   margin-bottom: 0;
   list-style: none;
-  border-bottom: 1px solid #00565e;
-  margin-bottom: 32px;
+  border-bottom: none;
+}
+
+.bootstrap-tabs > .nav:after {
+  content: "";
+  background-color: white;
+  height: 32px;
+  width: 100%;
+  border: 1px solid #00565e;
+  border-bottom-color: transparent;
 }
 
 .bootstrap-tabs > .nav > span > span > li {
@@ -157,4 +165,7 @@ Formatting for Tab and TabNavigation; based off of react-bootstrap
   -webkit-transition: opacity 0.15s linear;
   -o-transition: opacity 0.15s linear;
   transition: opacity 0.15s linear;
+  background-color: white;
+  border: 1px solid #00565e;
+  border-top-color: white;
 }

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -122,16 +122,7 @@ Formatting for Tab and TabNavigation; based off of react-bootstrap
   text-decoration: none;
   background-color: #eeeeee;
 }
-.bootstrap-tabs > .nav > span > span > li.disabled > button {
-  color: #777777;
-}
-.bootstrap-tabs > .nav > span > span > li.disabled > button:hover,
-.bootstrap-tabs > .nav > span > span > li.disabled > button:focus {
-  color: #777777;
-  text-decoration: none;
-  cursor: not-allowed;
-  background-color: transparent;
-}
+
 .bootstrap-tabs > .nav .open > button,
 .bootstrap-tabs > .nav .open > button:hover,
 .bootstrap-tabs > .nav .open > button:focus {

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -116,11 +116,11 @@ Formatting for Tab and TabNavigation; based off of react-bootstrap
   position: relative;
   display: block;
   padding: 10px 15px;
+  background-color: transparent;
 }
 .bootstrap-tabs > .nav > span > span > li > button:hover,
 .bootstrap-tabs > .nav > span > span > li > button:focus {
   text-decoration: none;
-  background-color: #eeeeee;
 }
 
 .bootstrap-tabs > .nav .nav-divider {

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -143,10 +143,6 @@ Formatting for Tab and TabNavigation; based off of react-bootstrap
   max-width: none;
 }
 
-.bootstrap-tabs > .nav > span > span > li > button:hover {
-  border-color: #eeeeee #eeeeee #dddddd;
-}
-
 .bootstrap-tabs > .nav > span > span > li.active > button,
 .bootstrap-tabs > .nav > span > span > li.active > button:hover,
 .bootstrap-tabs > .nav > span > span > li.active > button:focus {

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -113,6 +113,7 @@ Formatting for Tab and TabNavigation; based off of react-bootstrap
   margin-bottom: 0;
   list-style: none;
   border-bottom: 1px solid #00565e;
+  margin-bottom: 32px;
 }
 
 .bootstrap-tabs > .nav > span > span > li {
@@ -137,6 +138,7 @@ Formatting for Tab and TabNavigation; based off of react-bootstrap
 .bootstrap-tabs > .nav > span > span > li > button:focus {
   text-decoration: none;
 }
+
 .bootstrap-tabs > .nav > span > span > li > button > img {
   max-width: none;
 }

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -12,9 +12,6 @@ All component specific CSS lives in the React file with the component.
 }
 
 /* Headers */
-h3 {
-  color: #009fae;
-}
 
 /* h1: add green line underneath */
 h1.green-divider:after {
@@ -25,6 +22,14 @@ h1.green-divider:after {
 
 h2 {
   color: #137991;
+}
+
+h3 {
+  color: #009fae;
+}
+
+h4 {
+  color: #00565e;
 }
 
 /* Buttons */

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -137,13 +137,6 @@ Formatting for Tab and TabNavigation; based off of react-bootstrap
 .bootstrap-tabs > .nav > span > span > li > button:focus {
   text-decoration: none;
 }
-
-.bootstrap-tabs > .nav .nav-divider {
-  height: 1px;
-  margin: 9px 0;
-  overflow: hidden;
-  background-color: #e5e5e5;
-}
 .bootstrap-tabs > .nav > span > span > li > button > img {
   max-width: none;
 }


### PR DESCRIPTION
# Description

Correcting formatting issues with Instructions within the TestTabs, so that they more accurately confirm to the correct look and feel in the wireframes.

## Type of change

Please delete options that are not relevant.

- Code cleanliness or refactor

## Screenshot

![image](https://user-images.githubusercontent.com/2746350/53507533-155dac80-3a86-11e9-903d-1dda04c519fb.png)

![image](https://user-images.githubusercontent.com/2746350/53507561-1f7fab00-3a86-11e9-8b72-55eeda021436.png)

![image](https://user-images.githubusercontent.com/2746350/53507590-2ad2d680-3a86-11e9-8d84-f87052bfe3bc.png)

![image](https://user-images.githubusercontent.com/2746350/53507614-33c3a800-3a86-11e9-96ce-524aa2b9329e.png)

# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1. Go to Start Test
2. Verify that my changes do not cause any issues in the pre-instructions formatting
3. Continue to the test
4. Verify that the Instruction pages display correctly

NOTE:
There is a bug/glitch where the buttons in the SideNav (in test instructions page) resize seemingly randomly. I will make a seperate PR to address this.

Screenshot of unit tests run passing:

![image](https://user-images.githubusercontent.com/2746350/53508142-2ce96500-3a87-11e9-8588-623c9e5e095e.png)

# Checklist

Applicable for all code changes.

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
