### PR TITLE
[Bug Fix] Removed Extra Space in French Desc of Tips on Taking the eMIB

### DIFF
--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -301,7 +301,7 @@ let LOCALIZE = new LocalizedStrings({
         tipsOnTest: {
           title: "Conseils pour répondre à la BRG-e",
           description:
-            "La BRG-e vous présente des situations qui vous donneront l’occasion de démontrer les compétences clés en matière de leadership, décrit dans «Évaluation». Voici quelques conseils qui vous aideront à fournir aux évaluateurs l’information dont ils ont besoin pour évaluer votre rendement par rapport à ces \u00A0 compétences :",
+            "La BRG-e vous présente des situations qui vous donneront l’occasion de démontrer les compétences clés en matière de leadership, décrit dans «Évaluation». Voici quelques conseils qui vous aideront à fournir aux évaluateurs l’information dont ils ont besoin pour évaluer votre rendement par rapport à ces compétences :",
           bullet1:
             "Répondez à toutes les questions posées dans les courriels que vous recevez. Vous profiterez ainsi de toutes les occasions de démontrer les compétences recherchées.",
           bullet2:


### PR DESCRIPTION
# Description

Very simple PR: I just removed the extra space in the French description of Tips on Taking the eMIB component.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

![image](https://user-images.githubusercontent.com/23021242/53581781-3b4d8480-3b4c-11e9-9da6-5682ef1fc5a4.png)

# Testing

Manual steps to reproduce this functionality:

1.  Go to Prototype tab.
2.  Click _Start eMIB Sample Test_.
3.  Make sure that the French version of Tips on Taking the eMIB component looks good.

Screenshot of unit tests run passing:

![image](https://user-images.githubusercontent.com/23021242/53581934-81a2e380-3b4c-11e9-8a78-0f5d003e7bf4.png)

# Checklist

Applicable for all code changes.

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 10+, Firefox, and Chrome
