### PR TITLE
eMIB tabs: Use float over flex

### DIFF
--- a/frontend/src/components/commons/SideNavigation.jsx
+++ b/frontend/src/components/commons/SideNavigation.jsx
@@ -2,29 +2,26 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 
 const styles = {
-  sideNavPane: {
-    display: "flex",
-    flexDirection: "row"
-  },
+  sideNavPane: {},
   buttonList: {
     width: 240,
     paddingRight: 25,
-    marginTop: 18
+    marginTop: 18,
+    float: "left"
   },
   button: {
     width: 200,
     marginBottom: 10,
     marginLeft: 20,
     marginRight: 20,
-    display: "flex",
     justifyContent: "center",
     textAlign: "center",
     borderRadius: 4,
     padding: 6
   },
   bodyContent: {
-    display: "flex",
-    justifyContent: "flext-end",
+    float: "left",
+    maxWidth: 898,
     paddingRight: 20,
     height: "calc(100vh - 220px)",
     overflow: "auto"


### PR DESCRIPTION
# Description

Fixes side navigation on IE by using float over flexbox.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Screenshot

Please provide if applicable (browser for `frontend` or any visual way to show a `backend` change).
![image](https://user-images.githubusercontent.com/4640747/53582544-b8c5c480-3b4d-11e9-89cf-a0ea9a77497f.png)

# Checklist

Applicable for all code changes.

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
