### PR TITLE
Add padding and change text

### DIFF
--- a/frontend/src/components/eMIB/Background.jsx
+++ b/frontend/src/components/eMIB/Background.jsx
@@ -1,10 +1,16 @@
 import React, { Component } from "react";
 import LOCALIZE from "../../text_resources";
 
+const styles = {
+  padding: {
+    padding: 20
+  }
+};
+
 class Background extends Component {
   render() {
     return (
-      <div>
+      <div style={styles.padding}>
         <h2>{LOCALIZE.emibTest.backgroundPage.title}</h2>
         <h3>{LOCALIZE.emibTest.backgroundPage.orgChart}</h3>
         <h3>{LOCALIZE.emibTest.backgroundPage.Scenarios}</h3>

--- a/frontend/src/components/eMIB/Inbox.jsx
+++ b/frontend/src/components/eMIB/Inbox.jsx
@@ -1,10 +1,16 @@
 import React, { Component } from "react";
 import LOCALIZE from "../../text_resources";
 
+const styles = {
+  padding: {
+    padding: 20
+  }
+};
+
 class Inbox extends Component {
   render() {
     return (
-      <div>
+      <div style={styles.padding}>
         <h2>{LOCALIZE.emibTest.inboxPage.title}</h2>
         <h3>{LOCALIZE.emibTest.inboxPage.taskList}</h3>
         <h3>{LOCALIZE.emibTest.inboxPage.notePad}</h3>

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -174,14 +174,14 @@ let LOCALIZE = new LocalizedStrings({
 
       //Background Page
       backgroundPage: {
-        title: "Background Page",
+        title: "Background Coming Soon!",
         orgChart: "Org Chart",
         Scenarios: "Scenarios"
       },
 
       //Inbox Page
       inboxPage: {
-        title: "Inbox",
+        title: "Inbox Coming Soon!",
         taskList: "Tasks List",
         notePad: "NotePad",
         textTools: "Text Tools",


### PR DESCRIPTION
# Description

For our next demo, we want to make our "empty" features look a little nicer. 

This PR ads coming soon text to the Inbox and Background tabs.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

![image](https://user-images.githubusercontent.com/4640747/53898465-1b173d00-4006-11e9-8325-5abc3c7b7336.png)
![image](https://user-images.githubusercontent.com/4640747/53898479-22d6e180-4006-11e9-928a-2750ab2763d8.png)



# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Go to eMIB test and look at Background and Inbox tabs.

Screenshot of unit tests run passing:
![image](https://user-images.githubusercontent.com/4640747/53898508-32562a80-4006-11e9-9bf5-5780b3362051.png)


# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
