### PR TITLE
Docker - run database migrations on build

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,3 +1,5 @@
 #!bin/bash
 pip install -r requirements.txt
+python manage.py makemigrations backend
+python manage.py migrate backend
 python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
# Description

By default, we want to run our database migrations on build. This means the server will get these migrations, and whenever we pull new code locally it will run migrations. 

Right now the dev server is failing the DB check because it never ran migrations. 
Current error on dev:
![image](https://user-images.githubusercontent.com/4640747/53826285-476b8480-3f46-11e9-912d-68cd3a0a4800.png)


If you are in development mode, and don't want them to run automatically, you will have to comment out this file.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Testing

Manual steps to reproduce this functionality:

1.  docker-compose build should execute without errors and run migrations

Screenshot of unit tests run passing:
![image](https://user-images.githubusercontent.com/4640747/53826154-fbb8db00-3f45-11e9-9d3c-7b4b190230b7.png)

