### PR TITLE
[Zoom Functionality] Added zoom functionality on images in Background section

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "react-bootstrap": "^0.32.4",
     "react-dom": "^16.7.0",
     "react-localization": "^1.0.13",
+    "react-medium-image-zoom": "^3.0.15",
     "react-router-dom": "^4.3.1",
     "react-scripts": "2.1.5",
     "react-test-renderer": "^16.7.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "react-dom": "^16.7.0",
     "react-localization": "^1.0.13",
     "react-medium-image-zoom": "^3.0.15",
+    "prop-types": "^15.5.8",
     "react-router-dom": "^4.3.1",
     "react-scripts": "2.1.5",
     "react-test-renderer": "^16.7.0",

--- a/frontend/src/components/eMIB/OrganizationalStructure.jsx
+++ b/frontend/src/components/eMIB/OrganizationalStructure.jsx
@@ -8,6 +8,8 @@ import emib_sample_test_example_org_chart_en from "../../images/emib_sample_test
 //TODO (fnormand): Put a zoomed image of better quality
 import emib_sample_test_example_org_chart_en_zoomed from "../../images/emib_sample_test_example_org_chart_en.png";
 import emib_sample_test_example_org_chart_fr from "../../images/emib_sample_test_example_org_chart_fr.png";
+//TODO (fnormand): Put a zoomed image of better quality
+import emib_sample_test_example_org_chart_fr_zoomed from "../../images/emib_sample_test_example_org_chart_fr.png";
 import ImageZoom from "react-medium-image-zoom";
 
 const styles = {
@@ -97,7 +99,7 @@ class OrganizationalStructure extends Component {
                     style: styles.testImage
                   }}
                   zoomImage={{
-                    src: emib_sample_test_example_org_chart_fr,
+                    src: emib_sample_test_example_org_chart_fr_zoomed,
                     alt: LOCALIZE.emibTest.background.organizationalStructure.orgChart.desciption
                   }}
                 />

--- a/frontend/src/components/eMIB/OrganizationalStructure.jsx
+++ b/frontend/src/components/eMIB/OrganizationalStructure.jsx
@@ -5,7 +5,10 @@ import "../../css/cat-theme.css";
 import { LANGUAGES } from "../commons/Translation";
 import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
 import emib_sample_test_example_org_chart_en from "../../images/emib_sample_test_example_org_chart_en.png";
+//TODO (fnormand): Put a zoomed image of better quality
+import emib_sample_test_example_org_chart_en_zoomed from "../../images/emib_sample_test_example_org_chart_en.png";
 import emib_sample_test_example_org_chart_fr from "../../images/emib_sample_test_example_org_chart_fr.png";
+import ImageZoom from "react-medium-image-zoom";
 
 const styles = {
   testImage: {
@@ -73,19 +76,30 @@ class OrganizationalStructure extends Component {
             <p>
               {LOCALIZE.emibTest.howToPage.testExamples.conditionToDisplayImage ===
                 LANGUAGES.english && (
-                <img
-                  src={emib_sample_test_example_org_chart_en}
-                  alt={LOCALIZE.emibTest.background.organizationalStructure.orgChart.desciption}
-                  style={styles.testImage}
+                <ImageZoom
+                  image={{
+                    src: emib_sample_test_example_org_chart_en,
+                    alt: LOCALIZE.emibTest.background.organizationalStructure.orgChart.desciption,
+                    style: styles.testImage
+                  }}
+                  zoomImage={{
+                    src: emib_sample_test_example_org_chart_en_zoomed,
+                    alt: LOCALIZE.emibTest.background.organizationalStructure.orgChart.desciption
+                  }}
                 />
               )}
               {LOCALIZE.emibTest.howToPage.testExamples.conditionToDisplayImage ===
                 LANGUAGES.french && (
-                <img
-                  src={emib_sample_test_example_org_chart_fr}
-                  alt={LOCALIZE.emibTest.background.organizationalStructure.orgChart.desciption}
-                  style={styles.testImage}
-                  longdesc="#org-image-description"
+                <ImageZoom
+                  image={{
+                    src: emib_sample_test_example_org_chart_fr,
+                    alt: LOCALIZE.emibTest.background.organizationalStructure.orgChart.desciption,
+                    style: styles.testImage
+                  }}
+                  zoomImage={{
+                    src: emib_sample_test_example_org_chart_fr,
+                    alt: LOCALIZE.emibTest.background.organizationalStructure.orgChart.desciption
+                  }}
                 />
               )}
             </p>

--- a/frontend/src/components/eMIB/OrganizationalStructure.jsx
+++ b/frontend/src/components/eMIB/OrganizationalStructure.jsx
@@ -11,6 +11,7 @@ import emib_sample_test_example_org_chart_fr from "../../images/emib_sample_test
 //TODO (fnormand): Put a zoomed image of better quality
 import emib_sample_test_example_org_chart_fr_zoomed from "../../images/emib_sample_test_example_org_chart_fr.png";
 import ImageZoom from "react-medium-image-zoom";
+import "../../css/react-medium-image-zoom.css";
 
 const styles = {
   testImage: {
@@ -82,11 +83,13 @@ class OrganizationalStructure extends Component {
                   image={{
                     src: emib_sample_test_example_org_chart_en,
                     alt: LOCALIZE.emibTest.background.organizationalStructure.orgChart.desciption,
-                    style: styles.testImage
+                    style: styles.testImage,
+                    className: "ie-zoom-cursor"
                   }}
                   zoomImage={{
                     src: emib_sample_test_example_org_chart_en_zoomed,
-                    alt: LOCALIZE.emibTest.background.organizationalStructure.orgChart.desciption
+                    alt: LOCALIZE.emibTest.background.organizationalStructure.orgChart.desciption,
+                    className: "ie-zoom-cursor"
                   }}
                 />
               )}
@@ -96,11 +99,13 @@ class OrganizationalStructure extends Component {
                   image={{
                     src: emib_sample_test_example_org_chart_fr,
                     alt: LOCALIZE.emibTest.background.organizationalStructure.orgChart.desciption,
-                    style: styles.testImage
+                    style: styles.testImage,
+                    className: "ie-zoom-cursor"
                   }}
                   zoomImage={{
                     src: emib_sample_test_example_org_chart_fr_zoomed,
-                    alt: LOCALIZE.emibTest.background.organizationalStructure.orgChart.desciption
+                    alt: LOCALIZE.emibTest.background.organizationalStructure.orgChart.desciption,
+                    className: "ie-zoom-cursor"
                   }}
                 />
               )}

--- a/frontend/src/components/eMIB/TeamInformation.jsx
+++ b/frontend/src/components/eMIB/TeamInformation.jsx
@@ -5,7 +5,12 @@ import "../../css/cat-theme.css";
 import { LANGUAGES } from "../commons/Translation";
 import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
 import emib_sample_test_example_team_chart_en from "../../images/emib_sample_test_example_team_chart_en.png";
+//TODO (fnormand): Put a zoomed image of better quality
+import emib_sample_test_example_team_chart_en_zoomed from "../../images/emib_sample_test_example_team_chart_en.png";
 import emib_sample_test_example_team_chart_fr from "../../images/emib_sample_test_example_team_chart_fr.png";
+//TODO (fnormand): Put a zoomed image of better quality
+import emib_sample_test_example_team_chart_fr_zoomed from "../../images/emib_sample_test_example_team_chart_fr.png";
+import ImageZoom from "react-medium-image-zoom";
 
 const styles = {
   testImage: {
@@ -57,19 +62,32 @@ class TeamInformation extends Component {
             <p>
               {LOCALIZE.emibTest.howToPage.testExamples.conditionToDisplayImage ===
                 LANGUAGES.english && (
-                <img
-                  src={emib_sample_test_example_team_chart_en}
-                  alt={LOCALIZE.emibTest.background.teamInformation.teamChart.desciption}
-                  style={styles.testImage}
+                <ImageZoom
                   longdesc="#team-image-description"
+                  image={{
+                    src: emib_sample_test_example_team_chart_en,
+                    alt: LOCALIZE.emibTest.background.teamInformation.teamChart.desciption,
+                    style: styles.testImage
+                  }}
+                  zoomImage={{
+                    src: emib_sample_test_example_team_chart_en_zoomed,
+                    alt: LOCALIZE.emibTest.background.teamInformation.teamChart.desciption
+                  }}
                 />
               )}
               {LOCALIZE.emibTest.howToPage.testExamples.conditionToDisplayImage ===
                 LANGUAGES.french && (
-                <img
-                  src={emib_sample_test_example_team_chart_fr}
-                  alt={LOCALIZE.emibTest.background.teamInformation.teamChart.desciption}
-                  style={styles.testImage}
+                <ImageZoom
+                  longdesc="#team-image-description"
+                  image={{
+                    src: emib_sample_test_example_team_chart_fr,
+                    alt: LOCALIZE.emibTest.background.teamInformation.teamChart.desciption,
+                    style: styles.testImage
+                  }}
+                  zoomImage={{
+                    src: emib_sample_test_example_team_chart_fr_zoomed,
+                    alt: LOCALIZE.emibTest.background.teamInformation.teamChart.desciption
+                  }}
                 />
               )}
             </p>

--- a/frontend/src/components/eMIB/TeamInformation.jsx
+++ b/frontend/src/components/eMIB/TeamInformation.jsx
@@ -11,6 +11,7 @@ import emib_sample_test_example_team_chart_fr from "../../images/emib_sample_tes
 //TODO (fnormand): Put a zoomed image of better quality
 import emib_sample_test_example_team_chart_fr_zoomed from "../../images/emib_sample_test_example_team_chart_fr.png";
 import ImageZoom from "react-medium-image-zoom";
+import "../../css/react-medium-image-zoom.css";
 
 const styles = {
   testImage: {
@@ -67,11 +68,13 @@ class TeamInformation extends Component {
                   image={{
                     src: emib_sample_test_example_team_chart_en,
                     alt: LOCALIZE.emibTest.background.teamInformation.teamChart.desciption,
-                    style: styles.testImage
+                    style: styles.testImage,
+                    className: "ie-zoom-cursor"
                   }}
                   zoomImage={{
                     src: emib_sample_test_example_team_chart_en_zoomed,
-                    alt: LOCALIZE.emibTest.background.teamInformation.teamChart.desciption
+                    alt: LOCALIZE.emibTest.background.teamInformation.teamChart.desciption,
+                    className: "ie-zoom-cursor"
                   }}
                 />
               )}
@@ -82,11 +85,13 @@ class TeamInformation extends Component {
                   image={{
                     src: emib_sample_test_example_team_chart_fr,
                     alt: LOCALIZE.emibTest.background.teamInformation.teamChart.desciption,
-                    style: styles.testImage
+                    style: styles.testImage,
+                    className: "ie-zoom-cursor"
                   }}
                   zoomImage={{
                     src: emib_sample_test_example_team_chart_fr_zoomed,
-                    alt: LOCALIZE.emibTest.background.teamInformation.teamChart.desciption
+                    alt: LOCALIZE.emibTest.background.teamInformation.teamChart.desciption,
+                    className: "ie-zoom-cursor"
                   }}
                 />
               )}

--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -7,6 +7,11 @@ All component specific CSS lives in the React file with the component.
   text-align: center;
 }
 
+/* App header overridden class */
+.fixed-top {
+  z-index: 998;
+}
+
 /* Headers */
 
 /* h1: add green line underneath */

--- a/frontend/src/css/react-medium-image-zoom.css
+++ b/frontend/src/css/react-medium-image-zoom.css
@@ -1,0 +1,8 @@
+/*
+react-medium-image-zoom.css is used to override the style of react-medium-image-zoom library
+*/
+
+/* for IE */
+.ie-zoom-cursor {
+  cursor: pointer;
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7974,7 +7974,7 @@ prop-types-extra@^1.0.1:
     react-is "^16.3.2"
     warning "^3.0.0"
 
-prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8242,6 +8242,11 @@ react-localization@^1.0.13:
     localized-strings "^0.2.00"
     react "^16.0.0"
 
+react-medium-image-zoom@^3.0.15:
+  version "3.0.15"
+  resolved "https://registry.yarnpkg.com/react-medium-image-zoom/-/react-medium-image-zoom-3.0.15.tgz#c566c08225cff9c7c6454fe66b570609ffa2991d"
+  integrity sha512-OJc6XXmSFr0ApniFdCL1TliP6BG9eQabkcahWA9CbHha3y2IJXo1aAsQs7Irc2Wcek/N9QCeAY4wTitoMg5iLg==
+
 react-overlays@^0.8.0:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.8.3.tgz#fad65eea5b24301cca192a169f5dddb0b20d3ac5"


### PR DESCRIPTION
# Description

I added a zoom functionality on both images in **Background Information** section. You have to **click** on the image in order to zoom it.

Details to consider for this PR:
- We need zoomed images of better quality, because they are blurred
- IE zoom-in / zoom-out cursor styles are not compatible with IE, so I put the _pointer_ cursor style for IE

## Type of change

- New feature (non-breaking change which adds functionality)
- Dependency change

## Screenshot

**First Image - Zoomed:**

![image](https://user-images.githubusercontent.com/23021242/54532058-3dda1780-495d-11e9-97e7-1a163c813b38.png)

**Second Image - Zoomed:**

![image](https://user-images.githubusercontent.com/23021242/54532102-54806e80-495d-11e9-8492-550eec13deb8.png)

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB Sample Test.
2.  Complete the _pre-test information_ section.
3.  Go in _Background_ section and zoom-in / zoom-out both images in all browsers and make sure everything works well, including the navigation with the keyboard.

Screenshot of unit tests run passing:

![image](https://user-images.githubusercontent.com/23021242/54532536-5860c080-495e-11e9-8ede-5dd7e5181c8c.png)

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
