### PR TITLE
[Design Session] Updated popup box styles to match the design

### DIFF
--- a/frontend/src/components/commons/PopupBox.jsx
+++ b/frontend/src/components/commons/PopupBox.jsx
@@ -29,7 +29,8 @@ const styles = {
     width: "100%"
   },
   modelTitle: {
-    position: "absolute"
+    position: "absolute",
+    fontSize: "28px"
   },
   buttonsZone: {
     width: "100%",

--- a/frontend/src/components/commons/SystemMessage.jsx
+++ b/frontend/src/components/commons/SystemMessage.jsx
@@ -11,7 +11,7 @@ export let CLASS_NAME = {
   icon: ""
 };
 
-const styles = {
+export const styles = {
   boxPadding: {
     paddingTop: 18
   },

--- a/frontend/src/components/commons/SystemMessage.jsx
+++ b/frontend/src/components/commons/SystemMessage.jsx
@@ -12,6 +12,9 @@ export let CLASS_NAME = {
 };
 
 const styles = {
+  boxPadding: {
+    paddingTop: 18
+  },
   logoZone: {
     minWidth: 75
   },
@@ -20,7 +23,12 @@ const styles = {
   },
   textBox: {
     textAlign: "left",
-    paddingLeft: 25
+    paddingLeft: 24,
+    paddingRight: 24
+  },
+  h5: {
+    fontWeight: "bold",
+    paddingTop: 12
   }
 };
 
@@ -42,13 +50,13 @@ class SystemMessage extends Component {
     }
 
     return (
-      <div>
+      <div style={styles.boxPadding}>
         <div className={CLASS_NAME.alert} role="alert">
           <div className="icon" aria-hidden="true" style={styles.logoZone}>
             <i className={CLASS_NAME.icon} style={styles.logo} />
           </div>
           <div style={styles.textBox}>
-            <h3>{title}</h3>
+            <h5 style={styles.h5}>{title}</h5>
             <p>{message}</p>
           </div>
         </div>

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -23,7 +23,10 @@ const styles = {
   hr: {
     width: "100%",
     borderTop: "2px solid #96a8b2",
-    margin: "12px 0 0 0"
+    margin: "16px 0 16px 0"
+  },
+  checkboxZone: {
+    paddingTop: 8
   }
 };
 
@@ -178,7 +181,11 @@ class Emib extends Component {
               <div>
                 {this.state.quitConditions.map((condition, id) => {
                   return (
-                    <div key={id} className="custom-control custom-checkbox">
+                    <div
+                      key={id}
+                      className="custom-control custom-checkbox"
+                      style={styles.checkboxZone}
+                    >
                       <input
                         type="checkbox"
                         className="custom-control-input"

--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -191,6 +191,6 @@ Progess Steps
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%) !important;
-  min-width: 500px;
-  max-width: 1000px;
+  min-width: 500px !important;
+  max-width: 750px !important;
 }

--- a/frontend/src/tests/components/commons/SystemMessage.test.js
+++ b/frontend/src/tests/components/commons/SystemMessage.test.js
@@ -1,6 +1,10 @@
 import React from "react";
 import { mount } from "enzyme";
-import SystemMessage, { MESSAGE_TYPE, CLASS_NAME } from "../../../components/commons/SystemMessage";
+import SystemMessage, {
+  MESSAGE_TYPE,
+  CLASS_NAME,
+  styles
+} from "../../../components/commons/SystemMessage";
 
 it("renders warning message", () => {
   const wrapper = mount(
@@ -8,7 +12,7 @@ it("renders warning message", () => {
   );
   const warningAlertClassName = "alert-icon alert-warning";
   const warningIconClassName = "fas fa-exclamation-circle";
-  const title = <h3>title</h3>;
+  const title = <h5 style={styles.h5}>title</h5>;
   const message = <p>message</p>;
   expect(warningAlertClassName === CLASS_NAME.alert).toEqual(true);
   expect(warningIconClassName === CLASS_NAME.icon).toEqual(true);
@@ -22,7 +26,7 @@ it("renders default message (warning)", () => {
   );
   const warningAlertClassName = "alert-icon alert-warning";
   const warningIconClassName = "fas fa-exclamation-circle";
-  const title = <h3>title</h3>;
+  const title = <h5 style={styles.h5}>title</h5>;
   const message = <p>message</p>;
   expect(warningAlertClassName === CLASS_NAME.alert).toEqual(true);
   expect(warningIconClassName === CLASS_NAME.icon).toEqual(true);
@@ -36,7 +40,7 @@ it("renders error message", () => {
   );
   const errorAlertClassName = "alert-icon alert-danger";
   const errorIconClassName = "far fa-times-circle";
-  const title = <h3>title</h3>;
+  const title = <h5 style={styles.h5}>title</h5>;
   const message = <p>message</p>;
   expect(errorAlertClassName === CLASS_NAME.alert).toEqual(true);
   expect(errorIconClassName === CLASS_NAME.icon).toEqual(true);


### PR DESCRIPTION
# Description

I updated the popup box styles to match the design. I met with the UX Designer to do these changes.

## Type of change

- Code cleanliness or refactor

## Screenshot

**Submit Test Popup Box:**

![image](https://user-images.githubusercontent.com/23021242/54762282-2eabd180-4bca-11e9-8eef-1c19db7cd3a8.png)

**Quit Test Popup Box:**

![image](https://user-images.githubusercontent.com/23021242/54762314-41bea180-4bca-11e9-8b13-788a57a19d9e.png)

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB Sample Test.
2.  Complete the pre-test process.
3.  Click on _Submit test_ and _Quit test_ buttons and make sure these popup boxes look good and do what they are suppose to do.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
