### PR TITLE
Create a max height to the emib tabs

### DIFF
--- a/frontend/src/components/commons/SideNavigation.jsx
+++ b/frontend/src/components/commons/SideNavigation.jsx
@@ -26,7 +26,9 @@ const styles = {
   bodyContent: {
     display: "flex",
     justifyContent: "flext-end",
-    paddingRight: 20
+    paddingRight: 20,
+    height: "calc(100vh - 220px)",
+    overflow: "auto"
   },
   secondaryButton: {
     border: "none"

--- a/frontend/src/components/commons/TabNavigation.jsx
+++ b/frontend/src/components/commons/TabNavigation.jsx
@@ -24,7 +24,8 @@ const styles = {
     transition: "opacity 0.15s linear",
     backgroundColor: "white",
     border: "1px solid #00565e",
-    borderTopColor: "white"
+    borderTopColor: "white",
+    height: "calc(100vh - 210px)"
   }
 };
 


### PR DESCRIPTION
# Description

Added scrolling to content of SideNav, allowing TestTabs and SideNav buttons to remain stationary; Also added height to body of TestTabs, so that the bottom of the tab does not resize when changing tabs.

## Type of change

Please delete options that are not relevant.

- Code cleanliness or refactor

## Screenshot

![image](https://user-images.githubusercontent.com/2746350/53578493-d000b400-3b45-11e9-89cd-6cd591d7db07.png)

![image](https://user-images.githubusercontent.com/2746350/53578548-e1e25700-3b45-11e9-8e41-f3e388df6c1f.png)

![image](https://user-images.githubusercontent.com/2746350/53578582-ed358280-3b45-11e9-8dde-66454277716b.png)

![image](https://user-images.githubusercontent.com/2746350/53578629-01797f80-3b46-11e9-8ca0-7cb29158ba8e.png)


# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Start eMiB
2. Go to the test
3. Verify that tas render correctly and that scrolling does not move the tabs or side nav

NOTE:
Does not render correctly in IE. This is caused by a different bug that will be resolved in a separate PR.

Screenshot of unit tests run passing:
![image](https://user-images.githubusercontent.com/2746350/53578800-5d440880-3b46-11e9-82e0-922ad3d26dc1.png)


# Checklist

Applicable for all code changes.

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] New and existing unit tests pass locally with my changes
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
