### PR TITLE
[Instructions] Adding Instructions Text

### DIFF
--- a/frontend/src/components/eMIB/Overview.jsx
+++ b/frontend/src/components/eMIB/Overview.jsx
@@ -13,6 +13,14 @@ class Overview extends Component {
             <p>{LOCALIZE.emibTest.howToPage.overview.description}</p>
           </div>
           <div>
+            <p>{LOCALIZE.emibTest.howToPage.overview.noteSection.para1}</p>
+            <ul>
+              <li>{LOCALIZE.emibTest.howToPage.overview.noteSection.bullet1}</li>
+              <li>{LOCALIZE.emibTest.howToPage.overview.noteSection.bullet2}</li>
+              <li>{LOCALIZE.emibTest.howToPage.overview.noteSection.bullet3}</li>
+            </ul>
+          </div>
+          <div>
             <h3>{LOCALIZE.emibTest.howToPage.overview.aboutSection.title}</h3>
             <p>{LOCALIZE.emibTest.howToPage.overview.aboutSection.para1}</p>
             <ul>

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -62,6 +62,13 @@ let LOCALIZE = new LocalizedStrings({
           title: "Overview",
           description:
             'The electronic managerial Inbox (e-MIB) simulates an email inbox in which you will respond to a series of emails depicting situations typically encountered by managers in the federal public service. These situations will provide you with the opportunity to demonstrate the Key Leadership Competencies, outlined in "Evaluation".',
+          noteSection: {
+            para1: "While completing the e-MIB, you will have access to:",
+            bullet1: "The test instructions (the current document).",
+            bullet2:
+              "The background information describing your job as the manager and the fictitious organization where you work.",
+            bullet3: "A Notepad to serve as scrap paper. The Notepad will not be evaluated."
+          },
           aboutSection: {
             title: "About the sample test",
             para1:
@@ -419,6 +426,14 @@ let LOCALIZE = new LocalizedStrings({
           title: "Aperçu général",
           description:
             "La boîte de réception pour la gestion électronique (BRG-e) simule d’une boîte de courriel dans laquelle vous allez répondre à des courriels décrivant des situations qui sont typiquement vécues par les gestionnaires de la fonction publique. Ces situations vous donneront l’occasion de démontrer les compétences clés en leadership, décrit dans «Évaluation».",
+          noteSection: {
+            para1: "En complétant la BRG-e, vous aurez accès :",
+            bullet1: "Aux directives du test (le présent document).",
+            bullet2:
+              "À de l’information contextuelle décrivant votre rôle en tant que gestionnaire et l’organisation fictive où vous travaillez.",
+            bullet3:
+              "À un bloc-notes pouvant servir de papier brouillon. Le contenu du bloc-notes ne sera pas évalué."
+          },
           aboutSection: {
             title: "À propos de l’échantillon de test",
             para1:


### PR DESCRIPTION
# Description

Adding text to instructions Overview, noting that instructions will still be available in the test
(let me know if this should be in a different part of the Overview page)

## Type of change

- Code cleanliness or refactor

## Screenshot

![image](https://user-images.githubusercontent.com/2746350/54703263-cb109e00-4b0e-11e9-9490-e78bef3efd47.png)

![image](https://user-images.githubusercontent.com/2746350/54703281-db287d80-4b0e-11e9-9a88-38eb53942efb.png)

# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Protype -> Start eMIB
2.  Look at the Overview page
3.  This will also change the in-test instructions

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
