### PR TITLE
[Image Dialog] Addition of EN Content

### DIFF
--- a/frontend/src/components/eMIB/OrganizationalStructure.jsx
+++ b/frontend/src/components/eMIB/OrganizationalStructure.jsx
@@ -85,10 +85,16 @@ class OrganizationalStructure extends Component {
                   src={emib_sample_test_example_org_chart_fr}
                   alt={LOCALIZE.emibTest.background.organizationalStructure.orgChart.desciption}
                   style={styles.testImage}
+                  longdesc="#org-image-description"
                 />
               )}
             </p>
-            <button onClick={this.openPopup} className="btn btn-secondary" style={styles.button}>
+            <button
+              id="org-image-description"
+              onClick={this.openPopup}
+              className="btn btn-secondary"
+              style={styles.button}
+            >
               {LOCALIZE.emibTest.background.organizationalStructure.orgChart.link}
             </button>
           </div>

--- a/frontend/src/components/eMIB/TeamInformation.jsx
+++ b/frontend/src/components/eMIB/TeamInformation.jsx
@@ -61,6 +61,7 @@ class TeamInformation extends Component {
                   src={emib_sample_test_example_team_chart_en}
                   alt={LOCALIZE.emibTest.background.teamInformation.teamChart.desciption}
                   style={styles.testImage}
+                  longdesc="#team-image-description"
                 />
               )}
               {LOCALIZE.emibTest.howToPage.testInstructions.step2Section.example
@@ -72,7 +73,12 @@ class TeamInformation extends Component {
                 />
               )}
             </p>
-            <button onClick={this.openPopup} className="btn btn-secondary" style={styles.button}>
+            <button
+              id="team-image-description"
+              onClick={this.openPopup}
+              className="btn btn-secondary"
+              style={styles.button}
+            >
               {LOCALIZE.emibTest.background.teamInformation.teamChart.link}
             </button>
           </div>

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -224,7 +224,7 @@ let LOCALIZE = new LocalizedStrings({
           dialog: {
             title: "The Organizational Chart of the ODC",
             description:
-              "The Organizational Chart for the Organizational Development Council (ODC). At the top is the President: Jenna Icart. Under the president are 4 directors: Amari Kinsler from Corporate Affairs, Geneviève Bédard from Research and Innovations, Bartosz Greco from Program Development, Nancy Ward from Services and Communications. Corporate Affairs has 3 managers: Marc Sheridan from Human Resources, Bob McNutt from Finance, and Lana Hussad from Information Technology. Services and Communications has 4 managers: Claude Huard (You) from Quality Assurance, Haydar Kalil from Services and Support, Geoffrey Hamma from Audits, and Lucy Trang from E-Training."
+              "This is the organizational chart for the Organizational Development Council (ODC). At the top is the President: Jenna Icart. Under the president are 4 directors, one representing each unit of the council. These are presented left to right as: Amari Kinsler from Corporate Affairs, Geneviève Bédard from Research and Innovations, Bartosz Greco from Program Development, Nancy Ward from Services and Communications.  Corporate Affairs has 3 managers: Marc Sheridan from Human Resources, Bob McNutt from Finance, and Lana Hussad from Information Technology. Services and Communications has 4 managers: You are Claude Huard from Quality Assurance, Haydar Kalil from Services and Support, Geoffrey Hamma from Audits, and Lucy Trang from E-Training."
           }
         },
         teamInformation: {
@@ -248,7 +248,7 @@ let LOCALIZE = new LocalizedStrings({
           dialog: {
             title: "The Organizational Chart of the QA Team",
             description:
-              "The Organizational Chart for the Quality Assurance (QA) Team. At the top is the Manager, Claude Huard (you). Under the manager are 6 Quality Assurance Analysts: Danny McBride, Serge Duplessis, Marina Richter, Mary Woodside, Charlie Wang, and Jack Laurier."
+              "This is the organizational chart for the Quality Assurance (QA) Team at the Organizational Development Council. You, Claude Huard are the Manager of this unit, and are located at the top of the organizational chart. Under you, The Manager, are 6 Quality Assurance Analysts: Danny McBride, Serge Duplessis, Marina Richter, Mary Woodside, Charlie Wang, and Jack Laurier."
           },
           responsibilitiesSection: {
             title: "QA Team Responsibilities",
@@ -566,7 +566,7 @@ let LOCALIZE = new LocalizedStrings({
           dialog: {
             title: "FR The Organizational Chart of the ODC",
             description:
-              "FR The Organizational Chart for the Organizational Development Council (ODC). At the top is the President: Jenna Icart. Under the president are 4 directors: Amari Kinsler from Corporate Affairs, Geneviève Bédard from Research and Innovations, Bartosz Greco from Program Development, Nancy Ward from Services and Communications. Corporate Affairs has 3 managers: Marc Sheridan from Human Resources, Bob McNutt from Finance, and Lana Hussad from Information Technology. Services and Communications has 4 managers: Claude Huard (You) from Quality Assurance, Haydar Kalil from Services and Support, Geoffrey Hamma from Audits, and Lucy Trang from E-Training."
+              "FR This is the organizational chart for the Organizational Development Council (ODC). At the top is the President: Jenna Icart. Under the president are 4 directors, one representing each unit of the council. These are presented left to right as: Amari Kinsler from Corporate Affairs, Geneviève Bédard from Research and Innovations, Bartosz Greco from Program Development, Nancy Ward from Services and Communications.  Corporate Affairs has 3 managers: Marc Sheridan from Human Resources, Bob McNutt from Finance, and Lana Hussad from Information Technology. Services and Communications has 4 managers: You are Claude Huard from Quality Assurance, Haydar Kalil from Services and Support, Geoffrey Hamma from Audits, and Lucy Trang from E-Training."
           }
         },
         teamInformation: {
@@ -590,7 +590,7 @@ let LOCALIZE = new LocalizedStrings({
           dialog: {
             title: "FR The Organizational Chart of the QA Team",
             description:
-              "FR The Organizational Chart for the Quality Assurance (QA) Team. At the top is the Manager, Claude Huard (you). Under the manager are 6 Quality Assurance Analysts: Danny McBride, Serge Duplessis, Marina Richter, Mary Woodside, Charlie Wang, and Jack Laurier."
+              "FR This is the organizational chart for the Quality Assurance (QA) Team at the Organizational Development Council. You, Claude Huard are the Manager of this unit, and are located at the top of the organizational chart. Under you, The Manager, are 6 Quality Assurance Analysts: Danny McBride, Serge Duplessis, Marina Richter, Mary Woodside, Charlie Wang, and Jack Laurier."
           },
           responsibilitiesSection: {
             title: "Responsabilités de l’Équipe de l’AQ",


### PR DESCRIPTION
# Description

Added real english content to the Image Dialogs in the Background section.
Added longdesc referring to the id of the image description button

## Type of change

Please delete options that are not relevant.

- Code cleanliness or refactor

## Screenshot

![image](https://user-images.githubusercontent.com/2746350/54369762-debe8f00-464c-11e9-9a93-30d426b32579.png)

![image](https://user-images.githubusercontent.com/2746350/54369790-eaaa5100-464c-11e9-96fe-46d6e85859bb.png)


# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Navigate through Prototype -> Pre-test Instructions -> Background
2. Verify that the popups still work/show the correct text

Screenshot of unit tests run passing:

![image](https://user-images.githubusercontent.com/2746350/54369483-6a83eb80-464c-11e9-936b-133180a4f64b.png)

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
