### PR TITLE
[Notepad] Added Hide/Open Notepad Functionality

### DIFF
--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
 import TextareaAutosize from "react-textarea-autosize";
 import "../../css/emib-tabs.css";
@@ -79,10 +78,6 @@ const styles = {
 };
 
 class Notepad extends Component {
-  static propTypes = {
-    notepadContent: PropTypes.string
-  };
-
   state = {
     notepadHidden: false,
     notepadContent: ""

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -112,7 +112,7 @@ class Notepad extends Component {
               </button>
             </div>
             <div>
-              <h4 style={styles.h4}>{LOCALIZE.commons.notepad.title}</h4>
+              <h4 style={styles.h4}>{LOCALIZE.commons.notepad.title.toUpperCase()}</h4>
             </div>
             <div style={styles.notepadSection}>
               <form>

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -85,19 +85,14 @@ class Notepad extends Component {
 
   handleHide = () => {
     this.setState({ notepadHidden: true });
-    //Get current notepad content
-    let x = document.getElementById("notepad-content");
-    let txt = "";
-    for (let i = 1; i < x.length; i++) {
-      txt = txt + x.elements[i].value;
-    }
-    x.innerHTML = txt;
-    //Update NOTEPAD_CONTENT
-    this.setState({ notepadContent: txt });
   };
 
   handleOpen = () => {
     this.setState({ notepadHidden: false });
+  };
+
+  handleNotepadContent = event => {
+    this.setState({ notepadContent: event.target.value });
   };
 
   render() {
@@ -120,7 +115,7 @@ class Notepad extends Component {
               <h4 style={styles.h4}>{LOCALIZE.commons.notepad.title}</h4>
             </div>
             <div style={styles.notepadSection}>
-              <form id="notepad-content">
+              <form>
                 <fieldset>
                   <label htmlFor="text-area-zone" className="invisible position-absolute">
                     {LOCALIZE.commons.notepad.title}
@@ -131,9 +126,10 @@ class Notepad extends Component {
                     className="text-area"
                     style={styles.textArea}
                     cols="45"
-                    minRows={5}
+                    minRows={16}
                     placeholder={LOCALIZE.commons.notepad.placeholder}
-                    defaultValue={this.state.notepadContent}
+                    value={this.state.notepadContent}
+                    onChange={this.handleNotepadContent}
                   />
                 </fieldset>
               </form>

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -6,71 +6,43 @@ import "../../css/emib-tabs.css";
 
 const styles = {
   windowPadding: {
-    paddingTop: 43,
-    paddingLeft: 20,
+    paddingTop: 43.5,
     order: 2
   },
   h4: {
-    color: "white"
+    textAlign: "left",
+    fontSize: "16px",
+    fontWeight: "bold",
+    color: "#00565e",
+    padding: "0 0 8px 12px",
+    borderBottom: "1px solid green"
   },
   title: {
-    paddingLeft: 12,
     paddingTop: 0.1,
-    height: 55,
-    backgroundColor: "#00565e",
-    borderRadius: "5px 5px 0 0"
+    borderRadius: "0 5px 0 0"
   },
   content: {
     backgroundColor: "white",
     borderWidth: "1px 1px 0 1px",
     borderStyle: "solid",
     borderColor: "#00565e",
-    borderRadius: "5px 5px 0 0",
-    width: 220,
-    height: "calc(100vh - 237px)"
+    borderRadius: "0 5px 0 0",
+    width: "100%",
+    height: "calc(100vh - 238px)"
   },
   notepadSection: {
     overflow: "auto",
-    height: "calc(100vh - 297px)"
+    height: "calc(100vh - 291px)"
   },
   textArea: {
+    padding: "0 6px 6px 6px",
+    width: "100%",
     resize: "none",
     border: "none"
-  },
-  center: {
-    textAlign: "center"
   }
 };
 
 class Notepad extends Component {
-  state = {
-    columnWidth: 0
-  };
-
-  /*
-  Adjust the notepad text zone width depending on the browser
-  Each browser has its own interpretation of the notepad text zone width
-  */
-  detectBrowser = () => {
-    switch (BROWSER_STRING) {
-      case IE_STRING:
-        this.setState({ columnWidth: 20 });
-        break;
-      case VALID_BROWSERS[0]:
-        this.setState({ columnWidth: 22 });
-        break;
-      case VALID_BROWSERS[1]:
-        this.setState({ columnWidth: 18 });
-        break;
-      default:
-        this.setState({ columnWidth: 18 });
-    }
-  };
-
-  componentDidMount() {
-    this.detectBrowser();
-  }
-
   render() {
     return (
       <div style={styles.windowPadding}>
@@ -80,7 +52,7 @@ class Notepad extends Component {
           </div>
           <div style={styles.notepadSection}>
             <form>
-              <fieldset style={styles.center}>
+              <fieldset>
                 <label htmlFor="text-area-zone" className="invisible position-absolute">
                   {LOCALIZE.commons.notepad.title}
                 </label>
@@ -89,7 +61,7 @@ class Notepad extends Component {
                   maxLength="3000"
                   className="text-area"
                   style={styles.textArea}
-                  cols={this.state.columnWidth}
+                  cols="45"
                   minRows={5}
                   placeholder={LOCALIZE.commons.notepad.placeholder}
                 />

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -19,9 +19,15 @@ const styles = {
   hideNotepadBtn: {
     float: "right",
     margin: "8px 12px 0 0",
-    padding: 0,
+    padding: "0 6px 0 26px",
     backgroundColor: "transparent",
-    border: "none"
+    border: "none",
+    cursor: "pointer"
+  },
+  hideNotepadBtnIcon: {
+    position: "absolute",
+    padding: "12px 0 0 82px",
+    cursor: "pointer"
   },
   content: {
     backgroundColor: "white",
@@ -47,13 +53,22 @@ const styles = {
     paddingTop: 40,
     width: 60,
     fontSize: "13px",
-    color: "white"
+    color: "white",
+    cursor: "pointer"
   },
   openNotepadBtn: {
     width: 60,
     border: "none",
     backgroundColor: "#00565e",
-    height: "calc(100vh - 238px)"
+    height: "calc(100vh - 238px)",
+    cursor: "pointer",
+    borderRadius: "0 5px 0 0"
+  },
+  openNotepadBtnIcon: {
+    position: "absolute",
+    padding: "16px 0 0 22px",
+    cursor: "pointer",
+    color: "white"
   },
   openNotepadBtnHeight: {
     height: "calc(100vh - 238px)"
@@ -79,6 +94,11 @@ class Notepad extends Component {
       <div style={styles.windowPadding}>
         {!notepadHidden && (
           <div style={styles.content}>
+            <span
+              onClick={this.handleHide}
+              style={styles.hideNotepadBtnIcon}
+              className="fas fa-minus-circle"
+            />
             <button onClick={this.handleHide} style={styles.hideNotepadBtn}>
               {LOCALIZE.commons.notepad.hideButton}
             </button>
@@ -107,10 +127,19 @@ class Notepad extends Component {
         )}
         {notepadHidden && (
           <div style={styles.openNotepadBtnHeight}>
+            <span
+              onClick={this.handleOpen}
+              style={styles.openNotepadBtnIcon}
+              className="fas fa-external-link-alt"
+            />
             <label onClick={this.handleOpen} style={styles.openNotepadBtnLabel}>
               {LOCALIZE.commons.notepad.openButton}
             </label>
-            <button onClick={this.handleOpen} style={styles.openNotepadBtn} />
+            <button
+              className="btn btn-primary"
+              onClick={this.handleOpen}
+              style={styles.openNotepadBtn}
+            />
           </div>
         )}
       </div>

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -144,7 +144,7 @@ class Notepad extends Component {
               className="fas fa-external-link-alt"
             />
             <label onClick={this.handleOpen} style={styles.openNotepadBtnLabel}>
-              {LOCALIZE.commons.notepad.openButton}
+              {LOCALIZE.commons.notepad.openButton.toUpperCase()}
             </label>
             <button
               className="btn btn-primary"

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -5,7 +5,7 @@ import "../../css/emib-tabs.css";
 
 const styles = {
   windowPadding: {
-    paddingTop: 43.5,
+    paddingTop: 43,
     order: 2
   },
   h4: {
@@ -14,15 +14,18 @@ const styles = {
     fontWeight: "bold",
     color: "#00565e",
     padding: "0 0 8px 12px",
-    borderBottom: "1px solid green"
+    borderBottom: "1.5px solid green"
   },
-  title: {
-    paddingTop: 0.1,
-    borderRadius: "0 5px 0 0"
+  hideNotepadBtn: {
+    float: "right",
+    margin: "8px 12px 0 0",
+    padding: 0,
+    backgroundColor: "transparent",
+    border: "none"
   },
   content: {
     backgroundColor: "white",
-    borderWidth: "1px 1px 0 1px",
+    borderWidth: "1px 1px 0 3px",
     borderStyle: "solid",
     borderColor: "#00565e",
     borderRadius: "0 5px 0 0",
@@ -38,36 +41,78 @@ const styles = {
     width: "100%",
     resize: "none",
     border: "none"
+  },
+  openNotepadBtnLabel: {
+    position: "absolute",
+    paddingTop: 40,
+    width: 60,
+    fontSize: "13px",
+    color: "white"
+  },
+  openNotepadBtn: {
+    width: 60,
+    border: "none",
+    backgroundColor: "#00565e",
+    height: "calc(100vh - 238px)"
+  },
+  openNotepadBtnHeight: {
+    height: "calc(100vh - 238px)"
   }
 };
 
 class Notepad extends Component {
+  state = {
+    notepadHidden: false
+  };
+
+  handleHide = () => {
+    this.setState({ notepadHidden: true });
+  };
+
+  handleOpen = () => {
+    this.setState({ notepadHidden: false });
+  };
+
   render() {
+    const { notepadHidden } = this.state;
     return (
       <div style={styles.windowPadding}>
-        <div style={styles.content}>
-          <div style={styles.title}>
-            <h4 style={styles.h4}>{LOCALIZE.commons.notepad.title}</h4>
+        {!notepadHidden && (
+          <div style={styles.content}>
+            <button onClick={this.handleHide} style={styles.hideNotepadBtn}>
+              {LOCALIZE.commons.notepad.hideButton}
+            </button>
+            <div>
+              <h4 style={styles.h4}>{LOCALIZE.commons.notepad.title}</h4>
+            </div>
+            <div style={styles.notepadSection}>
+              <form>
+                <fieldset>
+                  <label htmlFor="text-area-zone" className="invisible position-absolute">
+                    {LOCALIZE.commons.notepad.title}
+                  </label>
+                  <TextareaAutosize
+                    id="text-area-zone"
+                    maxLength="3000"
+                    className="text-area"
+                    style={styles.textArea}
+                    cols="45"
+                    minRows={5}
+                    placeholder={LOCALIZE.commons.notepad.placeholder}
+                  />
+                </fieldset>
+              </form>
+            </div>
           </div>
-          <div style={styles.notepadSection}>
-            <form>
-              <fieldset>
-                <label htmlFor="text-area-zone" className="invisible position-absolute">
-                  {LOCALIZE.commons.notepad.title}
-                </label>
-                <TextareaAutosize
-                  id="text-area-zone"
-                  maxLength="3000"
-                  className="text-area"
-                  style={styles.textArea}
-                  cols="45"
-                  minRows={5}
-                  placeholder={LOCALIZE.commons.notepad.placeholder}
-                />
-              </fieldset>
-            </form>
+        )}
+        {notepadHidden && (
+          <div style={styles.openNotepadBtnHeight}>
+            <label onClick={this.handleOpen} style={styles.openNotepadBtnLabel}>
+              {LOCALIZE.commons.notepad.openButton}
+            </label>
+            <button onClick={this.handleOpen} style={styles.openNotepadBtn} />
           </div>
-        </div>
+        )}
       </div>
     );
   }

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -19,15 +19,17 @@ const styles = {
   hideNotepadBtn: {
     float: "right",
     margin: "8px 12px 0 0",
-    padding: "0 6px 0 26px",
+    padding: "0 8px 0 8px",
     backgroundColor: "transparent",
     border: "none",
     cursor: "pointer"
   },
   hideNotepadBtnIcon: {
-    position: "absolute",
-    padding: "12px 0 0 82px",
+    paddingTop: 12,
     cursor: "pointer"
+  },
+  hideNotepadBtnZone: {
+    float: "right"
   },
   content: {
     backgroundColor: "white",
@@ -94,14 +96,16 @@ class Notepad extends Component {
       <div style={styles.windowPadding}>
         {!notepadHidden && (
           <div style={styles.content}>
-            <span
-              onClick={this.handleHide}
-              style={styles.hideNotepadBtnIcon}
-              className="fas fa-minus-circle"
-            />
-            <button onClick={this.handleHide} style={styles.hideNotepadBtn}>
-              {LOCALIZE.commons.notepad.hideButton}
-            </button>
+            <div style={styles.hideNotepadBtnZone}>
+              <span
+                onClick={this.handleHide}
+                style={styles.hideNotepadBtnIcon}
+                className="fas fa-minus-circle"
+              />
+              <button onClick={this.handleHide} style={styles.hideNotepadBtn}>
+                {LOCALIZE.commons.notepad.hideButton}
+              </button>
+            </div>
             <div>
               <h4 style={styles.h4}>{LOCALIZE.commons.notepad.title}</h4>
             </div>

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
 import TextareaAutosize from "react-textarea-autosize";
 import "../../css/emib-tabs.css";
@@ -14,7 +15,7 @@ const styles = {
     fontWeight: "bold",
     color: "#00565e",
     padding: "0 0 8px 12px",
-    borderBottom: "1.5px solid green"
+    borderBottom: "1.5px solid #88C800"
   },
   hideNotepadBtn: {
     float: "right",
@@ -45,7 +46,7 @@ const styles = {
     height: "calc(100vh - 291px)"
   },
   textArea: {
-    padding: "0 6px 6px 6px",
+    padding: "0 12px 6px 12px",
     width: "100%",
     resize: "none",
     border: "none"
@@ -78,16 +79,37 @@ const styles = {
 };
 
 class Notepad extends Component {
+  static propTypes = {
+    notepadContent: PropTypes.string
+  };
+
   state = {
-    notepadHidden: false
+    notepadHidden: false,
+    notepadContent: ""
   };
 
-  handleHide = () => {
-    this.setState({ notepadHidden: true });
-  };
-
-  handleOpen = () => {
-    this.setState({ notepadHidden: false });
+  handleCollapse = arg => {
+    switch (arg) {
+      //When Closing the Notepad
+      case "handleHide":
+        this.setState({ notepadHidden: true });
+        //Get current notepad content
+        let x = document.getElementById("notepad-content");
+        let txt = "";
+        for (let i = 1; i < x.length; i++) {
+          txt = txt + x.elements[i].value;
+        }
+        x.innerHTML = txt;
+        //Update NOTEPAD_CONTENT
+        this.setState({ notepadContent: txt });
+        break;
+      //When Opening the Notepad
+      case "handleOpen":
+        this.setState({ notepadHidden: false });
+        break;
+      default:
+        this.setState({ notepadHidden: false });
+    }
   };
 
   render() {
@@ -98,11 +120,14 @@ class Notepad extends Component {
           <div style={styles.content}>
             <div style={styles.hideNotepadBtnZone}>
               <span
-                onClick={this.handleHide}
+                onClick={() => this.handleCollapse("handleHide")}
                 style={styles.hideNotepadBtnIcon}
                 className="fas fa-minus-circle"
               />
-              <button onClick={this.handleHide} style={styles.hideNotepadBtn}>
+              <button
+                onClick={() => this.handleCollapse("handleHide")}
+                style={styles.hideNotepadBtn}
+              >
                 {LOCALIZE.commons.notepad.hideButton}
               </button>
             </div>
@@ -110,7 +135,7 @@ class Notepad extends Component {
               <h4 style={styles.h4}>{LOCALIZE.commons.notepad.title}</h4>
             </div>
             <div style={styles.notepadSection}>
-              <form>
+              <form id="notepad-content">
                 <fieldset>
                   <label htmlFor="text-area-zone" className="invisible position-absolute">
                     {LOCALIZE.commons.notepad.title}
@@ -123,6 +148,7 @@ class Notepad extends Component {
                     cols="45"
                     minRows={5}
                     placeholder={LOCALIZE.commons.notepad.placeholder}
+                    defaultValue={this.state.notepadContent}
                   />
                 </fieldset>
               </form>
@@ -136,12 +162,15 @@ class Notepad extends Component {
               style={styles.openNotepadBtnIcon}
               className="fas fa-external-link-alt"
             />
-            <label onClick={this.handleOpen} style={styles.openNotepadBtnLabel}>
+            <label
+              onClick={() => this.handleCollapse("handleOpen")}
+              style={styles.openNotepadBtnLabel}
+            >
               {LOCALIZE.commons.notepad.openButton}
             </label>
             <button
               className="btn btn-primary"
-              onClick={this.handleOpen}
+              onClick={() => this.handleCollapse("handleOpen")}
               style={styles.openNotepadBtn}
             />
           </div>

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -153,7 +153,7 @@ class Notepad extends Component {
         {notepadHidden && (
           <div style={styles.openNotepadBtnHeight}>
             <span
-              onClick={this.handleOpen}
+              onClick={() => this.handleCollapse("handleOpen")}
               style={styles.openNotepadBtnIcon}
               className="fas fa-external-link-alt"
             />

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -83,28 +83,21 @@ class Notepad extends Component {
     notepadContent: ""
   };
 
-  handleCollapse = arg => {
-    switch (arg) {
-      //When Closing the Notepad
-      case "handleHide":
-        this.setState({ notepadHidden: true });
-        //Get current notepad content
-        let x = document.getElementById("notepad-content");
-        let txt = "";
-        for (let i = 1; i < x.length; i++) {
-          txt = txt + x.elements[i].value;
-        }
-        x.innerHTML = txt;
-        //Update NOTEPAD_CONTENT
-        this.setState({ notepadContent: txt });
-        break;
-      //When Opening the Notepad
-      case "handleOpen":
-        this.setState({ notepadHidden: false });
-        break;
-      default:
-        this.setState({ notepadHidden: false });
+  handleHide = () => {
+    this.setState({ notepadHidden: true });
+    //Get current notepad content
+    let x = document.getElementById("notepad-content");
+    let txt = "";
+    for (let i = 1; i < x.length; i++) {
+      txt = txt + x.elements[i].value;
     }
+    x.innerHTML = txt;
+    //Update NOTEPAD_CONTENT
+    this.setState({ notepadContent: txt });
+  };
+
+  handleOpen = () => {
+    this.setState({ notepadHidden: false });
   };
 
   render() {
@@ -115,14 +108,11 @@ class Notepad extends Component {
           <div style={styles.content}>
             <div style={styles.hideNotepadBtnZone}>
               <span
-                onClick={() => this.handleCollapse("handleHide")}
+                onClick={this.handleHide}
                 style={styles.hideNotepadBtnIcon}
                 className="fas fa-minus-circle"
               />
-              <button
-                onClick={() => this.handleCollapse("handleHide")}
-                style={styles.hideNotepadBtn}
-              >
+              <button onClick={this.handleHide} style={styles.hideNotepadBtn}>
                 {LOCALIZE.commons.notepad.hideButton}
               </button>
             </div>
@@ -153,19 +143,16 @@ class Notepad extends Component {
         {notepadHidden && (
           <div style={styles.openNotepadBtnHeight}>
             <span
-              onClick={() => this.handleCollapse("handleOpen")}
+              onClick={this.handleOpen}
               style={styles.openNotepadBtnIcon}
               className="fas fa-external-link-alt"
             />
-            <label
-              onClick={() => this.handleCollapse("handleOpen")}
-              style={styles.openNotepadBtnLabel}
-            >
+            <label onClick={this.handleOpen} style={styles.openNotepadBtnLabel}>
               {LOCALIZE.commons.notepad.openButton}
             </label>
             <button
               className="btn btn-primary"
-              onClick={() => this.handleCollapse("handleOpen")}
+              onClick={this.handleOpen}
               style={styles.openNotepadBtn}
             />
           </div>

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
 import LOCALIZE from "../../text_resources";
 import TextareaAutosize from "react-textarea-autosize";
-import { BROWSER_STRING, IE_STRING, VALID_BROWSERS } from "../../Status";
 import "../../css/emib-tabs.css";
 
 const styles = {

--- a/frontend/src/components/commons/SideNavigation.jsx
+++ b/frontend/src/components/commons/SideNavigation.jsx
@@ -26,7 +26,7 @@ const styles = {
   bodyContent: {
     overflow: "auto",
     paddingRight: 20,
-    height: "calc(100vh - 241px)"
+    height: "calc(100vh - 242px)"
   },
   secondaryButton: {
     border: "none"

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -358,7 +358,7 @@ let LOCALIZE = new LocalizedStrings({
         title: "notepad",
         placeholder: "Put your notes here...",
         hideButton: "hide",
-        openButton: "OPEN NOTES"
+        openButton: "open notes"
       },
       cancel: "Cancel",
       close: "Close"
@@ -730,7 +730,7 @@ let LOCALIZE = new LocalizedStrings({
         title: "bloc-notes",
         placeholder: "Mettez vos notes ici...",
         hideButton: "cacher",
-        openButton: "OUVRIR NOTES"
+        openButton: "ouvrir notes"
       },
       cancel: "Annuler",
       close: "Fermer"

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -355,7 +355,7 @@ let LOCALIZE = new LocalizedStrings({
       disabled: "Disabled",
       backToTop: "Back to top",
       notepad: {
-        title: "NOTEPAD",
+        title: "notepad",
         placeholder: "Put your notes here...",
         hideButton: "hide",
         openButton: "OPEN NOTES"
@@ -727,7 +727,7 @@ let LOCALIZE = new LocalizedStrings({
       disabled: "Désactivé",
       backToTop: "Haut de la page",
       notepad: {
-        title: "BLOC-NOTES",
+        title: "bloc-notes",
         placeholder: "Mettez vos notes ici...",
         hideButton: "cacher",
         openButton: "OUVRIR NOTES"

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -356,7 +356,9 @@ let LOCALIZE = new LocalizedStrings({
       backToTop: "Back to top",
       notepad: {
         title: "NOTEPAD",
-        placeholder: "Put your notes here..."
+        placeholder: "Put your notes here...",
+        hideButton: "hide",
+        openButton: "OPEN NOTES"
       },
       cancel: "Cancel",
       close: "Close"
@@ -726,7 +728,9 @@ let LOCALIZE = new LocalizedStrings({
       backToTop: "Haut de la page",
       notepad: {
         title: "BLOC-NOTES",
-        placeholder: "Mettez vos notes ici..."
+        placeholder: "Mettez vos notes ici...",
+        hideButton: "cacher",
+        openButton: "OUVRIR NOTES"
       },
       cancel: "Annuler",
       close: "Fermer"

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -355,7 +355,7 @@ let LOCALIZE = new LocalizedStrings({
       disabled: "Disabled",
       backToTop: "Back to top",
       notepad: {
-        title: "Notepad",
+        title: "NOTEPAD",
         placeholder: "Put your notes here..."
       },
       cancel: "Cancel",
@@ -725,7 +725,7 @@ let LOCALIZE = new LocalizedStrings({
       disabled: "Désactivé",
       backToTop: "Haut de la page",
       notepad: {
-        title: "Bloc-notes",
+        title: "BLOC-NOTES",
         placeholder: "Mettez vos notes ici..."
       },
       cancel: "Annuler",


### PR DESCRIPTION
# Description

I added hide/open notepad functionality and updated notepad styles. These style updates have also been approved by the UX Designer. 

Also, the notepad content is saved using a state, so even if you collapse the notepad, the content of it will be kept and restored when you'll reopen the notepad.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Code cleanliness or refactor

## Screenshot

**Opened Notepad:**

![image](https://user-images.githubusercontent.com/23021242/55017418-0d325780-4fc7-11e9-997c-9fcf381ce523.png)

**Hidden Notepad:**

![image](https://user-images.githubusercontent.com/23021242/55017433-16bbbf80-4fc7-11e9-8c06-a141f974ff03.png)

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB Sample Test.
2.  Complete the pre-instruction process.
3.  Play with the notepad and make sure it looks good and works well in all browsers.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
