### PR TITLE
Refactor / bug fix: instructions side bar localization bug

### DIFF
--- a/frontend/src/components/eMIB/EmibTabs.jsx
+++ b/frontend/src/components/eMIB/EmibTabs.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
 import Background from "./Background";
 import Inbox from "./Inbox";
-import SideNavigation from "../commons/SideNavigation";
 import LOCALIZE from "../../text_resources";
 import TabNavigation from "../commons/TabNavigation";
 import InTestInstructions from "./InTestInstructions";

--- a/frontend/src/components/eMIB/EmibTabs.jsx
+++ b/frontend/src/components/eMIB/EmibTabs.jsx
@@ -4,24 +4,17 @@ import Inbox from "./Inbox";
 import SideNavigation from "../commons/SideNavigation";
 import LOCALIZE from "../../text_resources";
 import TabNavigation from "../commons/TabNavigation";
-import { getInstructionContent } from "./Emib";
+import InTestInstructions from "./InTestInstructions";
 import Notepad from "../commons/Notepad";
 import "../../css/emib-tabs.css";
 
 class EmibTabs extends Component {
   render() {
-    const SPECS = getInstructionContent();
     const TABS = [
       {
         id: 0,
         tabName: LOCALIZE.emibTest.tabs.instructionsTabTitle,
-        body: (
-          <SideNavigation
-            navSpecs={SPECS}
-            currentNode={0}
-            menuName={LOCALIZE.ariaLabel.instructionsMenu}
-          />
-        )
+        body: <InTestInstructions />
       },
       {
         id: 1,

--- a/frontend/src/components/eMIB/InTestInstructions.jsx
+++ b/frontend/src/components/eMIB/InTestInstructions.jsx
@@ -1,0 +1,19 @@
+import React, { Component } from "react";
+import LOCALIZE from "../../text_resources";
+import SideNavigation from "../commons/SideNavigation";
+import { getInstructionContent } from "./Emib";
+
+class InTestInstructions extends Component {
+  render() {
+    const SPECS = getInstructionContent();
+    return (
+      <SideNavigation
+        navSpecs={SPECS}
+        currentNode={0}
+        menuName={LOCALIZE.ariaLabel.instructionsMenu}
+      />
+    );
+  }
+}
+
+export default InTestInstructions;


### PR DESCRIPTION
# Description

This fixes the translation bug for the side navigation of the in test instructions.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Code cleanliness or refactor

## Screenshot
<img width="1016" alt="Screen Shot 2019-03-20 at 5 53 01 PM" src="https://user-images.githubusercontent.com/4640747/54721707-0c1da800-4b39-11e9-9df0-a1d9b1a2183b.png">


# Testing

Manual steps to reproduce this functionality:

1.  Go to the emib sample test on the instructions tab.
2. Toggle the language and notice the language updates on the side navigation.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 10+, Firefox, and Chrome
