### PR TITLE
[Tab Navigation] Added new prop for style customization

### DIFF
--- a/frontend/src/components/commons/TabNavigation.jsx
+++ b/frontend/src/components/commons/TabNavigation.jsx
@@ -25,13 +25,7 @@ const styles = {
     display: "block",
     WebkitTransition: "opacity 0.15s linear",
     OTransition: "opacity 0.15s linear",
-    transition: "opacity 0.15s linear",
-    backgroundColor: "white",
-    borderWidth: "1px 1px 0 1px",
-    borderStyle: "solid",
-    borderColor: "#00565e",
-    borderTopColor: "white",
-    height: "calc(100vh - 241px)"
+    transition: "opacity 0.15s linear"
   }
 };
 
@@ -39,7 +33,8 @@ class TabNavigation extends Component {
   static propTypes = {
     tabSpecs: PropTypes.array.isRequired,
     currentTab: PropTypes.number.isRequired,
-    menuName: PropTypes.string.isRequired
+    menuName: PropTypes.string.isRequired,
+    style: PropTypes.object
   };
 
   state = {
@@ -65,7 +60,9 @@ class TabNavigation extends Component {
           </ul>
         </nav>
         <div style={styles.afterNav} />
-        <div style={styles.tabContent}>{this.state.currentBody}</div>
+        <div style={this.props.style}>
+          <div style={styles.tabContent}>{this.state.currentBody}</div>
+        </div>
       </div>
     );
   }

--- a/frontend/src/components/eMIB/EmibTabs.jsx
+++ b/frontend/src/components/eMIB/EmibTabs.jsx
@@ -8,7 +8,7 @@ import Notepad from "../commons/Notepad";
 import "../../css/emib-tabs.css";
 import { getInboxContent } from "./Emib";
 
-const customStyles = {
+const styles = {
   container: {
     maxWidth: 1400,
     minWidth: 900,
@@ -17,6 +17,14 @@ const customStyles = {
     display: "flex",
     paddingRight: 20,
     paddingLeft: 20
+  },
+  tabNavigation: {
+    height: "calc(100vh - 241px)",
+    backgroundColor: "white",
+    borderWidth: "1px 1px 0 1px",
+    borderStyle: "solid",
+    borderColor: "#00565e",
+    borderTopColor: "white"
   }
 };
 
@@ -41,8 +49,13 @@ class EmibTabs extends Component {
       }
     ];
     return (
-      <div style={customStyles.container}>
-        <TabNavigation tabSpecs={TABS} currentTab={1} menuName={LOCALIZE.ariaLabel.tabMenu} />
+      <div style={styles.container}>
+        <TabNavigation
+          tabSpecs={TABS}
+          currentTab={1}
+          menuName={LOCALIZE.ariaLabel.tabMenu}
+          style={styles.tabNavigation}
+        />
         <Notepad />
       </div>
     );


### PR DESCRIPTION
# Description

I simply added a new prop in _TabNavigation.jsx_ component, so we can now customize it when using it. For now, this component was only used by _EmibTabs.jsx_ component, but in the future, this component will be used in other places, so that is important to be able to customize the style.

## Type of change

Please delete options that are not relevant.

- Code cleanliness or refactor

## Screenshot

**Still look the same as before:**

![image](https://user-images.githubusercontent.com/23021242/55227416-d2f6cf00-51ed-11e9-8664-f1aec92721e1.png)

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB Sample Test.
2.  Complete the _pre-test_ process.
3.  Make sure that the eMIB interface looks the same as before, especially the tab navigation window.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 10+, Firefox, and Chrome
