### PR TITLE
[Pairing Design Session] Notepad and Test Footer Style Updates

### DIFF
--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -13,7 +13,7 @@ const styles = {
     color: "white"
   },
   title: {
-    paddingLeft: 15,
+    paddingLeft: 12,
     paddingTop: 0.1,
     height: 55,
     backgroundColor: "#00565e",
@@ -26,11 +26,11 @@ const styles = {
     borderColor: "#00565e",
     borderRadius: "5px 5px 0 0",
     width: 220,
-    height: "calc(100vh - 270px)"
+    height: "calc(100vh - 237px)"
   },
   notepadSection: {
     overflow: "auto",
-    height: "calc(100vh - 330px)"
+    height: "calc(100vh - 297px)"
   },
   textArea: {
     resize: "none",

--- a/frontend/src/components/commons/SideNavigation.jsx
+++ b/frontend/src/components/commons/SideNavigation.jsx
@@ -26,7 +26,7 @@ const styles = {
   bodyContent: {
     overflow: "auto",
     paddingRight: 20,
-    height: "calc(100vh - 273px)"
+    height: "calc(100vh - 241px)"
   },
   secondaryButton: {
     border: "none"

--- a/frontend/src/components/commons/TabNavigation.jsx
+++ b/frontend/src/components/commons/TabNavigation.jsx
@@ -27,7 +27,7 @@ const styles = {
     borderStyle: "solid",
     borderColor: "#00565e",
     borderTopColor: "white",
-    height: "calc(100vh - 272px)",
+    height: "calc(100vh - 241px)",
     width: 900
   }
 };

--- a/frontend/src/components/commons/TestFooter.jsx
+++ b/frontend/src/components/commons/TestFooter.jsx
@@ -8,7 +8,7 @@ const styles = {
     marginLeft: "auto",
     marginRight: "auto",
     width: 1140,
-    height: 104
+    height: 72
   },
   hr: {
     width: "100%",
@@ -17,11 +17,11 @@ const styles = {
   },
   submitBtn: {
     float: "right",
-    paddingTop: 32
+    paddingTop: 17
   },
   quitTestBtn: {
     float: "left",
-    paddingTop: 32
+    paddingTop: 17
   }
 };
 


### PR DESCRIPTION
# Description

I met Joey (UX Designer) and made some style updates related to the notepad and the test footer components.

## Type of change

- Code cleanliness or refactor

## Screenshot

![image](https://user-images.githubusercontent.com/23021242/53967756-cafeb000-40c3-11e9-96c7-65bf39943bf0.png)

# Testing

Manual steps to reproduce this functionality:

1.  Go to _Prototype_ tab.
2.  Click _Star eMIB Sample Test_.
3.  Pass the instructions.
4. Make sure that the notepad and the test footer look good in all browsers.

Screenshot of unit tests run passing:

![image](https://user-images.githubusercontent.com/23021242/53967929-2335b200-40c4-11e9-80ba-3f3418cee7a9.png)

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ]~~ I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 10+, Firefox, and Chrome
