### PR TITLE
[Background Page] Image Dailog

### DIFF
--- a/frontend/src/components/eMIB/OrganizationalStructure.jsx
+++ b/frontend/src/components/eMIB/OrganizationalStructure.jsx
@@ -85,7 +85,7 @@ class OrganizationalStructure extends Component {
                 />
               )}
             </p>
-            <button onClick={this.openPopup} className="button-link">
+            <button onClick={this.openPopup} className="btn btn-secondary">
               {LOCALIZE.emibTest.background.organizationalStructure.orgChart.link}
             </button>
           </div>

--- a/frontend/src/components/eMIB/OrganizationalStructure.jsx
+++ b/frontend/src/components/eMIB/OrganizationalStructure.jsx
@@ -10,6 +10,9 @@ import emib_sample_test_example_org_chart_fr from "../../images/emib_sample_test
 const styles = {
   testImage: {
     maxWidth: 600
+  },
+  button: {
+    marginLeft: 5
   }
 };
 
@@ -85,7 +88,7 @@ class OrganizationalStructure extends Component {
                 />
               )}
             </p>
-            <button onClick={this.openPopup} className="btn btn-secondary">
+            <button onClick={this.openPopup} className="btn btn-secondary" style={styles.button}>
               {LOCALIZE.emibTest.background.organizationalStructure.orgChart.link}
             </button>
           </div>

--- a/frontend/src/components/eMIB/OrganizationalStructure.jsx
+++ b/frontend/src/components/eMIB/OrganizationalStructure.jsx
@@ -3,6 +3,7 @@ import "../../css/lib/aurora.min.css";
 import LOCALIZE from "../../text_resources";
 import "../../css/cat-theme.css";
 import { LANGUAGES } from "../commons/Translation";
+import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
 import emib_sample_test_example_org_chart_en from "../../images/emib_sample_test_example_org_chart_en.png";
 import emib_sample_test_example_org_chart_fr from "../../images/emib_sample_test_example_org_chart_fr.png";
 
@@ -13,9 +14,31 @@ const styles = {
 };
 
 class OrganizationalStructure extends Component {
+  state = {
+    showPopupBox: false
+  };
+
+  openPopup = () => {
+    this.setState({ showPopupBox: true });
+  };
+
+  closePopup = () => {
+    this.setState({ showPopupBox: false });
+  };
+
   render() {
     return (
       <div>
+        <PopupBox
+          show={this.state.showPopupBox}
+          handleClose={this.closePopup}
+          title={LOCALIZE.emibTest.background.organizationalStructure.dialog.title}
+          description={
+            <div>{LOCALIZE.emibTest.background.organizationalStructure.dialog.description}</div>
+          }
+          rightButtonType={BUTTON_TYPE.secondary}
+          rightButtonTitle={LOCALIZE.commons.close}
+        />
         <div>
           <h2>{LOCALIZE.emibTest.background.organizationalStructure.title}</h2>
           <div>
@@ -62,7 +85,9 @@ class OrganizationalStructure extends Component {
                 />
               )}
             </p>
-            <p>{LOCALIZE.emibTest.background.organizationalStructure.orgChart.link}</p>
+            <span onClick={this.openPopup}>
+              {LOCALIZE.emibTest.background.organizationalStructure.orgChart.link}
+            </span>
           </div>
         </div>
       </div>

--- a/frontend/src/components/eMIB/OrganizationalStructure.jsx
+++ b/frontend/src/components/eMIB/OrganizationalStructure.jsx
@@ -85,9 +85,9 @@ class OrganizationalStructure extends Component {
                 />
               )}
             </p>
-            <span onClick={this.openPopup}>
+            <button onClick={this.openPopup} className="button-link">
               {LOCALIZE.emibTest.background.organizationalStructure.orgChart.link}
-            </span>
+            </button>
           </div>
         </div>
       </div>

--- a/frontend/src/components/eMIB/TeamInformation.jsx
+++ b/frontend/src/components/eMIB/TeamInformation.jsx
@@ -3,6 +3,7 @@ import "../../css/lib/aurora.min.css";
 import LOCALIZE from "../../text_resources";
 import "../../css/cat-theme.css";
 import { LANGUAGES } from "../commons/Translation";
+import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
 import emib_sample_test_example_team_chart_en from "../../images/emib_sample_test_example_team_chart_en.png";
 import emib_sample_test_example_team_chart_fr from "../../images/emib_sample_test_example_team_chart_fr.png";
 
@@ -13,9 +14,29 @@ const styles = {
 };
 
 class TeamInformation extends Component {
+  state = {
+    showPopupBox: false
+  };
+
+  openPopup = () => {
+    this.setState({ showPopupBox: true });
+  };
+
+  closePopup = () => {
+    this.setState({ showPopupBox: false });
+  };
+
   render() {
     return (
       <div>
+        <PopupBox
+          show={this.state.showPopupBox}
+          handleClose={this.closePopup}
+          title={LOCALIZE.emibTest.background.teamInformation.dialog.title}
+          description={<div>{LOCALIZE.emibTest.background.teamInformation.dialog.description}</div>}
+          rightButtonType={BUTTON_TYPE.secondary}
+          rightButtonTitle={LOCALIZE.commons.close}
+        />
         <div>
           <h2>{LOCALIZE.emibTest.background.teamInformation.title}</h2>
           <div>
@@ -48,7 +69,9 @@ class TeamInformation extends Component {
                 />
               )}
             </p>
-            <p>{LOCALIZE.emibTest.background.teamInformation.teamChart.link}</p>
+            <span onClick={this.openPopup}>
+              {LOCALIZE.emibTest.background.teamInformation.teamChart.link}
+            </span>
           </div>
           <div>
             <h3>{LOCALIZE.emibTest.background.teamInformation.responsibilitiesSection.title}</h3>

--- a/frontend/src/components/eMIB/TeamInformation.jsx
+++ b/frontend/src/components/eMIB/TeamInformation.jsx
@@ -69,9 +69,9 @@ class TeamInformation extends Component {
                 />
               )}
             </p>
-            <span onClick={this.openPopup}>
+            <button onClick={this.openPopup} className="button-link">
               {LOCALIZE.emibTest.background.teamInformation.teamChart.link}
-            </span>
+            </button>
           </div>
           <div>
             <h3>{LOCALIZE.emibTest.background.teamInformation.responsibilitiesSection.title}</h3>

--- a/frontend/src/components/eMIB/TeamInformation.jsx
+++ b/frontend/src/components/eMIB/TeamInformation.jsx
@@ -69,7 +69,7 @@ class TeamInformation extends Component {
                 />
               )}
             </p>
-            <button onClick={this.openPopup} className="button-link">
+            <button onClick={this.openPopup} className="btn btn-secondary">
               {LOCALIZE.emibTest.background.teamInformation.teamChart.link}
             </button>
           </div>

--- a/frontend/src/components/eMIB/TeamInformation.jsx
+++ b/frontend/src/components/eMIB/TeamInformation.jsx
@@ -10,6 +10,9 @@ import emib_sample_test_example_team_chart_fr from "../../images/emib_sample_tes
 const styles = {
   testImage: {
     maxWidth: 600
+  },
+  button: {
+    marginLeft: 5
   }
 };
 
@@ -69,7 +72,7 @@ class TeamInformation extends Component {
                 />
               )}
             </p>
-            <button onClick={this.openPopup} className="btn btn-secondary">
+            <button onClick={this.openPopup} className="btn btn-secondary" style={styles.button}>
               {LOCALIZE.emibTest.background.teamInformation.teamChart.link}
             </button>
           </div>

--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -187,3 +187,13 @@ Progess Steps
   min-width: 500px;
   max-width: 1000px;
 }
+
+.button-link {
+  background: none !important;
+  color: blue;
+  border: none;
+  padding: 0 !important;
+  font: inherit;
+  border-bottom: 1px solid blue;
+  cursor: pointer;
+}

--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -187,13 +187,3 @@ Progess Steps
   min-width: 500px;
   max-width: 1000px;
 }
-
-.button-link {
-  background: none !important;
-  color: blue;
-  border: none;
-  padding: 0 !important;
-  font: inherit;
-  border-bottom: 1px solid blue;
-  cursor: pointer;
-}

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -220,6 +220,11 @@ let LOCALIZE = new LocalizedStrings({
           orgChart: {
             desciption: "Organizational Chart (ODC)",
             link: "Image Description (Coming Soon)"
+          },
+          dialog: {
+            title: "The Organizational Chart of the Organizational Development Council’s (ODC)",
+            description:
+              "The Organizational Chart for ODC. At the top is President: Jenna Icart. Under the president are 4 directors: Amari Kinsler from Corporate Affairs, nameless from Research and Innovations, Bartosz Greco from Program Development, nameless from Services and Communications. Corporate Affairs has 3 managers: HR, Bob McNutt manager from Finance, and Lana Hussad from Information Technology. etc. etc."
           }
         },
         teamInformation: {
@@ -239,6 +244,10 @@ let LOCALIZE = new LocalizedStrings({
           teamChart: {
             desciption: "Organizational Chart The Quality Assurance (QA) Team",
             link: "Image Description (Coming Soon)"
+          },
+          dialog: {
+            title: "The Organizational Chart The Quality Assurance (QA) Team",
+            description: "Description (coming soon)"
           },
           responsibilitiesSection: {
             title: "QA Team Responsibilities",
@@ -323,7 +332,8 @@ let LOCALIZE = new LocalizedStrings({
         title: "Notepad",
         placeholder: "Put your notes here..."
       },
-      cancel: "Cancel"
+      cancel: "Cancel",
+      close: "Close"
     }
   },
 
@@ -551,6 +561,11 @@ let LOCALIZE = new LocalizedStrings({
           orgChart: {
             desciption: "Organigramme (CDO)",
             link: "FR Image Description (Coming Soon)"
+          },
+          dialog: {
+            title: "FR The Organizational Chart of the Organizational Development Council’s (ODC)",
+            description:
+              "FR The Organizational Chart for ODC. At the top is President: Jenna Icart. Under the president are 4 directors: Amari Kinsler from Corporate Affairs, nameless from Research and Innovations, Bartosz Greco from Program Development, nameless from Services and Communications. Corporate Affairs has 3 managers: HR, Bob McNutt manager from Finance, and Lana Hussad from Information Technology. etc. etc."
           }
         },
         teamInformation: {
@@ -570,6 +585,10 @@ let LOCALIZE = new LocalizedStrings({
           teamChart: {
             desciption: "Organigramme Équipe de l'assurance de la qualité (AQ) Team",
             link: "FR Image Description (Coming Soon)"
+          },
+          dialog: {
+            title: "Organigramme Équipe de l'assurance de la qualité (AQ) Team",
+            description: "FR Description (coming soon)"
           },
           responsibilitiesSection: {
             title: "Responsabilités de l’Équipe de l’AQ",
@@ -655,7 +674,8 @@ let LOCALIZE = new LocalizedStrings({
         title: "Bloc-notes",
         placeholder: "Mettez vos notes ici..."
       },
-      cancel: "Annuler"
+      cancel: "Annuler",
+      close: "FR Close"
     }
   }
 });

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -219,12 +219,12 @@ let LOCALIZE = new LocalizedStrings({
             "The main goals of the SC unit are to continuously evaluate training programs offered by organizations in the public service, conduct internal and external audits for partners and clients, and oversee the dissemination of information (e.g., content review for online tools, developing documentation for training programs). The SC unit is comprised of the Quality Assurance Team, the Service and support Team, the Audits Team, and the E-Training Team.",
           orgChart: {
             desciption: "Organizational Chart (ODC)",
-            link: "Image Description (Coming Soon)"
+            link: "Image Description"
           },
           dialog: {
             title: "The Organizational Chart of the Organizational Development Council’s (ODC)",
             description:
-              "The Organizational Chart for ODC. At the top is President: Jenna Icart. Under the president are 4 directors: Amari Kinsler from Corporate Affairs, nameless from Research and Innovations, Bartosz Greco from Program Development, nameless from Services and Communications. Corporate Affairs has 3 managers: HR, Bob McNutt manager from Finance, and Lana Hussad from Information Technology. etc. etc."
+              "The Organizational Chart for the Organizational Development Council (ODC). At the top is the President: Jenna Icart. Under the president are 4 directors: Amari Kinsler from Corporate Affairs, Geneviève Bédard from Research and Innovations, Bartosz Greco from Program Development, Nancy Ward from Services and Communications. Corporate Affairs has 3 managers: Marc Sheridan from Human Resources, Bob McNutt from Finance, and Lana Hussad from Information Technology. Services and Communications has 4 managers: Claude Huard (You) from Quality Assurance, Haydar Kalil from Services and Support, Geoffrey Hamma from Audits, and Lucy Trang from E-Training."
           }
         },
         teamInformation: {
@@ -243,11 +243,12 @@ let LOCALIZE = new LocalizedStrings({
           },
           teamChart: {
             desciption: "Organizational Chart The Quality Assurance (QA) Team",
-            link: "Image Description (Coming Soon)"
+            link: "Image Description"
           },
           dialog: {
             title: "The Organizational Chart The Quality Assurance (QA) Team",
-            description: "Description (coming soon)"
+            description:
+              "The Organizational Chart for the Quality Assurance (QA) Team. At the top is the Manager, Claude Huard (you). Under the manager are 6 Quality Assurance Analysts: Danny McBride, Serge Duplessis, Marina Richter, Mary Woodside, Charlie Wang, and Jack Laurier."
           },
           responsibilitiesSection: {
             title: "QA Team Responsibilities",
@@ -560,12 +561,12 @@ let LOCALIZE = new LocalizedStrings({
             "Les principaux objectifs de l’Unité des SC sont d’évaluer de façon continue les programmes de formation offerts par les organisations de la fonction publique, effectuer des vérifications internes et externes pour les partenaires et les clients, et surveiller la diffusion de l’information (p. ex., évaluer le contenu des outils en ligne, rédiger les documents relatifs aux programmes de formation). L’Unité des SC est composée de l’Équipe de l’assurance de la qualité, l’Équipe du service et soutien, l’Équipe des vérifications et de l’Équipe des formations en ligne.",
           orgChart: {
             desciption: "Organigramme (CDO)",
-            link: "FR Image Description (Coming Soon)"
+            link: "FR Image Description"
           },
           dialog: {
             title: "FR The Organizational Chart of the Organizational Development Council’s (ODC)",
             description:
-              "FR The Organizational Chart for ODC. At the top is President: Jenna Icart. Under the president are 4 directors: Amari Kinsler from Corporate Affairs, nameless from Research and Innovations, Bartosz Greco from Program Development, nameless from Services and Communications. Corporate Affairs has 3 managers: HR, Bob McNutt manager from Finance, and Lana Hussad from Information Technology. etc. etc."
+              "FR The Organizational Chart for the Organizational Development Council (ODC). At the top is the President: Jenna Icart. Under the president are 4 directors: Amari Kinsler from Corporate Affairs, Geneviève Bédard from Research and Innovations, Bartosz Greco from Program Development, Nancy Ward from Services and Communications. Corporate Affairs has 3 managers: Marc Sheridan from Human Resources, Bob McNutt from Finance, and Lana Hussad from Information Technology. Services and Communications has 4 managers: Claude Huard (You) from Quality Assurance, Haydar Kalil from Services and Support, Geoffrey Hamma from Audits, and Lucy Trang from E-Training."
           }
         },
         teamInformation: {
@@ -584,11 +585,12 @@ let LOCALIZE = new LocalizedStrings({
           },
           teamChart: {
             desciption: "Organigramme Équipe de l'assurance de la qualité (AQ) Team",
-            link: "FR Image Description (Coming Soon)"
+            link: "FR Image Description"
           },
           dialog: {
             title: "Organigramme Équipe de l'assurance de la qualité (AQ) Team",
-            description: "FR Description (coming soon)"
+            description:
+              "FR The Organizational Chart for the Quality Assurance (QA) Team. At the top is the Manager, Claude Huard (you). Under the manager are 6 Quality Assurance Analysts: Danny McBride, Serge Duplessis, Marina Richter, Mary Woodside, Charlie Wang, and Jack Laurier."
           },
           responsibilitiesSection: {
             title: "Responsabilités de l’Équipe de l’AQ",

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -222,7 +222,7 @@ let LOCALIZE = new LocalizedStrings({
             link: "Image Description"
           },
           dialog: {
-            title: "The Organizational Chart of the Organizational Development Council’s (ODC)",
+            title: "The Organizational Chart of the ODC",
             description:
               "The Organizational Chart for the Organizational Development Council (ODC). At the top is the President: Jenna Icart. Under the president are 4 directors: Amari Kinsler from Corporate Affairs, Geneviève Bédard from Research and Innovations, Bartosz Greco from Program Development, Nancy Ward from Services and Communications. Corporate Affairs has 3 managers: Marc Sheridan from Human Resources, Bob McNutt from Finance, and Lana Hussad from Information Technology. Services and Communications has 4 managers: Claude Huard (You) from Quality Assurance, Haydar Kalil from Services and Support, Geoffrey Hamma from Audits, and Lucy Trang from E-Training."
           }
@@ -246,7 +246,7 @@ let LOCALIZE = new LocalizedStrings({
             link: "Image Description"
           },
           dialog: {
-            title: "The Organizational Chart of the Quality Assurance (QA) Team",
+            title: "The Organizational Chart of the QA Team",
             description:
               "The Organizational Chart for the Quality Assurance (QA) Team. At the top is the Manager, Claude Huard (you). Under the manager are 6 Quality Assurance Analysts: Danny McBride, Serge Duplessis, Marina Richter, Mary Woodside, Charlie Wang, and Jack Laurier."
           },
@@ -564,7 +564,7 @@ let LOCALIZE = new LocalizedStrings({
             link: "FR Image Description"
           },
           dialog: {
-            title: "FR The Organizational Chart of the Organizational Development Council’s (ODC)",
+            title: "FR The Organizational Chart of the ODC",
             description:
               "FR The Organizational Chart for the Organizational Development Council (ODC). At the top is the President: Jenna Icart. Under the president are 4 directors: Amari Kinsler from Corporate Affairs, Geneviève Bédard from Research and Innovations, Bartosz Greco from Program Development, Nancy Ward from Services and Communications. Corporate Affairs has 3 managers: Marc Sheridan from Human Resources, Bob McNutt from Finance, and Lana Hussad from Information Technology. Services and Communications has 4 managers: Claude Huard (You) from Quality Assurance, Haydar Kalil from Services and Support, Geoffrey Hamma from Audits, and Lucy Trang from E-Training."
           }
@@ -588,7 +588,7 @@ let LOCALIZE = new LocalizedStrings({
             link: "FR Image Description"
           },
           dialog: {
-            title: "FR The Organizational Chart of the Quality Assurance (QA) Team",
+            title: "FR The Organizational Chart of the QA Team",
             description:
               "FR The Organizational Chart for the Quality Assurance (QA) Team. At the top is the Manager, Claude Huard (you). Under the manager are 6 Quality Assurance Analysts: Danny McBride, Serge Duplessis, Marina Richter, Mary Woodside, Charlie Wang, and Jack Laurier."
           },

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -246,7 +246,7 @@ let LOCALIZE = new LocalizedStrings({
             link: "Image Description"
           },
           dialog: {
-            title: "The Organizational Chart The Quality Assurance (QA) Team",
+            title: "The Organizational Chart of the Quality Assurance (QA) Team",
             description:
               "The Organizational Chart for the Quality Assurance (QA) Team. At the top is the Manager, Claude Huard (you). Under the manager are 6 Quality Assurance Analysts: Danny McBride, Serge Duplessis, Marina Richter, Mary Woodside, Charlie Wang, and Jack Laurier."
           },
@@ -588,7 +588,7 @@ let LOCALIZE = new LocalizedStrings({
             link: "FR Image Description"
           },
           dialog: {
-            title: "Organigramme Équipe de l'assurance de la qualité (AQ) Team",
+            title: "FR The Organizational Chart of the Quality Assurance (QA) Team",
             description:
               "FR The Organizational Chart for the Quality Assurance (QA) Team. At the top is the Manager, Claude Huard (you). Under the manager are 6 Quality Assurance Analysts: Danny McBride, Serge Duplessis, Marina Richter, Mary Woodside, Charlie Wang, and Jack Laurier."
           },


### PR DESCRIPTION
# Description

This PR adds popup boxes for the org chart image descriptions on the background page.
Notes:
- this does not include the french translations
- I used buttons rather than links because links without a valid href generate warnings when compiling.


## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Screenshot

Please provide if applicable (browser for `frontend` or any visual way to show a `backend` change).

![image](https://user-images.githubusercontent.com/2746350/54276018-932fb680-4562-11e9-98c1-c42d29a592f9.png)

![image](https://user-images.githubusercontent.com/2746350/54276039-a04ca580-4562-11e9-988d-94c9be9ce154.png)

![image](https://user-images.githubusercontent.com/2746350/54276058-ae022b00-4562-11e9-8eb2-c0692556c45b.png)


# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Navigate through the eMiB pre-test instruction pages to the eMIB itself
2.  In the background page, scroll down to the org charts.
3.  Click the link below the org charts to open the popup box with descriptuion

Screenshot of unit tests run passing:
![image](https://user-images.githubusercontent.com/2746350/54227584-a5641300-44d6-11e9-8c07-fa796131ee91.png)


# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
