### PR TITLE
[Functionality] Building Notepad

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
     "react-localization": "^1.0.13",
     "react-router-dom": "^4.3.1",
     "react-scripts": "2.1.5",
-    "react-test-renderer": "^16.7.0"
+    "react-test-renderer": "^16.7.0",
+    "react-textarea-autosize": "^7.1.0"
   },
   "resolutions": {
     "mem": ">=4.1.0",

--- a/frontend/src/Status.jsx
+++ b/frontend/src/Status.jsx
@@ -22,10 +22,10 @@ const headers = new Headers({
 });
 
 // Valid browser other than IE
-const VALID_BROWSERS = ["chrome", "firefox"];
-const IE_STRING = "IE";
+export const VALID_BROWSERS = ["chrome", "firefox"];
+export const IE_STRING = "IE";
 
-const BROWSER_STRING = detectBrowser();
+export const BROWSER_STRING = detectBrowser();
 const IE_VERSION = getIeVersion();
 
 const SCREEN_RESOLUTION = getScreenResolution();

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -24,7 +24,8 @@ const styles = {
     backgroundColor: "white",
     border: "1px solid #00565e",
     borderRadius: "5px 5px 0 0",
-    width: 220
+    width: 220,
+    height: "calc(100vh - 208px)"
   },
   notepadSection: {
     overflow: "auto",
@@ -47,11 +48,11 @@ class Notepad extends Component {
       COLS = "20";
     }
     //if browser is Chrome
-    if (BROWSER_STRING === VALID_BROWSERS[0]) {
+    else if (BROWSER_STRING === VALID_BROWSERS[0]) {
       COLS = "22";
     }
     //if browser is Firefox
-    if (BROWSER_STRING === VALID_BROWSERS[1]) {
+    else if (BROWSER_STRING === VALID_BROWSERS[1]) {
       COLS = "18";
     }
     //other

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -3,7 +3,7 @@ import LOCALIZE from "../../text_resources";
 import TextareaAutosize from "react-textarea-autosize";
 import { BROWSER_STRING, IE_STRING, VALID_BROWSERS } from "../../Status";
 
-let COLS = "";
+let COLS = 0;
 
 const styles = {
   windowPadding: {
@@ -43,21 +43,18 @@ const styles = {
 class Notepad extends Component {
   //Adjust the notepad text zone width depending on the browser
   detectBrowser = () => {
-    //if browser is IE
-    if (BROWSER_STRING === IE_STRING) {
-      COLS = "20";
-    }
-    //if browser is Chrome
-    else if (BROWSER_STRING === VALID_BROWSERS[0]) {
-      COLS = "22";
-    }
-    //if browser is Firefox
-    else if (BROWSER_STRING === VALID_BROWSERS[1]) {
-      COLS = "18";
-    }
-    //other
-    else {
-      COLS = "18";
+    switch (BROWSER_STRING) {
+      case IE_STRING:
+        COLS = 20;
+        break;
+      case VALID_BROWSERS[0]:
+        COLS = 22;
+        break;
+      case VALID_BROWSERS[1]:
+        COLS = 18;
+        break;
+      default:
+        COLS = 18;
     }
   };
 

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -1,6 +1,9 @@
 import React, { Component } from "react";
 import LOCALIZE from "../../text_resources";
 import TextareaAutosize from "react-textarea-autosize";
+import { BROWSER_STRING, IE_STRING, VALID_BROWSERS } from "../../Status";
+
+let COLS = "";
 
 const styles = {
   windowPadding: {
@@ -37,11 +40,28 @@ const styles = {
 };
 
 class Notepad extends Component {
-  state = {
-    height: "3"
+  //Adjust the notepad text zone width depending on the browser
+  detectBrowser = () => {
+    //if browser is IE
+    if (BROWSER_STRING === IE_STRING) {
+      COLS = "20";
+    }
+    //if browser is Chrome
+    if (BROWSER_STRING === VALID_BROWSERS[0]) {
+      COLS = "22";
+    }
+    //if browser is Firefox
+    if (BROWSER_STRING === VALID_BROWSERS[1]) {
+      COLS = "18";
+    }
+    //other
+    else {
+      COLS = "18";
+    }
   };
 
   render() {
+    this.detectBrowser();
     return (
       <div style={styles.windowPadding}>
         <div style={styles.content}>
@@ -51,13 +71,16 @@ class Notepad extends Component {
           <div style={styles.notepadSection}>
             <form>
               <fieldset style={styles.center}>
+                <label for="text-area-zone" className="invisible position-absolute">
+                  {LOCALIZE.commons.notepad.title}
+                </label>
                 <TextareaAutosize
-                  maxlength="3000"
-                  className="textArea"
+                  id="text-area-zone"
+                  maxLength="3000"
+                  className="text-area"
                   style={styles.textArea}
-                  cols="22"
-                  minRows={3}
-                  maxRows={1000}
+                  cols={COLS}
+                  minRows={5}
                   placeholder={LOCALIZE.commons.notepad.placeholder}
                 />
               </fieldset>

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -1,0 +1,111 @@
+import React, { Component } from "react";
+import LOCALIZE from "../../text_resources";
+
+const styles = {
+  title: {
+    paddingLeft: 15,
+    paddingTop: 0.1,
+    height: 55,
+    backgroundColor: "#00565e",
+    borderRadius: "5px 5px 0 0"
+  },
+  h4: {
+    color: "white"
+  },
+  windowPadding: {
+    paddingTop: 43,
+    paddingLeft: 20
+  },
+  content: {
+    backgroundColor: "white",
+    border: "1px solid #00565e",
+    borderRadius: "5px 5px 0 0",
+    height: "calc(100vh - 210px)",
+    width: 220
+  },
+  center: {
+    textAlign: "center"
+  },
+  textArea: {
+    resize: "none",
+    border: "none",
+    overflow: "auto",
+    background: "red"
+  },
+  test: {
+    overflow: "auto"
+  }
+};
+
+class Notepad extends Component {
+  state = {
+    height: "3"
+  };
+
+  test = () => {
+    let defaultHeight = 150,
+      increment = 20,
+      newValue = 0;
+    let width = document.getElementById("notepad-window").offsetHeight;
+    console.log(width);
+    if (width > defaultHeight) {
+      this.setState({ height: "3" });
+      newValue = defaultHeight;
+    }
+    if (width > newValue + increment) {
+      this.setState({ height: "4" });
+      newValue += increment;
+    }
+    if (width > newValue + increment) {
+      this.setState({ height: "5" });
+      newValue += increment;
+    }
+    if (width > newValue + increment) {
+      this.setState({ height: "6" });
+      newValue += increment;
+    }
+    if (width > newValue + increment) {
+      this.setState({ height: "7" });
+      newValue += increment;
+    }
+    if (width > newValue + increment) {
+      this.setState({ height: "8" });
+      newValue += increment;
+    }
+    if (width > newValue + increment) {
+      this.setState({ height: "9" });
+      newValue += increment;
+    }
+  };
+
+  componentDidMount() {
+    window.addEventListener("resize", this.test, false);
+  }
+
+  render() {
+    return (
+      <div style={styles.windowPadding}>
+        <div id="notepad-window" style={styles.content}>
+          <div style={styles.title}>
+            <h4 style={styles.h4}>{LOCALIZE.commons.notepad.title}</h4>
+          </div>
+          <div style={styles.test}>
+            <form>
+              <fieldset style={styles.center}>
+                <textarea
+                  className="textArea"
+                  style={styles.textArea}
+                  rows={this.state.height}
+                  cols="23"
+                  placeholder={LOCALIZE.commons.notepad.placeholder}
+                />
+              </fieldset>
+            </form>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default Notepad;

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -42,7 +42,10 @@ const styles = {
 };
 
 class Notepad extends Component {
-  //Adjust the notepad text zone width depending on the browser
+  /*
+  Adjust the notepad text zone width depending on the browser
+  Each browser has its own interpretation of the notepad text zone width
+  */
   detectBrowser = () => {
     switch (BROWSER_STRING) {
       case IE_STRING:

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -72,7 +72,7 @@ class Notepad extends Component {
           <div style={styles.notepadSection}>
             <form>
               <fieldset style={styles.center}>
-                <label for="text-area-zone" className="invisible position-absolute">
+                <label htmlFor="text-area-zone" className="invisible position-absolute">
                   {LOCALIZE.commons.notepad.title}
                 </label>
                 <TextareaAutosize

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -4,8 +4,6 @@ import TextareaAutosize from "react-textarea-autosize";
 import { BROWSER_STRING, IE_STRING, VALID_BROWSERS } from "../../Status";
 import "../../css/emib-tabs.css";
 
-let COLS = 0;
-
 const styles = {
   windowPadding: {
     paddingTop: 43,
@@ -42,6 +40,10 @@ const styles = {
 };
 
 class Notepad extends Component {
+  state = {
+    columnWidth: 0
+  };
+
   /*
   Adjust the notepad text zone width depending on the browser
   Each browser has its own interpretation of the notepad text zone width
@@ -49,21 +51,24 @@ class Notepad extends Component {
   detectBrowser = () => {
     switch (BROWSER_STRING) {
       case IE_STRING:
-        COLS = 20;
+        this.setState({ columnWidth: 20 });
         break;
       case VALID_BROWSERS[0]:
-        COLS = 22;
+        this.setState({ columnWidth: 22 });
         break;
       case VALID_BROWSERS[1]:
-        COLS = 18;
+        this.setState({ columnWidth: 18 });
         break;
       default:
-        COLS = 18;
+        this.setState({ columnWidth: 18 });
     }
   };
 
-  render() {
+  componentDidMount() {
     this.detectBrowser();
+  }
+
+  render() {
     return (
       <div style={styles.windowPadding}>
         <div style={styles.content}>
@@ -81,7 +86,7 @@ class Notepad extends Component {
                   maxLength="3000"
                   className="text-area"
                   style={styles.textArea}
-                  cols={COLS}
+                  cols={this.state.columnWidth}
                   minRows={5}
                   placeholder={LOCALIZE.commons.notepad.placeholder}
                 />

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import LOCALIZE from "../../text_resources";
 import TextareaAutosize from "react-textarea-autosize";
 import { BROWSER_STRING, IE_STRING, VALID_BROWSERS } from "../../Status";
+import "../../css/emib-tabs.css";
 
 let COLS = 0;
 

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -1,7 +1,15 @@
 import React, { Component } from "react";
 import LOCALIZE from "../../text_resources";
+import TextareaAutosize from "react-textarea-autosize";
 
 const styles = {
+  windowPadding: {
+    paddingTop: 43,
+    paddingLeft: 20
+  },
+  h4: {
+    color: "white"
+  },
   title: {
     paddingLeft: 15,
     paddingTop: 0.1,
@@ -9,31 +17,22 @@ const styles = {
     backgroundColor: "#00565e",
     borderRadius: "5px 5px 0 0"
   },
-  h4: {
-    color: "white"
-  },
-  windowPadding: {
-    paddingTop: 43,
-    paddingLeft: 20
-  },
   content: {
     backgroundColor: "white",
     border: "1px solid #00565e",
     borderRadius: "5px 5px 0 0",
-    height: "calc(100vh - 210px)",
     width: 220
   },
-  center: {
-    textAlign: "center"
+  notepadSection: {
+    overflow: "auto",
+    height: "calc(100vh - 270px)"
   },
   textArea: {
     resize: "none",
-    border: "none",
-    overflow: "auto",
-    background: "red"
+    border: "none"
   },
-  test: {
-    overflow: "auto"
+  center: {
+    textAlign: "center"
   }
 };
 
@@ -42,61 +41,23 @@ class Notepad extends Component {
     height: "3"
   };
 
-  test = () => {
-    let defaultHeight = 150,
-      increment = 20,
-      newValue = 0;
-    let width = document.getElementById("notepad-window").offsetHeight;
-    console.log(width);
-    if (width > defaultHeight) {
-      this.setState({ height: "3" });
-      newValue = defaultHeight;
-    }
-    if (width > newValue + increment) {
-      this.setState({ height: "4" });
-      newValue += increment;
-    }
-    if (width > newValue + increment) {
-      this.setState({ height: "5" });
-      newValue += increment;
-    }
-    if (width > newValue + increment) {
-      this.setState({ height: "6" });
-      newValue += increment;
-    }
-    if (width > newValue + increment) {
-      this.setState({ height: "7" });
-      newValue += increment;
-    }
-    if (width > newValue + increment) {
-      this.setState({ height: "8" });
-      newValue += increment;
-    }
-    if (width > newValue + increment) {
-      this.setState({ height: "9" });
-      newValue += increment;
-    }
-  };
-
-  componentDidMount() {
-    window.addEventListener("resize", this.test, false);
-  }
-
   render() {
     return (
       <div style={styles.windowPadding}>
-        <div id="notepad-window" style={styles.content}>
+        <div style={styles.content}>
           <div style={styles.title}>
             <h4 style={styles.h4}>{LOCALIZE.commons.notepad.title}</h4>
           </div>
-          <div style={styles.test}>
+          <div style={styles.notepadSection}>
             <form>
               <fieldset style={styles.center}>
-                <textarea
+                <TextareaAutosize
+                  maxlength="3000"
                   className="textArea"
                   style={styles.textArea}
-                  rows={this.state.height}
-                  cols="23"
+                  cols="22"
+                  minRows={3}
+                  maxRows={1000}
                   placeholder={LOCALIZE.commons.notepad.placeholder}
                 />
               </fieldset>

--- a/frontend/src/components/commons/TabNavigation.jsx
+++ b/frontend/src/components/commons/TabNavigation.jsx
@@ -13,7 +13,7 @@ const styles = {
     //this replaces the .bootstrap-tabs > .nav:after
     content: "",
     backgroundColor: "white",
-    width: 1140,
+    width: 900,
     border: "1px solid #00565e",
     borderBottomColor: "transparent"
   },
@@ -26,7 +26,7 @@ const styles = {
     border: "1px solid #00565e",
     borderTopColor: "white",
     height: "calc(100vh - 210px)",
-    width: 1140
+    width: 900
   }
 };
 

--- a/frontend/src/components/eMIB/EmibTabs.jsx
+++ b/frontend/src/components/eMIB/EmibTabs.jsx
@@ -6,6 +6,19 @@ import SideNavigation from "../commons/SideNavigation";
 import LOCALIZE from "../../text_resources";
 import TabNavigation from "../commons/TabNavigation";
 import { getInstructionContent } from "./Emib";
+import Notepad from "../commons/Notepad";
+
+const styles = {
+  container: {
+    display: "grid"
+  },
+  tabNavigation: {
+    gridColumn: "1"
+  },
+  notepad: {
+    gridColumn: "2"
+  }
+};
 
 class EmibTabs extends Component {
   static propTypes = {
@@ -32,11 +45,16 @@ class EmibTabs extends Component {
       }
     ];
     return (
-      <div>
-        <TabNavigation tabSpecs={TABS} currentTab={1} />
-        <button type="button" className="btn btn-primary" onClick={this.props.submitTest}>
-          {LOCALIZE.commons.submitTestButton}
-        </button>
+      <div style={styles.container}>
+        <div style={styles.tabNavigation}>
+          <TabNavigation tabSpecs={TABS} currentTab={1} />
+          <button type="button" className="btn btn-primary" onClick={this.props.submitTest}>
+            {LOCALIZE.commons.submitTestButton}
+          </button>
+        </div>
+        <div style={styles.notepad}>
+          <Notepad />
+        </div>
       </div>
     );
   }

--- a/frontend/src/components/eMIB/EmibTabs.jsx
+++ b/frontend/src/components/eMIB/EmibTabs.jsx
@@ -7,18 +7,7 @@ import LOCALIZE from "../../text_resources";
 import TabNavigation from "../commons/TabNavigation";
 import { getInstructionContent } from "./Emib";
 import Notepad from "../commons/Notepad";
-
-const styles = {
-  container: {
-    display: "grid"
-  },
-  tabNavigation: {
-    gridColumn: "1"
-  },
-  notepad: {
-    gridColumn: "2"
-  }
-};
+import "../../css/emib-tabs.css";
 
 class EmibTabs extends Component {
   static propTypes = {
@@ -45,14 +34,14 @@ class EmibTabs extends Component {
       }
     ];
     return (
-      <div style={styles.container}>
-        <div style={styles.tabNavigation}>
+      <div className="emib-tabs-grid">
+        <div className="test-tabs-cell">
           <TabNavigation tabSpecs={TABS} currentTab={1} />
           <button type="button" className="btn btn-primary" onClick={this.props.submitTest}>
             {LOCALIZE.commons.submitTestButton}
           </button>
         </div>
-        <div style={styles.notepad}>
+        <div className="notepad-cell">
           <Notepad />
         </div>
       </div>

--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -149,8 +149,3 @@ Progess Steps
 .nav-pills .show > .nav-link {
   background-color: #00565e;
 }
-
-/* Notepad.jsx Text Area Focus Style */
-.text-area:focus {
-  outline: 0;
-}

--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -151,6 +151,6 @@ Progess Steps
 }
 
 /* Notepad.jsx Text Area Focus Style */
-.textArea:focus {
+.text-area:focus {
   outline: 0;
 }

--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -149,3 +149,8 @@ Progess Steps
 .nav-pills .show > .nav-link {
   background-color: #00565e;
 }
+
+/* Notepad.jsx Text Area Focus Style */
+.textArea:focus {
+  outline: 0;
+}

--- a/frontend/src/css/emib-tabs.css
+++ b/frontend/src/css/emib-tabs.css
@@ -1,0 +1,18 @@
+/*
+emib-tabs.css is used for the EmibTabs.jsx styles that cannot be added inside a const
+*/
+
+.emib-tabs-grid {
+  display: -ms-grid;
+  display: grid;
+}
+
+.test-tabs-cell {
+  -ms-grid-column: 1;
+  grid-column: 1;
+}
+
+.notepad-cell {
+  -ms-grid-column: 2;
+  grid-column: 2;
+}

--- a/frontend/src/css/emib-tabs.css
+++ b/frontend/src/css/emib-tabs.css
@@ -16,3 +16,8 @@ emib-tabs.css is used for the EmibTabs.jsx styles that cannot be added inside a 
   -ms-grid-column: 2;
   grid-column: 2;
 }
+
+/* Notepad.jsx Text Area Focus Style */
+.text-area:focus {
+  outline: 0;
+}

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -221,7 +221,11 @@ let LOCALIZE = new LocalizedStrings({
       failStatus: "Fail",
       enabled: "Enabled",
       disabled: "Disabled",
-      backToTop: "Back to top"
+      backToTop: "Back to top",
+      notepad: {
+        title: "Notepad",
+        placeholder: "Put your notes here..."
+      }
     }
   },
 
@@ -449,7 +453,11 @@ let LOCALIZE = new LocalizedStrings({
       failStatus: "Échoue",
       enabled: "Activé",
       disabled: "Désactivé",
-      backToTop: "Haut de la page"
+      backToTop: "Haut de la page",
+      notepad: {
+        title: "Bloc-notes",
+        placeholder: "Mettez vos notes ici..."
+      }
     }
   }
 });

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7974,7 +7974,7 @@ prop-types-extra@^1.0.1:
     react-is "^16.3.2"
     warning "^3.0.0"
 
-prop-types@^15.5.10, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -8350,6 +8350,14 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.7.0:
     prop-types "^15.6.2"
     react-is "^16.8.3"
     scheduler "^0.13.3"
+
+react-textarea-autosize@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-7.1.0.tgz#3132cb77e65d94417558d37c0bfe415a5afd3445"
+  integrity sha512-c2FlR/fP0qbxmlrW96SdrbgP/v0XZMTupqB90zybvmDVDutytUgPl7beU35klwcTeMepUIQEpQUn3P3bdshGPg==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    prop-types "^15.6.0"
 
 react-transition-group@^2.0.0, react-transition-group@^2.2.0:
   version "2.6.0"


### PR DESCRIPTION
# Description

I added a notepad next to the test side navigation tabs. I tried to replicate the design as much as possible.

To do that, I used a React library called _'react-textarea-autosize'_ to get the height of the notepad text zone dynamic.

For now, there is a max of 3000 characters allowed. May be updated in the future.

No unit test has been added, since we are not storing any of the notes for now. Unit tests for that new component will be added once notes storing using Redux will be configured.

Also, when using _tab navigation_, note that **Submit test** button becomes selected before the **notepad window**. However, the test footer will fix that issue.

## Type of change

- New feature (non-breaking change which adds functionality)
- Dependency change

## Screenshot

**English Version:**

![image](https://user-images.githubusercontent.com/23021242/53825493-6832da80-3f44-11e9-8766-6935f7ff7b0e.png)

**French Version:**

![image](https://user-images.githubusercontent.com/23021242/53825524-7bde4100-3f44-11e9-951f-07a915a1f65f.png)

**Overflow Example:**

![image](https://user-images.githubusercontent.com/23021242/53825572-987a7900-3f44-11e9-9cfe-fad428a96265.png)


# Testing

Manual steps to reproduce this functionality:

1.  Go to _Prototype_ tab.
2.  Click _Start eMIB Sample Test_.
3.  Click _Next_, _Next_, _Next_ and _Start Test_.
4.  Play with the notepad and make sure everything looks good in **IE**, **Chrome** and **Firefox**

***It is important to test in all browser, because each browser has its own notepad text zone width.**

Screenshot of unit tests run passing:

![image](https://user-images.githubusercontent.com/23021242/53881328-69661500-3fe1-11e9-907b-3355d3116e73.png)

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
