### PR TITLE
eMIB in test - screens between 900 and 1400px

### DIFF
--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -7,7 +7,8 @@ import "../../css/emib-tabs.css";
 const styles = {
   windowPadding: {
     paddingTop: 43,
-    paddingLeft: 20
+    paddingLeft: 20,
+    order: 2
   },
   h4: {
     color: "white"

--- a/frontend/src/components/commons/TabNavigation.jsx
+++ b/frontend/src/components/commons/TabNavigation.jsx
@@ -3,6 +3,10 @@ import PropTypes from "prop-types";
 import Tab from "./Tab";
 
 const styles = {
+  tabContainer: {
+    order: 1,
+    textAlign: "left"
+  },
   bootstrapNav: {
     paddingLeft: "0",
     marginBottom: "0",
@@ -13,7 +17,6 @@ const styles = {
     //this replaces the .bootstrap-tabs > .nav:after
     content: "",
     backgroundColor: "white",
-    width: 900,
     border: "1px solid #00565e",
     borderBottomColor: "transparent"
   },
@@ -27,8 +30,7 @@ const styles = {
     borderStyle: "solid",
     borderColor: "#00565e",
     borderTopColor: "white",
-    height: "calc(100vh - 241px)",
-    width: 900
+    height: "calc(100vh - 241px)"
   }
 };
 
@@ -50,7 +52,7 @@ class TabNavigation extends Component {
 
   render() {
     return (
-      <div>
+      <div style={styles.tabContainer}>
         <nav aria-label={this.props.menuName} role="dialog">
           <ul role="menubar" className="nav nav-tabs" style={styles.bootstrapNav}>
             {this.props.tabSpecs.map((tab, key) => (

--- a/frontend/src/components/commons/TabNavigation.jsx
+++ b/frontend/src/components/commons/TabNavigation.jsx
@@ -5,7 +5,8 @@ import Tab from "./Tab";
 const styles = {
   tabContainer: {
     order: 1,
-    textAlign: "left"
+    textAlign: "left",
+    width: "100%"
   },
   bootstrapNav: {
     paddingLeft: "0",

--- a/frontend/src/components/commons/TestFooter.jsx
+++ b/frontend/src/components/commons/TestFooter.jsx
@@ -7,7 +7,8 @@ const styles = {
     display: "block",
     marginLeft: "auto",
     marginRight: "auto",
-    width: 1140,
+    maxWidth: 1400,
+    minWidth: 900,
     height: 72
   },
   hr: {

--- a/frontend/src/components/commons/TestFooter.jsx
+++ b/frontend/src/components/commons/TestFooter.jsx
@@ -9,7 +9,9 @@ const styles = {
     marginRight: "auto",
     maxWidth: 1400,
     minWidth: 900,
-    height: 72
+    height: 72,
+    paddingRight: 20,
+    paddingLeft: 20
   },
   hr: {
     width: "100%",

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -113,26 +113,28 @@ class Emib extends Component {
     return (
       <div className="app">
         <div>{this.state.curPage === PAGES.emibTabs && <EmibTabs />}</div>
-        <ContentContainer hideBanner={this.state.curPage === PAGES.emibTabs}>
-          {this.state.curPage === PAGES.preTest && (
-            <ProgressPane
-              progressSpecs={SPECS}
-              currentNode={0}
-              paneTitle={LOCALIZE.emibTest.homePage.testTitle}
-              exitButton={
-                <button
-                  type="button"
-                  className="btn btn-primary btn-wide"
-                  onClick={this.changePage}
-                >
-                  {LOCALIZE.commons.startTest}
-                </button>
-              }
-            />
-          )}
+        {this.state.curPage !== PAGES.emibTabs && (
+          <ContentContainer hideBanner={this.state.curPage === PAGES.emibTabs}>
+            {this.state.curPage === PAGES.preTest && (
+              <ProgressPane
+                progressSpecs={SPECS}
+                currentNode={0}
+                paneTitle={LOCALIZE.emibTest.homePage.testTitle}
+                exitButton={
+                  <button
+                    type="button"
+                    className="btn btn-primary btn-wide"
+                    onClick={this.changePage}
+                  >
+                    {LOCALIZE.commons.startTest}
+                  </button>
+                }
+              />
+            )}
 
-          {this.state.curPage === PAGES.confirm && <Confirmation />}
-        </ContentContainer>
+            {this.state.curPage === PAGES.confirm && <Confirmation />}
+          </ContentContainer>
+        )}
         {this.state.curPage === PAGES.emibTabs && (
           <TestFooter submitTest={this.openSubmitPopup} quitTest={this.openQuitPopup} />
         )}

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -112,6 +112,7 @@ class Emib extends Component {
     const submitButtonState = allChecked ? BUTTON_STATE.enabled : BUTTON_STATE.disabled;
     return (
       <div className="app">
+        <div>{this.state.curPage === PAGES.emibTabs && <EmibTabs />}</div>
         <ContentContainer hideBanner={this.state.curPage === PAGES.emibTabs}>
           {this.state.curPage === PAGES.preTest && (
             <ProgressPane
@@ -129,7 +130,7 @@ class Emib extends Component {
               }
             />
           )}
-          {this.state.curPage === PAGES.emibTabs && <EmibTabs />}
+
           {this.state.curPage === PAGES.confirm && <Confirmation />}
         </ContentContainer>
         {this.state.curPage === PAGES.emibTabs && (

--- a/frontend/src/components/eMIB/EmibTabs.jsx
+++ b/frontend/src/components/eMIB/EmibTabs.jsx
@@ -6,7 +6,6 @@ import TabNavigation from "../commons/TabNavigation";
 import InTestInstructions from "./InTestInstructions";
 import Notepad from "../commons/Notepad";
 import "../../css/emib-tabs.css";
-import { styles } from "../commons/Tab";
 
 const customStyles = {
   container: {
@@ -14,7 +13,9 @@ const customStyles = {
     minWidth: 900,
     margin: "0px auto",
     paddingTop: 20,
-    display: "flex"
+    display: "flex",
+    paddingRight: 20,
+    paddingLeft: 20
   }
 };
 

--- a/frontend/src/components/eMIB/EmibTabs.jsx
+++ b/frontend/src/components/eMIB/EmibTabs.jsx
@@ -6,6 +6,17 @@ import TabNavigation from "../commons/TabNavigation";
 import InTestInstructions from "./InTestInstructions";
 import Notepad from "../commons/Notepad";
 import "../../css/emib-tabs.css";
+import { styles } from "../commons/Tab";
+
+const customStyles = {
+  container: {
+    maxWidth: 1400,
+    minWidth: 900,
+    margin: "0px auto",
+    paddingTop: 20,
+    display: "flex"
+  }
+};
 
 class EmibTabs extends Component {
   render() {
@@ -27,13 +38,9 @@ class EmibTabs extends Component {
       }
     ];
     return (
-      <div className="emib-tabs-grid">
-        <div className="test-tabs-cell">
-          <TabNavigation tabSpecs={TABS} currentTab={1} menuName={LOCALIZE.ariaLabel.tabMenu} />
-        </div>
-        <div className="notepad-cell">
-          <Notepad />
-        </div>
+      <div style={customStyles.container}>
+        <TabNavigation tabSpecs={TABS} currentTab={1} menuName={LOCALIZE.ariaLabel.tabMenu} />
+        <Notepad />
       </div>
     );
   }

--- a/frontend/src/components/eMIB/OrganizationalStructure.jsx
+++ b/frontend/src/components/eMIB/OrganizationalStructure.jsx
@@ -5,16 +5,15 @@ import "../../css/cat-theme.css";
 import { LANGUAGES } from "../commons/Translation";
 import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
 import emib_sample_test_example_org_chart_en from "../../images/emib_sample_test_example_org_chart_en.png";
-//TODO (fnormand): Put a zoomed image of better quality
 import emib_sample_test_example_org_chart_en_zoomed from "../../images/emib_sample_test_example_org_chart_en.png";
 import emib_sample_test_example_org_chart_fr from "../../images/emib_sample_test_example_org_chart_fr.png";
-//TODO (fnormand): Put a zoomed image of better quality
 import emib_sample_test_example_org_chart_fr_zoomed from "../../images/emib_sample_test_example_org_chart_fr.png";
 import ImageZoom from "react-medium-image-zoom";
 import "../../css/react-medium-image-zoom.css";
 
 const styles = {
   testImage: {
+    width: "100%",
     maxWidth: 600
   },
   button: {

--- a/frontend/src/components/eMIB/TeamInformation.jsx
+++ b/frontend/src/components/eMIB/TeamInformation.jsx
@@ -5,16 +5,15 @@ import "../../css/cat-theme.css";
 import { LANGUAGES } from "../commons/Translation";
 import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
 import emib_sample_test_example_team_chart_en from "../../images/emib_sample_test_example_team_chart_en.png";
-//TODO (fnormand): Put a zoomed image of better quality
 import emib_sample_test_example_team_chart_en_zoomed from "../../images/emib_sample_test_example_team_chart_en.png";
 import emib_sample_test_example_team_chart_fr from "../../images/emib_sample_test_example_team_chart_fr.png";
-//TODO (fnormand): Put a zoomed image of better quality
 import emib_sample_test_example_team_chart_fr_zoomed from "../../images/emib_sample_test_example_team_chart_fr.png";
 import ImageZoom from "react-medium-image-zoom";
 import "../../css/react-medium-image-zoom.css";
 
 const styles = {
   testImage: {
+    width: "100%",
     maxWidth: 600
   },
   button: {


### PR DESCRIPTION
# Description

Now, when you are within the test, you can use a screen anywhere between 900-1400. You'll get more room for content if you have a larger screen.

Paired with: @fnormand01 

## Type of change
- New feature (non-breaking change which adds functionality)

## Screenshot

![image](https://user-images.githubusercontent.com/4640747/54758452-92ca9780-4bc2-11e9-8544-ddc4f2abcc2d.png)

![image](https://user-images.githubusercontent.com/4640747/54758496-a70e9480-4bc2-11e9-9b09-7cc43611fbcf.png)



# Testing

Manual steps to reproduce this functionality:

1.  Go to eMIB test.
2.  Resize the screen.
3.  Repeat in IE.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
