### PR TITLE
[Quit Test Flow] Real Content Insert

### DIFF
--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -228,8 +228,8 @@ class Emib extends Component {
               <div>
                 <SystemMessage
                   messageType={MESSAGE_TYPE.error}
-                  title={LOCALIZE.emibTest.testFooter.quitTestPopupBox.error.title}
-                  message={LOCALIZE.emibTest.testFooter.quitTestPopupBox.error.message}
+                  title={LOCALIZE.emibTest.testFooter.quitTestPopupBox.warning.title}
+                  message={LOCALIZE.emibTest.testFooter.quitTestPopupBox.warning.message}
                 />
               </div>
               <p className="font-weight-bold">
@@ -262,6 +262,9 @@ class Emib extends Component {
               <hr style={styles.hr} />
               <p className="font-weight-bold">
                 {LOCALIZE.emibTest.testFooter.quitTestPopupBox.descriptionPart2}
+              </p>
+              <p className="font-weight-bold">
+                {LOCALIZE.emibTest.testFooter.quitTestPopupBox.descriptionPart3}
               </p>
             </div>
           }

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -296,19 +296,20 @@ let LOCALIZE = new LocalizedStrings({
         },
         quitTestPopupBox: {
           title: "Are you sure you want to quit this test?",
-          error: {
-            title: "Warning! All answers will be deleted.",
+          warning: {
+            title: "Warning! Once you exit the test, you will not be able to get back in.",
             message:
-              "All the work in this session will be lost if you quit this test. You will not be able to recover your answers, and will forfeit this assessment. You may be re-tested at a later time."
+              "You will not be able to recover your answers, and will be withdrawn from this test session. You may be retested at a later time."
           },
           descriptionPart1:
-            "You are about to withdraw from this test. By proceeding, you acknowledge and consent to the following:",
+            "You are about to withdraw from this test. By proceeding, you acknowledge the following:",
           checkboxOne: "I voluntarily withdraw from this examination",
-          checkboxTwo: "I do not wish to have my test scored",
+          checkboxTwo: "my test will not be scored",
           checkboxThree:
             "I am aware that the retest period for this test may apply, should I wish to write this test again",
           descriptionPart2:
-            'If you are certain that you want to quit this session, click the "Quit test" button. You will be exited out of this test session and provided instructions to complete your withdrawal.'
+            "If you are certain that you want to quit this session, click the “Quit test” button. You will be exited out of this test session and provided instructions to complete your withdrawal.",
+          descriptionPart3: "Are you sure you want to quit this test?"
         }
       }
     },
@@ -330,7 +331,7 @@ let LOCALIZE = new LocalizedStrings({
       startTest: "Start test",
       submitTestButton: "Submit test",
       quitTest: "Quit Test",
-      returnToTest: "Return to test",
+      returnToTest: "Return to Test",
       passStatus: "Pass",
       failStatus: "Fail",
       enabled: "Enabled",
@@ -644,20 +645,22 @@ let LOCALIZE = new LocalizedStrings({
             'FR If you are ready to send your test in for scoring, click the "Submit test" button. You will be exited out of this test session and provided further instructions'
         },
         quitTestPopupBox: {
-          title: "FR Are you sure you want to quit this test?",
-          error: {
-            title: "FR Warning! All answers will be deleted.",
+          title: "Souhaitez-vous mettre fin à cette séance de test?",
+          warning: {
+            title:
+              "Avertissement : une fois la séance de test terminée, vous ne pourrez plus y retourner.",
             message:
-              "FR All the work in this session will be lost if you quit this test. You will not be able to recover your answers, and will forfeit this assessment. You may be re-tested at a later time."
+              "Vous ne pourrez pas récupérer vos réponses et n’aurez plus accès à la séance de test. Vous pourrez reprendre le test à une date ultérieure."
           },
           descriptionPart1:
-            "FR You are about to withdraw from this test. By proceeding, you acknowledge and consent to the following:",
-          checkboxOne: "FR I voluntarily withdraw from this examination",
-          checkboxTwo: "FR I do not wish to have my test scored",
+            "Vous êtes sur le point de mettre fin à la séance de test. Ce faisant, vous affirmez et reconnaissez :",
+          checkboxOne: "je me retire volontairement de ce test;",
+          checkboxTwo: "mon test ne sera pas noté;",
           checkboxThree:
-            "FR I am aware that the retest period for this test may apply, should I wish to write this test again",
+            "je suis conscient(e) que la période d'attente pour ce test peut s’appliquer, si je veux écrire ce test de nouveau dans le futur.",
           descriptionPart2:
-            'FR If you are certain that you want to quit this session, click the "Quit test" button. You will be exited out of this test session and provided instructions to complete your withdrawal.'
+            "Si vous êtes certain(e) de vouloir mettre fin à cette séance, cliquez sur le bouton « Quitter la séance test ». La séance de test sera fermée et vous recevrez des instructions sur la façon de vous retirer.",
+          descriptionPart3: "Souhaitez-vous mettre fin à cette séance de test?"
         }
       }
     },
@@ -678,8 +681,8 @@ let LOCALIZE = new LocalizedStrings({
       backButton: "Retour",
       startTest: "Commencer le test",
       submitTestButton: "Soumettre le test",
-      quitTest: "Quitter le test",
-      returnToTest: "Retour au test",
+      quitTest: "Quitter la séance de test",
+      returnToTest: "Retourner à la séance",
       passStatus: "Réussi",
       failStatus: "Échoue",
       enabled: "Activé",


### PR DESCRIPTION
# Description

I added the real content in the quit test popup box in both official languages.

## Type of change

- Code cleanliness or refactor

## Screenshot

**English Version:**

![image](https://user-images.githubusercontent.com/23021242/54352489-2d0d6700-4628-11e9-9d30-d37f12f72609.png)

**French Version:**

![image](https://user-images.githubusercontent.com/23021242/54352457-1a932d80-4628-11e9-8ca3-dd94080fc6da.png)

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB sample test.
2.  Complete the pre-test process.
3.  Click Quit test and make sure that the content is right (in both official languages).

Screenshot of unit tests run passing:

![image](https://user-images.githubusercontent.com/23021242/54352689-9ab99300-4628-11e9-97dd-13e5458f2358.png)

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 10+, Firefox, and Chrome
