### PR TITLE
[Accessibility Review] Menus

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -79,6 +79,7 @@ class App extends Component {
       <Router>
         <div>
           <nav
+            aria-label="main-menu"
             style={styles.navBar}
             className="fixed-top bg-white navbar navbar-expand"
             role="banner"
@@ -89,17 +90,32 @@ class App extends Component {
             <div style={styles.tabs} className="fixed-top nav nav-tabs">
               <ul id="navigation-tabs" className="mx-auto nav-site nav nav-tabs nav-item">
                 <li className="bg-white">
-                  <NavLink isActive={isHomeActive} className="nav-link" to={PATH.home}>
+                  <NavLink
+                    aria-current="page"
+                    isActive={isHomeActive}
+                    className="nav-link"
+                    to={PATH.home}
+                  >
                     {LOCALIZE.mainTabs.homeTabTitle}
                   </NavLink>
                 </li>
                 <li className="bg-white">
-                  <NavLink isActive={isPrototypeActive} className="nav-link" to={PATH.prototype}>
+                  <NavLink
+                    aria-current="page"
+                    isActive={isPrototypeActive}
+                    className="nav-link"
+                    to={PATH.prototype}
+                  >
                     {LOCALIZE.mainTabs.prototypeTabTitle}
                   </NavLink>
                 </li>
                 <li className="bg-white">
-                  <NavLink isActive={isStatusActive} className="nav-link" to={PATH.status}>
+                  <NavLink
+                    aria-current="page"
+                    isActive={isStatusActive}
+                    className="nav-link"
+                    to={PATH.status}
+                  >
                     {LOCALIZE.mainTabs.statusTabTitle}
                   </NavLink>
                 </li>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -79,10 +79,10 @@ class App extends Component {
       <Router>
         <div>
           <nav
-            aria-label="main-menu"
+            aria-label={LOCALIZE.ariaLabel.mainMenu}
             style={styles.navBar}
             className="fixed-top bg-white navbar navbar-expand"
-            role="navigation"
+            role="dialog"
           >
             <div style={styles.pscImage} id="psc-image">
               <img src={psc_header} alt={LOCALIZE.commons.psc} />
@@ -120,7 +120,7 @@ class App extends Component {
                   </NavLink>
                 </li>
               </ul>
-              <div style={styles.languageButton}>
+              <div aria-label={LOCALIZE.ariaLabel.languageToggleBtn} style={styles.languageButton}>
                 <Translation updateLanguageOnPage={this.updateLanguage} />
               </div>
             </div>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -82,7 +82,7 @@ class App extends Component {
             aria-label="main-menu"
             style={styles.navBar}
             className="fixed-top bg-white navbar navbar-expand"
-            role="banner"
+            role="navigation"
           >
             <div style={styles.pscImage} id="psc-image">
               <img src={psc_header} alt={LOCALIZE.commons.psc} />

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -206,6 +206,12 @@ let LOCALIZE = new LocalizedStrings({
       }
     },
 
+    //Screen Reader
+    ariaLabel: {
+      mainMenu: "main-menu",
+      languageToggleBtn: "language-toggle-button"
+    },
+
     //Commons
     commons: {
       psc: "Public Service Commission",
@@ -429,6 +435,12 @@ let LOCALIZE = new LocalizedStrings({
         backgroundTabTitle: "Contexte",
         inboxTabTitle: "Boîte de réception"
       }
+    },
+
+    //Screen Reader
+    ariaLabel: {
+      mainMenu: "menu-principal",
+      languageToggleBtn: "bouton-de-langue-a-bascule"
     },
 
     //Commons


### PR DESCRIPTION
# Description

Added _aria-label_, _aria-current_ and _roles_ inside < nav > tags in order to meet the menus accessibility requirements.

## Type of change

- Code cleanliness or refactor

## Screenshot

(Not useful for this PR)

# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Enable the narrator on your machine.
2.  Open CAT in your browser.
3.  Hit _tab_ until the **Home** page tab is focused.
4.  Listen the narrator and make sure he says "_main menu_" and the current selected tab (Home, Prototype or Status) + make sure that the narrator says "_language toggle button_" when the concerned button is selected.

Screenshot of unit tests run passing:

![image](https://user-images.githubusercontent.com/23021242/53569837-0ed93e80-3b33-11e9-8d2a-59f6086f1a96.png)

# Checklist

Applicable for all code changes.

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 10+, Firefox, and Chrome
