### PR TITLE
[CI Tools] Adding Travis CI Tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+#Travis Config File
+
+services:
+  - docker
+
+language: node_js
+
+matrix:
+  include:
+    #Backend Tests
+    - language: python
+      python: 3.6
+      provider: script
+      script:
+        - docker-compose run --rm backend ./manage.py test backend/tests/
+
+    #Frontend Tests
+    - language: node_js
+      node_js: 10.15
+      provider: script
+      before_script:
+        - docker-compose up -d --build
+        - npm install frontend/
+      script:
+        - docker-compose run --rm frontend npm test src/tests/ -- --coverage

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -25,8 +25,6 @@ Manual steps to reproduce this functionality:
 1.  Go to \_\_\_ page.
 2.  Click \_\_\_. Notice \_\_\_.
 
-Screenshot of unit tests run passing:
-
 # Checklist
 
 Applicable for all code changes.
@@ -36,6 +34,5 @@ Applicable for all code changes.
 - [ ] My changes generate no new compiler warnings
 - [ ] My changes generate no new accessibility errors and/or warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
 - [ ] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
 - [ ] My changes look good on IE 10+, Firefox, and Chrome

--- a/frontend/src/tests/components/commons/TestFooter.test.js
+++ b/frontend/src/tests/components/commons/TestFooter.test.js
@@ -6,7 +6,7 @@ it("calls submit test and quit test when the buttons are clicked", () => {
   const submitMock1 = jest.fn();
   const submitMock2 = jest.fn();
   const wrapper = shallow(<TestFooter submitTest={submitMock1} quitTest={submitMock2} />);
-  wrapper.find("#unit-test-submit-btns").simulate("click");
+  wrapper.find("#unit-test-submit-btn").simulate("click");
   wrapper.find("#unit-test-quit-btn").simulate("click");
   expect(submitMock1).toHaveBeenCalledTimes(1);
   expect(submitMock2).toHaveBeenCalledTimes(1);

--- a/frontend/src/tests/components/commons/TestFooter.test.js
+++ b/frontend/src/tests/components/commons/TestFooter.test.js
@@ -6,7 +6,7 @@ it("calls submit test and quit test when the buttons are clicked", () => {
   const submitMock1 = jest.fn();
   const submitMock2 = jest.fn();
   const wrapper = shallow(<TestFooter submitTest={submitMock1} quitTest={submitMock2} />);
-  wrapper.find("#unit-test-submit-btn").simulate("click");
+  wrapper.find("#unit-test-submit-btns").simulate("click");
   wrapper.find("#unit-test-quit-btn").simulate("click");
   expect(submitMock1).toHaveBeenCalledTimes(1);
   expect(submitMock2).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
# Description

Added Travis in order to automate the front end/back end tests. To do that, we simply added Travis to this GutHub repository and added a config file called _.travis.yml_.

I also updated the PR Template, since we don't need the test screenshot and all tests passed checkbox.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**When all tests are passing:**

![image](https://user-images.githubusercontent.com/23021242/54619562-2cffd380-4a3b-11e9-9dae-ee9e07966e37.png)

**If some tests are failing (done by pushing commit #https://github.com/code-for-canada/project-thundercat/pull/139/commits/12ea70908c6add1059ab9685af34df27ae91ebff):**

![image](https://user-images.githubusercontent.com/23021242/54620532-b49a1200-4a3c-11e9-8f23-521dd5dc2757.png)

**Failing tests from Travis console:**

![image](https://user-images.githubusercontent.com/23021242/54620663-e4491a00-4a3c-11e9-8ea2-9e268f6d97c7.png)

# Testing

Manual steps to reproduce this functionality:

- You can only test that by opening a new PR OR add a commit to an existing one.

Screenshot of unit tests run passing:

**Screenshot from Travis console (frontend):**

![image](https://user-images.githubusercontent.com/23021242/54619729-73edc900-4a3b-11e9-91df-dee9d0915331.png)

**Screenshot from Travis console (backend):**

![image](https://user-images.githubusercontent.com/23021242/54619775-8831c600-4a3b-11e9-9bf0-76fac515566f.png)

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~My changes generate no new compiler warnings~~
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [ ] ~~My changes look good on IE 10+, Firefox, and Chrome~~
