### PR TITLE
[Bug Fix] Back to top button was overlapping the text when the page is shrunk

### DIFF
--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -88,6 +88,10 @@ p {
   text-align: center;
 }
 
+.btn-backtotop {
+  background-color: white;
+}
+
 .btn-backtotop:hover {
   background-color: #00565e;
 }


### PR DESCRIPTION
# Description

Put a white background to **Back to top** button, so even if it overlaps the text when the page is shrunk, the button looks good.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

![image](https://user-images.githubusercontent.com/23021242/53646469-41556b00-3c09-11e9-9a87-2296f5279387.png)

# Testing

Manual steps to reproduce this functionality:

1.  Go to _Prototype_ tab.
2.  Click _Start the eMIB Sample Test_.
3.  Shrink your browser page.
4.  Scroll down and once the _Back to top_ button appears, make sure it looks good even if it overlaps the text.

Screenshot of unit tests run passing:

![image](https://user-images.githubusercontent.com/23021242/53646718-e2dcbc80-3c09-11e9-987c-17d6f4ec650b.png)

# Checklist

Applicable for all code changes.

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 10+, Firefox, and Chrome
