### PR TITLE
[Quit Test Flow] Simplified the enabled/disabled Quit Test button logic

### DIFF
--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -100,13 +100,13 @@ class Emib extends Component {
     this.setState({ quitConditions: updatedQuitConditions });
   };
 
-  allChecked = currentCheckbox => {
+  isChecked = currentCheckbox => {
     return currentCheckbox.checked;
   };
 
   render() {
     const { quitConditions } = this.state;
-    const allChecked = quitConditions.every(this.allChecked);
+    const allChecked = quitConditions.every(this.isChecked);
     const SPECS = getInstructionContent();
 
     const submitButtonState = allChecked ? BUTTON_STATE.enabled : BUTTON_STATE.disabled;

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -100,14 +100,16 @@ class Emib extends Component {
     this.setState({ quitConditions: updatedQuitConditions });
   };
 
+  allChecked = currentCheckbox => {
+    return currentCheckbox.checked;
+  };
+
   render() {
+    const { quitConditions } = this.state;
+    const allChecked = quitConditions.every(this.allChecked);
     const SPECS = getInstructionContent();
-    const submitButtonState =
-      this.state.quitConditions[0].checked &&
-      this.state.quitConditions[1].checked &&
-      this.state.quitConditions[2].checked
-        ? BUTTON_STATE.enabled
-        : BUTTON_STATE.disabled;
+
+    const submitButtonState = allChecked ? BUTTON_STATE.enabled : BUTTON_STATE.disabled;
     return (
       <div className="app">
         <ContentContainer hideBanner={this.state.curPage === PAGES.emibTabs}>


### PR DESCRIPTION
# Description

Simplified the enabled/disabled **Quit Test** button logic in eMIB.jsx component.

## Type of change

- Code cleanliness or refactor

## Screenshot

(N/A)

# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Start the eMIB Sample Test.
2.  Complete the pre-test process.
3.  Click **Quit Test** and make sure everything still working as expected, meaning that the button becomes enabled only when all the checkboxes are checked.

Screenshot of unit tests run passing:

![image](https://user-images.githubusercontent.com/23021242/54432316-37e6fb00-46ff-11e9-8576-65c4a22b3ecf.png)

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 10+, Firefox, and Chrome
