### PR TITLE
[Login & Create Account] Added Login Form and Create Account Form and Included Validation

### DIFF
--- a/frontend/src/Home.jsx
+++ b/frontend/src/Home.jsx
@@ -1,16 +1,39 @@
-import React from "react";
+import React, { Component } from "react";
 import LOCALIZE from "./text_resources";
 import ContentContainer from "./components/commons/ContentContainer";
+import LoginTabs from "./components/authentication/AuthenticationTabs";
 
-const Home = () => {
-  return (
-    <div className="app">
-      <ContentContainer>
-        <h1>{LOCALIZE.homePage.title}</h1>
-        <p>{LOCALIZE.homePage.description}</p>
-      </ContentContainer>
-    </div>
-  );
-};
+class Home extends Component {
+  //TODO(fnormand): Remove this part when implementing login functionality in the backend
+  //===========================================
+  state = {
+    isAuthenticated: false
+  };
+
+  authentification = () => {
+    this.setState({ isAuthenticated: true });
+  };
+  //===========================================
+
+  render() {
+    return (
+      <div className="app">
+        <ContentContainer>
+          <h1>{LOCALIZE.homePage.title}</h1>
+          <p>{LOCALIZE.homePage.description}</p>
+          <div>
+            <LoginTabs authentification={this.authentification} />
+          </div>
+          {this.state.isAuthenticated && (
+            <div>
+              <h3>Welcome!</h3>
+              <p>You've just logged in.</p>
+            </div>
+          )}
+        </ContentContainer>
+      </div>
+    );
+  }
+}
 
 export default Home;

--- a/frontend/src/components/authentication/AuthenticationTabs.jsx
+++ b/frontend/src/components/authentication/AuthenticationTabs.jsx
@@ -1,0 +1,74 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import TabNavigation from "../commons/TabNavigation";
+import LoginForm from "./LoginForm";
+import CreateAccountForm from "./CreateAccountForm";
+import LOCALIZE from "../../text_resources";
+
+const styles = {
+  container: {
+    width: 500,
+    margin: "0px auto",
+    paddingTop: 24,
+    paddingRight: 20,
+    paddingLeft: 20
+  },
+  tabNavigationStyle: {
+    height: "100%",
+    backgroundColor: "white",
+    borderWidth: "1px 1px 1px 1px",
+    borderStyle: "solid",
+    borderColor: "#00565e",
+    borderTopColor: "white",
+    marginBottom: 25
+  }
+};
+
+class AuthenticationTabs extends Component {
+  //TODO(fnormand): Remove this part when implementing login functionality in the backend
+  //===========================================
+  static propTypes = {
+    authentification: PropTypes.func
+  };
+
+  state = {
+    isAuthenticated: false
+  };
+
+  authentification = () => {
+    this.setState({ isAuthenticated: true });
+    this.props.authentification();
+  };
+  //===========================================
+
+  render() {
+    const TABS = [
+      {
+        id: 0,
+        tabName: LOCALIZE.authentication.login.title,
+        body: <LoginForm authentification={this.authentification} />
+      },
+      {
+        id: 1,
+        tabName: LOCALIZE.authentication.createAccount.title,
+        body: <CreateAccountForm />
+      }
+    ];
+    return (
+      <div>
+        {!this.state.isAuthenticated && (
+          <div style={styles.container}>
+            <TabNavigation
+              tabSpecs={TABS}
+              currentTab={0}
+              menuName={LOCALIZE.ariaLabel.authenticationMenu}
+              style={styles.tabNavigationStyle}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+export default AuthenticationTabs;

--- a/frontend/src/components/authentication/CreateAccountForm.jsx
+++ b/frontend/src/components/authentication/CreateAccountForm.jsx
@@ -58,34 +58,19 @@ class CreateAccountForm extends Component {
   firstNameValidation = () => {
     const firstName = document.getElementById("first-name").value;
     const isValide = validateName(firstName);
-    this.setState({ isFirstLoad: false });
-    if (isValide) {
-      this.setState({ isValidFirstName: true });
-    } else {
-      this.setState({ isValidFirstName: false });
-    }
+    this.setState({ isFirstLoad: false, isValidFirstName: isValide });
   };
 
   lastNameValidation = () => {
     const lastName = document.getElementById("last-name").value;
     const isValide = validateName(lastName);
-    this.setState({ isFirstLoad: false });
-    if (isValide) {
-      this.setState({ isValidLastName: true });
-    } else {
-      this.setState({ isValidLastName: false });
-    }
+    this.setState({ isFirstLoad: false, isValidLastName: isValide });
   };
 
   emailValidation = () => {
     const email = document.getElementById("email").value;
     const isValide = validateEmail(email);
-    this.setState({ isFirstLoad: false });
-    if (isValide) {
-      this.setState({ isValidEmail: true });
-    } else {
-      this.setState({ isValidEmail: false });
-    }
+    this.setState({ isFirstLoad: false, isValidEmail: isValide });
   };
 
   passwordValidation = () => {
@@ -94,11 +79,7 @@ class CreateAccountForm extends Component {
     const isValide = validatePassword(password);
     const passwordConfirmation = document.getElementById("password-confirmation").value;
     //Password valid?
-    if (isValide) {
-      this.setState({ isValidPassword: true });
-    } else {
-      this.setState({ isValidPassword: false });
-    }
+    this.setState({ isFirstPasswordLoad: false, isValidPassword: isValide });
     //Password confirmation is the same?
     if (password === passwordConfirmation) {
       this.setState({

--- a/frontend/src/components/authentication/CreateAccountForm.jsx
+++ b/frontend/src/components/authentication/CreateAccountForm.jsx
@@ -42,11 +42,11 @@ const styles = {
   }
 };
 
-let SUBMIT_BTN_DISABLED;
-
 class CreateAccountForm extends Component {
   state = {
+    // Ensures no errors are shown on page load
     isFirstLoad: true,
+    // Form content and validation
     firstNameContent: "",
     isValidFirstName: false,
     lastNameContent: "",
@@ -62,43 +62,41 @@ class CreateAccountForm extends Component {
 
   firstNameValidation = event => {
     const updatedFirstNameValue = event.target.value;
-    const isValide = validateName(updatedFirstNameValue);
+    const isValid = validateName(updatedFirstNameValue);
     this.setState({
       isFirstLoad: false,
       firstNameContent: updatedFirstNameValue,
-      isValidFirstName: isValide
+      isValidFirstName: isValid
     });
   };
 
   lastNameValidation = event => {
     const updatedLastNameValue = event.target.value;
-    const isValide = validateName(updatedLastNameValue);
+    const isValid = validateName(updatedLastNameValue);
     this.setState({
       isFirstLoad: false,
       lastNameContent: updatedLastNameValue,
-      isValidLastName: isValide
+      isValidLastName: isValid
     });
   };
 
   emailValidation = event => {
     const updatedEmailValue = event.target.value;
-    const isValide = validateEmail(updatedEmailValue);
-    this.setState({ isFirstLoad: false, emailContent: updatedEmailValue, isValidEmail: isValide });
+    const isValid = validateEmail(updatedEmailValue);
+    this.setState({ isFirstLoad: false, emailContent: updatedEmailValue, isValidEmail: isValid });
   };
 
   passwordValidation = event => {
     const updatedPasswordValue = event.target.value;
     const passwordConfirmationValue = this.state.passwordConfirmationContent;
-    const isValide = validatePassword(updatedPasswordValue);
+    const isValid = validatePassword(updatedPasswordValue);
     this.setState({
       isFirstLoad: false,
       isFirstPasswordLoad: false,
       passwordContent: updatedPasswordValue,
-      isValidPassword: isValide
+      isValidPassword: isValid,
+      isValidPasswordConfirmation: updatedPasswordValue === passwordConfirmationValue
     });
-    updatedPasswordValue === passwordConfirmationValue
-      ? this.setState({ isValidPasswordConfirmation: true })
-      : this.setState({ isValidPasswordConfirmation: false });
   };
 
   passwordConfirmationValidation = event => {
@@ -106,34 +104,9 @@ class CreateAccountForm extends Component {
     const passwordValue = this.state.passwordContent;
     this.setState({
       isFirstLoad: false,
-      passwordConfirmationContent: updatedPasswordConfirmationValue
+      passwordConfirmationContent: updatedPasswordConfirmationValue,
+      isValidPasswordConfirmation: updatedPasswordConfirmationValue === passwordValue
     });
-    updatedPasswordConfirmationValue === passwordValue
-      ? this.setState({ isValidPasswordConfirmation: true })
-      : this.setState({ isValidPasswordConfirmation: false });
-  };
-
-  areAllFieldsValid = () => {
-    const {
-      isValidFirstName,
-      isValidLastName,
-      isValidEmail,
-      isValidPassword,
-      isValidPasswordConfirmation
-    } = this.state;
-
-    if (
-      isValidFirstName &&
-      isValidLastName &&
-      isValidEmail &&
-      isValidPassword &&
-      isValidPasswordConfirmation
-    ) {
-      //did not use state because of maximum update depth exeeded error
-      SUBMIT_BTN_DISABLED = false;
-    } else {
-      SUBMIT_BTN_DISABLED = true;
-    }
   };
 
   render() {
@@ -153,17 +126,14 @@ class CreateAccountForm extends Component {
     } = this.state;
 
     const validFieldClass = "valid-field";
-    let invalidFieldClass = "";
+    const invalidFieldClass = "invalid-field";
 
-    //if this is the first load of create account form, display all fields as 'valid-field'
-    if (isFirstLoad) {
-      invalidFieldClass = "valid-field";
-    } else {
-      invalidFieldClass = "invalid-field";
-    }
-
-    //check if all fields are valid
-    this.areAllFieldsValid();
+    const submitButtonEnabled =
+      isValidFirstName &&
+      isValidLastName &&
+      isValidEmail &&
+      isValidPassword &&
+      isValidPasswordConfirmation;
     return (
       <div>
         <div>
@@ -184,7 +154,9 @@ class CreateAccountForm extends Component {
 
                   <input
                     aria-label={LOCALIZE.authentication.createAccount.content.inputs.firstNameTitle}
-                    className={isValidFirstName ? validFieldClass : invalidFieldClass}
+                    className={
+                      isValidFirstName || isFirstLoad ? validFieldClass : invalidFieldClass
+                    }
                     type="text"
                     placeholder={
                       LOCALIZE.authentication.createAccount.content.inputs.firstNamePlaceholder
@@ -205,7 +177,7 @@ class CreateAccountForm extends Component {
                   )}
                   <input
                     aria-label={LOCALIZE.authentication.createAccount.content.inputs.lastNameTitle}
-                    className={isValidLastName ? validFieldClass : invalidFieldClass}
+                    className={isValidLastName || isFirstLoad ? validFieldClass : invalidFieldClass}
                     type="text"
                     placeholder={
                       LOCALIZE.authentication.createAccount.content.inputs.lastNamePlaceholder
@@ -225,7 +197,7 @@ class CreateAccountForm extends Component {
                 )}
                 <input
                   aria-label={LOCALIZE.authentication.createAccount.content.inputs.emailTitle}
-                  className={isValidEmail ? validFieldClass : invalidFieldClass}
+                  className={isValidEmail || isFirstLoad ? validFieldClass : invalidFieldClass}
                   type="text"
                   placeholder={
                     LOCALIZE.authentication.createAccount.content.inputs.emailPlaceholder
@@ -244,7 +216,7 @@ class CreateAccountForm extends Component {
                 )}
                 <input
                   aria-label={LOCALIZE.authentication.createAccount.content.inputs.passwordTitle}
-                  className={isValidPassword ? validFieldClass : invalidFieldClass}
+                  className={isValidPassword || isFirstLoad ? validFieldClass : invalidFieldClass}
                   type="password"
                   placeholder={
                     LOCALIZE.authentication.createAccount.content.inputs.passwordPlaceholder
@@ -303,7 +275,9 @@ class CreateAccountForm extends Component {
                   aria-label={
                     LOCALIZE.authentication.createAccount.content.inputs.passwordConfirmationTitle
                   }
-                  className={isValidPasswordConfirmation ? validFieldClass : invalidFieldClass}
+                  className={
+                    isValidPasswordConfirmation || isFirstLoad ? validFieldClass : invalidFieldClass
+                  }
                   type="password"
                   placeholder={
                     LOCALIZE.authentication.createAccount.content.inputs
@@ -313,14 +287,14 @@ class CreateAccountForm extends Component {
                   style={styles.inputs}
                   onChange={this.passwordConfirmationValidation}
                 />
-                {!isValidPasswordConfirmation && !isFirstLoad && (
+                {!isValidPasswordConfirmation && !isFirstPasswordLoad && (
                   <p style={styles.validationError}>
                     {LOCALIZE.authentication.createAccount.content.inputs.passwordConfirmationError}
                   </p>
                 )}
               </div>
               <button
-                disabled={SUBMIT_BTN_DISABLED}
+                disabled={!submitButtonEnabled}
                 style={styles.loginBtn}
                 className="btn btn-primary"
                 type="submit"

--- a/frontend/src/components/authentication/CreateAccountForm.jsx
+++ b/frontend/src/components/authentication/CreateAccountForm.jsx
@@ -47,49 +47,70 @@ let SUBMIT_BTN_DISABLED;
 class CreateAccountForm extends Component {
   state = {
     isFirstLoad: true,
+    firstNameContent: "",
     isValidFirstName: false,
+    lastNameContent: "",
     isValidLastName: false,
+    emailContent: "",
     isValidEmail: false,
+    passwordContent: "",
     isValidPassword: false,
+    passwordConfirmationContent: "",
     isFirstPasswordLoad: true,
     isValidPasswordConfirmation: false
   };
 
-  firstNameValidation = () => {
-    const firstName = document.getElementById("first-name").value;
-    const isValide = validateName(firstName);
-    this.setState({ isFirstLoad: false, isValidFirstName: isValide });
+  firstNameValidation = event => {
+    const updatedFirstNameValue = event.target.value;
+    const isValide = validateName(updatedFirstNameValue);
+    this.setState({
+      isFirstLoad: false,
+      firstNameContent: updatedFirstNameValue,
+      isValidFirstName: isValide
+    });
   };
 
-  lastNameValidation = () => {
-    const lastName = document.getElementById("last-name").value;
-    const isValide = validateName(lastName);
-    this.setState({ isFirstLoad: false, isValidLastName: isValide });
+  lastNameValidation = event => {
+    const updatedLastNameValue = event.target.value;
+    const isValide = validateName(updatedLastNameValue);
+    this.setState({
+      isFirstLoad: false,
+      lastNameContent: updatedLastNameValue,
+      isValidLastName: isValide
+    });
   };
 
-  emailValidation = () => {
-    const email = document.getElementById("email").value;
-    const isValide = validateEmail(email);
-    this.setState({ isFirstLoad: false, isValidEmail: isValide });
+  emailValidation = event => {
+    const updatedEmailValue = event.target.value;
+    const isValide = validateEmail(updatedEmailValue);
+    this.setState({ isFirstLoad: false, emailContent: updatedEmailValue, isValidEmail: isValide });
   };
 
-  passwordValidation = () => {
-    this.setState({ isFirstPasswordLoad: false, isFirstLoad: false });
-    const password = document.getElementById("password").value;
-    const isValide = validatePassword(password);
-    const passwordConfirmation = document.getElementById("password-confirmation").value;
-    //Password valid?
-    this.setState({ isFirstPasswordLoad: false, isValidPassword: isValide });
-    //Password confirmation is the same?
-    if (password === passwordConfirmation) {
-      this.setState({
-        isValidPasswordConfirmation: true
-      });
-    } else {
-      this.setState({
-        isValidPasswordConfirmation: false
-      });
-    }
+  passwordValidation = event => {
+    const updatedPasswordValue = event.target.value;
+    const passwordConfirmationValue = this.state.passwordConfirmationContent;
+    const isValide = validatePassword(updatedPasswordValue);
+    this.setState({
+      isFirstLoad: false,
+      isFirstPasswordLoad: false,
+      passwordContent: updatedPasswordValue,
+      isValidPassword: isValide
+    });
+    updatedPasswordValue === passwordConfirmationValue
+      ? this.setState({ isValidPasswordConfirmation: true })
+      : this.setState({ isValidPasswordConfirmation: false });
+  };
+
+  passwordConfirmationValidation = event => {
+    const updatedPasswordConfirmationValue = event.target.value;
+    const passwordValue = this.state.passwordContent;
+    this.setState({
+      isFirstLoad: false,
+      passwordConfirmationContent: updatedPasswordConfirmationValue
+    });
+    updatedPasswordConfirmationValue === passwordValue
+      ? this.setState({ isValidPasswordConfirmation: true })
+      : this.setState({ isValidPasswordConfirmation: false });
   };
 
   areAllFieldsValid = () => {
@@ -118,11 +139,16 @@ class CreateAccountForm extends Component {
   render() {
     const {
       isFirstLoad,
+      firstNameContent,
       isValidFirstName,
+      lastNameContent,
       isValidLastName,
+      emailContent,
       isValidEmail,
+      passwordContent,
       isValidPassword,
       isFirstPasswordLoad,
+      passwordConfirmationContent,
       isValidPasswordConfirmation
     } = this.state;
 
@@ -163,7 +189,7 @@ class CreateAccountForm extends Component {
                     placeholder={
                       LOCALIZE.authentication.createAccount.content.inputs.firstNamePlaceholder
                     }
-                    id="first-name"
+                    value={firstNameContent}
                     style={styles.inputForNames}
                     onChange={this.firstNameValidation}
                   />
@@ -184,7 +210,7 @@ class CreateAccountForm extends Component {
                     placeholder={
                       LOCALIZE.authentication.createAccount.content.inputs.lastNamePlaceholder
                     }
-                    id="last-name"
+                    value={lastNameContent}
                     style={styles.inputForNames}
                     onChange={this.lastNameValidation}
                   />
@@ -204,7 +230,7 @@ class CreateAccountForm extends Component {
                   placeholder={
                     LOCALIZE.authentication.createAccount.content.inputs.emailPlaceholder
                   }
-                  id="email"
+                  value={emailContent}
                   style={styles.inputs}
                   onChange={this.emailValidation}
                 />
@@ -223,7 +249,7 @@ class CreateAccountForm extends Component {
                   placeholder={
                     LOCALIZE.authentication.createAccount.content.inputs.passwordPlaceholder
                   }
-                  id="password"
+                  value={passwordContent}
                   style={styles.inputs}
                   onChange={this.passwordValidation}
                 />
@@ -283,11 +309,11 @@ class CreateAccountForm extends Component {
                     LOCALIZE.authentication.createAccount.content.inputs
                       .passwordConfirmationPlaceholder
                   }
-                  id="password-confirmation"
+                  value={passwordConfirmationContent}
                   style={styles.inputs}
-                  onChange={this.passwordValidation}
+                  onChange={this.passwordConfirmationValidation}
                 />
-                {!isValidPasswordConfirmation && !isFirstPasswordLoad && (
+                {!isValidPasswordConfirmation && !isFirstLoad && (
                   <p style={styles.validationError}>
                     {LOCALIZE.authentication.createAccount.content.inputs.passwordConfirmationError}
                   </p>

--- a/frontend/src/components/authentication/CreateAccountForm.jsx
+++ b/frontend/src/components/authentication/CreateAccountForm.jsx
@@ -16,9 +16,6 @@ const styles = {
     padding: "3px 6px 3px 6px",
     borderRadius: 4
   },
-  zoneForNames: {
-    display: "flow-root"
-  },
   inputForNames: {
     width: 190,
     padding: "3px 6px 3px 6px",
@@ -164,8 +161,8 @@ class CreateAccountForm extends Component {
             <h3>{LOCALIZE.authentication.createAccount.content.title}</h3>
             <span>{LOCALIZE.authentication.createAccount.content.description}</span>
             <form>
-              <div style={styles.zoneForNames}>
-                <div className="float-left">
+              <div className="names-grid">
+                <div className="names-grid-first-name">
                   <div style={styles.inputTitle}>
                     <span>
                       {LOCALIZE.authentication.createAccount.content.inputs.firstNameTitle}
@@ -187,7 +184,7 @@ class CreateAccountForm extends Component {
                     onChange={this.firstNameValidation}
                   />
                 </div>
-                <div className="float-right">
+                <div className="names-grid-last-name">
                   <div style={styles.inputTitle}>
                     <span style={styles.inputTitle}>
                       {LOCALIZE.authentication.createAccount.content.inputs.lastNameTitle}

--- a/frontend/src/components/authentication/CreateAccountForm.jsx
+++ b/frontend/src/components/authentication/CreateAccountForm.jsx
@@ -46,70 +46,67 @@ let SUBMIT_BTN_DISABLED;
 
 class CreateAccountForm extends Component {
   state = {
-    isFirstPasswordLoad: true,
+    isFirstLoad: true,
     isValidFirstName: false,
-    firstNameClassStyle: "valid-field",
     isValidLastName: false,
-    lastNameClassStyle: "valid-field",
     isValidEmail: false,
-    emailClassStyle: "valid-field",
     isValidPassword: false,
-    passwordClassStyle: "valid-field",
-    isValidPasswordConfirmation: false,
-    passwordConfirmationClassStyle: "valid-field"
+    isFirstPasswordLoad: true,
+    isValidPasswordConfirmation: false
   };
 
   firstNameValidation = () => {
     const firstName = document.getElementById("first-name").value;
     const isValide = validateName(firstName);
+    this.setState({ isFirstLoad: false });
     if (isValide) {
-      this.setState({ isValidFirstName: true, firstNameClassStyle: "valid-field" });
+      this.setState({ isValidFirstName: true });
     } else {
-      this.setState({ isValidFirstName: false, firstNameClassStyle: "invalid-field" });
+      this.setState({ isValidFirstName: false });
     }
   };
 
   lastNameValidation = () => {
     const lastName = document.getElementById("last-name").value;
     const isValide = validateName(lastName);
+    this.setState({ isFirstLoad: false });
     if (isValide) {
-      this.setState({ isValidLastName: true, lastNameClassStyle: "valid-field" });
+      this.setState({ isValidLastName: true });
     } else {
-      this.setState({ isValidLastName: false, lastNameClassStyle: "invalid-field" });
+      this.setState({ isValidLastName: false });
     }
   };
 
   emailValidation = () => {
     const email = document.getElementById("email").value;
     const isValide = validateEmail(email);
+    this.setState({ isFirstLoad: false });
     if (isValide) {
-      this.setState({ isValidEmail: true, emailClassStyle: "valid-field" });
+      this.setState({ isValidEmail: true });
     } else {
-      this.setState({ isValidEmail: false, emailClassStyle: "invalid-field" });
+      this.setState({ isValidEmail: false });
     }
   };
 
   passwordValidation = () => {
-    this.setState({ isFirstPasswordLoad: false });
+    this.setState({ isFirstPasswordLoad: false, isFirstLoad: false });
     const password = document.getElementById("password").value;
     const isValide = validatePassword(password);
     const passwordConfirmation = document.getElementById("password-confirmation").value;
     //Password valid?
     if (isValide) {
-      this.setState({ isValidPassword: true, passwordClassStyle: "valid-field" });
+      this.setState({ isValidPassword: true });
     } else {
-      this.setState({ isValidPassword: false, passwordClassStyle: "invalid-field" });
+      this.setState({ isValidPassword: false });
     }
     //Password confirmation is the same?
     if (password === passwordConfirmation) {
       this.setState({
-        isValidPasswordConfirmation: true,
-        passwordConfirmationClassStyle: "valid-field"
+        isValidPasswordConfirmation: true
       });
     } else {
       this.setState({
-        isValidPasswordConfirmation: false,
-        passwordConfirmationClassStyle: "invalid-field"
+        isValidPasswordConfirmation: false
       });
     }
   };
@@ -139,18 +136,24 @@ class CreateAccountForm extends Component {
 
   render() {
     const {
+      isFirstLoad,
       isValidFirstName,
       isValidLastName,
       isValidEmail,
       isValidPassword,
       isFirstPasswordLoad,
-      firstNameClassStyle,
-      lastNameClassStyle,
-      emailClassStyle,
-      passwordClassStyle,
-      isValidPasswordConfirmation,
-      passwordConfirmationClassStyle
+      isValidPasswordConfirmation
     } = this.state;
+
+    const validFieldClass = "valid-field";
+    let invalidFieldClass = "";
+
+    //if this is the first load of create account form, display all fields as 'valid-field'
+    if (isFirstLoad) {
+      invalidFieldClass = "valid-field";
+    } else {
+      invalidFieldClass = "invalid-field";
+    }
 
     //check if all fields are valid
     this.areAllFieldsValid();
@@ -174,7 +177,7 @@ class CreateAccountForm extends Component {
 
                   <input
                     aria-label={LOCALIZE.authentication.createAccount.content.inputs.firstNameTitle}
-                    className={firstNameClassStyle}
+                    className={isValidFirstName ? validFieldClass : invalidFieldClass}
                     type="text"
                     placeholder={
                       LOCALIZE.authentication.createAccount.content.inputs.firstNamePlaceholder
@@ -195,7 +198,7 @@ class CreateAccountForm extends Component {
                   )}
                   <input
                     aria-label={LOCALIZE.authentication.createAccount.content.inputs.lastNameTitle}
-                    className={lastNameClassStyle}
+                    className={isValidLastName ? validFieldClass : invalidFieldClass}
                     type="text"
                     placeholder={
                       LOCALIZE.authentication.createAccount.content.inputs.lastNamePlaceholder
@@ -215,7 +218,7 @@ class CreateAccountForm extends Component {
                 )}
                 <input
                   aria-label={LOCALIZE.authentication.createAccount.content.inputs.emailTitle}
-                  className={emailClassStyle}
+                  className={isValidEmail ? validFieldClass : invalidFieldClass}
                   type="text"
                   placeholder={
                     LOCALIZE.authentication.createAccount.content.inputs.emailPlaceholder
@@ -234,7 +237,7 @@ class CreateAccountForm extends Component {
                 )}
                 <input
                   aria-label={LOCALIZE.authentication.createAccount.content.inputs.passwordTitle}
-                  className={passwordClassStyle}
+                  className={isValidPassword ? validFieldClass : invalidFieldClass}
                   type="password"
                   placeholder={
                     LOCALIZE.authentication.createAccount.content.inputs.passwordPlaceholder
@@ -293,7 +296,7 @@ class CreateAccountForm extends Component {
                   aria-label={
                     LOCALIZE.authentication.createAccount.content.inputs.passwordConfirmationTitle
                   }
-                  className={passwordConfirmationClassStyle}
+                  className={isValidPasswordConfirmation ? validFieldClass : invalidFieldClass}
                   type="password"
                   placeholder={
                     LOCALIZE.authentication.createAccount.content.inputs

--- a/frontend/src/components/authentication/CreateAccountForm.jsx
+++ b/frontend/src/components/authentication/CreateAccountForm.jsx
@@ -1,0 +1,331 @@
+import React, { Component } from "react";
+import LOCALIZE from "../../text_resources";
+import validateName, { validateEmail, validatePassword } from "../../helpers/regexValidator";
+import "../../css/create-account-form.css";
+
+const styles = {
+  createAccountContent: {
+    padding: "12px 32px 0 32px"
+  },
+  inputTitle: {
+    padding: "12px 0 6px 0",
+    fontWeight: "bold"
+  },
+  inputs: {
+    width: "100%",
+    padding: "3px 6px 3px 6px",
+    borderRadius: 4
+  },
+  zoneForNames: {
+    display: "flow-root"
+  },
+  inputForNames: {
+    width: 190,
+    padding: "3px 6px 3px 6px",
+    borderRadius: 4
+  },
+  iconForNames: {
+    color: "#278400",
+    position: "absolute",
+    margin: "8px 0 0 170px"
+  },
+  iconForOtherFields: {
+    color: "#278400",
+    position: "absolute",
+    margin: "8px 0 0 370px"
+  },
+  loginBtn: {
+    width: 150,
+    display: "block",
+    margin: "24px auto"
+  },
+  validationError: {
+    color: "red",
+    marginTop: 6
+  }
+};
+
+let SUBMIT_BTN_DISABLED;
+
+class CreateAccountForm extends Component {
+  state = {
+    isFirstPasswordLoad: true,
+    isValidFirstName: false,
+    firstNameClassStyle: "valid-field",
+    isValidLastName: false,
+    lastNameClassStyle: "valid-field",
+    isValidEmail: false,
+    emailClassStyle: "valid-field",
+    isValidPassword: false,
+    passwordClassStyle: "valid-field",
+    isValidPasswordConfirmation: false,
+    passwordConfirmationClassStyle: "valid-field"
+  };
+
+  firstNameValidation = () => {
+    const firstName = document.getElementById("first-name").value;
+    const isValide = validateName(firstName);
+    if (isValide) {
+      this.setState({ isValidFirstName: true, firstNameClassStyle: "valid-field" });
+    } else {
+      this.setState({ isValidFirstName: false, firstNameClassStyle: "invalid-field" });
+    }
+  };
+
+  lastNameValidation = () => {
+    const lastName = document.getElementById("last-name").value;
+    const isValide = validateName(lastName);
+    if (isValide) {
+      this.setState({ isValidLastName: true, lastNameClassStyle: "valid-field" });
+    } else {
+      this.setState({ isValidLastName: false, lastNameClassStyle: "invalid-field" });
+    }
+  };
+
+  emailValidation = () => {
+    const email = document.getElementById("email").value;
+    const isValide = validateEmail(email);
+    if (isValide) {
+      this.setState({ isValidEmail: true, emailClassStyle: "valid-field" });
+    } else {
+      this.setState({ isValidEmail: false, emailClassStyle: "invalid-field" });
+    }
+  };
+
+  passwordValidation = () => {
+    this.setState({ isFirstPasswordLoad: false });
+    const password = document.getElementById("password").value;
+    const isValide = validatePassword(password);
+    const passwordConfirmation = document.getElementById("password-confirmation").value;
+    //Password valid?
+    if (isValide) {
+      this.setState({ isValidPassword: true, passwordClassStyle: "valid-field" });
+    } else {
+      this.setState({ isValidPassword: false, passwordClassStyle: "invalid-field" });
+    }
+    //Password confirmation is the same?
+    if (password === passwordConfirmation) {
+      this.setState({
+        isValidPasswordConfirmation: true,
+        passwordConfirmationClassStyle: "valid-field"
+      });
+    } else {
+      this.setState({
+        isValidPasswordConfirmation: false,
+        passwordConfirmationClassStyle: "invalid-field"
+      });
+    }
+  };
+
+  areAllFieldsValid = () => {
+    const {
+      isValidFirstName,
+      isValidLastName,
+      isValidEmail,
+      isValidPassword,
+      isValidPasswordConfirmation
+    } = this.state;
+
+    if (
+      isValidFirstName &&
+      isValidLastName &&
+      isValidEmail &&
+      isValidPassword &&
+      isValidPasswordConfirmation
+    ) {
+      //did not use state because of maximum update depth exeeded error
+      SUBMIT_BTN_DISABLED = false;
+    } else {
+      SUBMIT_BTN_DISABLED = true;
+    }
+  };
+
+  render() {
+    const {
+      isValidFirstName,
+      isValidLastName,
+      isValidEmail,
+      isValidPassword,
+      isFirstPasswordLoad,
+      firstNameClassStyle,
+      lastNameClassStyle,
+      emailClassStyle,
+      passwordClassStyle,
+      isValidPasswordConfirmation,
+      passwordConfirmationClassStyle
+    } = this.state;
+
+    //check if all fields are valid
+    this.areAllFieldsValid();
+    return (
+      <div>
+        <div>
+          <div style={styles.createAccountContent}>
+            <h3>{LOCALIZE.authentication.createAccount.content.title}</h3>
+            <span>{LOCALIZE.authentication.createAccount.content.description}</span>
+            <form>
+              <div style={styles.zoneForNames}>
+                <div className="float-left">
+                  <div style={styles.inputTitle}>
+                    <span>
+                      {LOCALIZE.authentication.createAccount.content.inputs.firstNameTitle}
+                    </span>
+                  </div>
+                  {isValidFirstName && (
+                    <span className="far fa-check-circle" style={styles.iconForNames} />
+                  )}
+
+                  <input
+                    aria-label={LOCALIZE.authentication.createAccount.content.inputs.firstNameTitle}
+                    className={firstNameClassStyle}
+                    type="text"
+                    placeholder={
+                      LOCALIZE.authentication.createAccount.content.inputs.firstNamePlaceholder
+                    }
+                    id="first-name"
+                    style={styles.inputForNames}
+                    onChange={this.firstNameValidation}
+                  />
+                </div>
+                <div className="float-right">
+                  <div style={styles.inputTitle}>
+                    <span style={styles.inputTitle}>
+                      {LOCALIZE.authentication.createAccount.content.inputs.lastNameTitle}
+                    </span>
+                  </div>
+                  {isValidLastName && (
+                    <span className="far fa-check-circle" style={styles.iconForNames} />
+                  )}
+                  <input
+                    aria-label={LOCALIZE.authentication.createAccount.content.inputs.lastNameTitle}
+                    className={lastNameClassStyle}
+                    type="text"
+                    placeholder={
+                      LOCALIZE.authentication.createAccount.content.inputs.lastNamePlaceholder
+                    }
+                    id="last-name"
+                    style={styles.inputForNames}
+                    onChange={this.lastNameValidation}
+                  />
+                </div>
+              </div>
+              <div>
+                <div style={styles.inputTitle}>
+                  <span>{LOCALIZE.authentication.createAccount.content.inputs.emailTitle}</span>
+                </div>
+                {isValidEmail && (
+                  <span className="far fa-check-circle" style={styles.iconForOtherFields} />
+                )}
+                <input
+                  aria-label={LOCALIZE.authentication.createAccount.content.inputs.emailTitle}
+                  className={emailClassStyle}
+                  type="text"
+                  placeholder={
+                    LOCALIZE.authentication.createAccount.content.inputs.emailPlaceholder
+                  }
+                  id="email"
+                  style={styles.inputs}
+                  onChange={this.emailValidation}
+                />
+              </div>
+              <div>
+                <div style={styles.inputTitle}>
+                  <span>{LOCALIZE.authentication.createAccount.content.inputs.passwordTitle}</span>
+                </div>
+                {isValidPassword && (
+                  <span className="far fa-check-circle" style={styles.iconForOtherFields} />
+                )}
+                <input
+                  aria-label={LOCALIZE.authentication.createAccount.content.inputs.passwordTitle}
+                  className={passwordClassStyle}
+                  type="password"
+                  placeholder={
+                    LOCALIZE.authentication.createAccount.content.inputs.passwordPlaceholder
+                  }
+                  id="password"
+                  style={styles.inputs}
+                  onChange={this.passwordValidation}
+                />
+                {!isValidPassword && !isFirstPasswordLoad && (
+                  <div>
+                    <p style={styles.validationError}>
+                      {
+                        LOCALIZE.authentication.createAccount.content.inputs.passwordErrors
+                          .description
+                      }
+                    </p>
+                    <ul style={styles.validationError}>
+                      <li>
+                        {
+                          LOCALIZE.authentication.createAccount.content.inputs.passwordErrors
+                            .upperCase
+                        }
+                      </li>
+                      <li>
+                        {
+                          LOCALIZE.authentication.createAccount.content.inputs.passwordErrors
+                            .lowerCase
+                        }
+                      </li>
+                      <li>
+                        {LOCALIZE.authentication.createAccount.content.inputs.passwordErrors.digit}
+                      </li>
+                      <li>
+                        {
+                          LOCALIZE.authentication.createAccount.content.inputs.passwordErrors
+                            .specialCharacter
+                        }
+                      </li>
+                      <li>
+                        {LOCALIZE.authentication.createAccount.content.inputs.passwordErrors.length}
+                      </li>
+                    </ul>
+                  </div>
+                )}
+              </div>
+              <div>
+                <div style={styles.inputTitle}>
+                  <span>
+                    {LOCALIZE.authentication.createAccount.content.inputs.passwordConfirmationTitle}
+                  </span>
+                </div>
+                {isValidPasswordConfirmation && (
+                  <span className="far fa-check-circle" style={styles.iconForOtherFields} />
+                )}
+                <input
+                  aria-label={
+                    LOCALIZE.authentication.createAccount.content.inputs.passwordConfirmationTitle
+                  }
+                  className={passwordConfirmationClassStyle}
+                  type="password"
+                  placeholder={
+                    LOCALIZE.authentication.createAccount.content.inputs
+                      .passwordConfirmationPlaceholder
+                  }
+                  id="password-confirmation"
+                  style={styles.inputs}
+                  onChange={this.passwordValidation}
+                />
+                {!isValidPasswordConfirmation && !isFirstPasswordLoad && (
+                  <p style={styles.validationError}>
+                    {LOCALIZE.authentication.createAccount.content.inputs.passwordConfirmationError}
+                  </p>
+                )}
+              </div>
+              <button
+                disabled={SUBMIT_BTN_DISABLED}
+                style={styles.loginBtn}
+                className="btn btn-primary"
+                type="submit"
+              >
+                {LOCALIZE.authentication.createAccount.button}
+              </button>
+            </form>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default CreateAccountForm;

--- a/frontend/src/components/authentication/LoginForm.jsx
+++ b/frontend/src/components/authentication/LoginForm.jsx
@@ -1,0 +1,95 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import LOCALIZE from "../../text_resources";
+
+const styles = {
+  loginContent: {
+    padding: "12px 32px 0 32px"
+  },
+  inputTitles: {
+    padding: "12px 0 6px 0",
+    fontWeight: "bold"
+  },
+  inputs: {
+    width: "100%",
+    padding: "3px 6px 3px 6px",
+    border: "1px solid #00565E",
+    borderRadius: 4
+  },
+  loginBtn: {
+    width: 150,
+    display: "block",
+    margin: "24px auto"
+  },
+  validationError: {
+    color: "red",
+    paddingTop: 8
+  }
+};
+
+class LoginForm extends Component {
+  //TODO(fnormand): Remove this part when implementing login functionality in the backend
+  //===========================================
+  static propTypes = {
+    authentification: PropTypes.func
+  };
+
+  state = {
+    isAuthenticated: false
+  };
+
+  handleSubmit = () => {
+    this.setState({ isAuthenticated: true });
+    this.props.authentification();
+  };
+  //===========================================
+
+  render() {
+    return (
+      <div>
+        {!this.state.isAuthenticated && (
+          <div>
+            <div style={styles.loginContent}>
+              <h3>{LOCALIZE.authentication.login.content.title}</h3>
+              <span>{LOCALIZE.authentication.login.content.description}</span>
+              <form onSubmit={this.handleSubmit}>
+                <div>
+                  <div style={styles.inputTitles}>
+                    <span>{LOCALIZE.authentication.login.content.inputs.emailTitle}</span>
+                  </div>
+                  <input
+                    aria-label={LOCALIZE.authentication.login.content.inputs.emailTitle}
+                    type="text"
+                    placeholder={LOCALIZE.authentication.login.content.inputs.emailPlaceholder}
+                    id="username"
+                    style={styles.inputs}
+                  />
+                </div>
+                <div>
+                  <div style={styles.inputTitles}>
+                    <span>{LOCALIZE.authentication.login.content.inputs.passwordTitle}</span>
+                  </div>
+                  <input
+                    aria-label={LOCALIZE.authentication.login.content.inputs.passwordTitle}
+                    type="password"
+                    placeholder={LOCALIZE.authentication.login.content.inputs.passwordPlaceholder}
+                    id="password"
+                    style={styles.inputs}
+                  />
+                </div>
+                <input
+                  style={styles.loginBtn}
+                  className="btn btn-primary"
+                  type="submit"
+                  value={LOCALIZE.authentication.login.button}
+                />
+              </form>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+export default LoginForm;

--- a/frontend/src/css/create-account-form.css
+++ b/frontend/src/css/create-account-form.css
@@ -2,10 +2,35 @@
 create-account-form.css is used for the CreateAccountForm.jsx styles that cannot be added inside a const
 */
 
+.names-grid {
+  display: -ms-grid;
+  display: grid;
+}
+
+.names-grid-first-name {
+  -ms-grid-column: 1;
+  grid-column: 1;
+  margin-right: 14px;
+}
+
+.names-grid-last-name {
+  -ms-grid-column: 2;
+  grid-column: 2;
+}
+
 .valid-field {
   border: 1px solid #00565e;
 }
 
 .invalid-field {
   border: 3px solid red;
+}
+
+/* this removes the 'clear field (X)' button in IE */
+.valid-field::-ms-clear {
+  display: none;
+}
+
+.invalid-field::-ms-clear {
+  display: none;
 }

--- a/frontend/src/css/create-account-form.css
+++ b/frontend/src/css/create-account-form.css
@@ -1,0 +1,11 @@
+/*
+create-account-form.css is used for the CreateAccountForm.jsx styles that cannot be added inside a const
+*/
+
+.valid-field {
+  border: 1px solid #00565e;
+}
+
+.invalid-field {
+  border: 3px solid red;
+}

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -9,6 +9,55 @@ let LOCALIZE = new LocalizedStrings({
       statusTabTitle: "Status"
     },
 
+    //authentication
+    authentication: {
+      login: {
+        title: "LOG IN",
+        content: {
+          title: "Login",
+          description:
+            "An account is required to proceed further. To log in, enter your credentials below.",
+          inputs: {
+            emailTitle: "Email Address:",
+            emailPlaceholder: "john.smith@outlook.ca",
+            passwordTitle: "Password:",
+            passwordPlaceholder: "Password"
+          }
+        },
+        button: "Login"
+      },
+      createAccount: {
+        title: "CREATE AN ACCOUNT",
+        content: {
+          title: "Create an account",
+          description:
+            "An account is required to proceed further. To create an account, fill out the following.",
+          inputs: {
+            firstNameTitle: "First Name:",
+            firstNamePlaceholder: "John",
+            lastNameTitle: "Last Name:",
+            lastNamePlaceholder: "Smith",
+            emailTitle: "Email Address:",
+            emailPlaceholder: "john.smith@outlook.ca",
+            passwordTitle: "Password (must be between 5-15 characters):",
+            passwordPlaceholder: "Password",
+            passwordErrors: {
+              description: "Your password must satisfy the following:",
+              upperCase: "At least one upper case",
+              lowerCase: "At least one lower case",
+              digit: "At least one digit",
+              specialCharacter: "At least one special character",
+              length: "Minimum of 5 characters and maximum of 15"
+            },
+            passwordConfirmationTitle: "Confirm Password:",
+            passwordConfirmationPlaceholder: "Password",
+            passwordConfirmationError: "Must match the Password"
+          }
+        },
+        button: "Create account"
+      }
+    },
+
     //Home Page
     homePage: {
       title: "The Public Service Commission's Competency Assessment Tool",
@@ -419,7 +468,8 @@ let LOCALIZE = new LocalizedStrings({
       mainMenu: "Main Menu",
       tabMenu: "eMIB Tab Menu",
       instructionsMenu: "Instructions Menu",
-      languageToggleBtn: "language-toggle-button"
+      languageToggleBtn: "language-toggle-button",
+      authenticationMenu: "Authentication Menu"
     },
 
     //Commons
@@ -453,6 +503,55 @@ let LOCALIZE = new LocalizedStrings({
       homeTabTitle: "Accueil",
       prototypeTabTitle: "Prototype",
       statusTabTitle: "Statut"
+    },
+
+    //authentication
+    authentication: {
+      login: {
+        title: "SE CONNECTER",
+        content: {
+          title: "Connexion",
+          description:
+            "FR An account is required to proceed further. To log in, enter your credentials below.",
+          inputs: {
+            emailTitle: "Adresse courriel :",
+            emailPlaceholder: "john.smith@outlook.ca",
+            passwordTitle: "Mot de passe :",
+            passwordPlaceholder: "Mot de passe"
+          }
+        },
+        button: "Connexion"
+      },
+      createAccount: {
+        title: "CRÉER UN COMPTE",
+        content: {
+          title: "Créer un compte",
+          description:
+            "FR An account is required to proceed further. To create an account, fill out the following.",
+          inputs: {
+            firstNameTitle: "Prénom :",
+            firstNamePlaceholder: "John",
+            lastNameTitle: "Nom de famille :",
+            lastNamePlaceholder: "Smith",
+            emailTitle: "Adresse courriel :",
+            emailPlaceholder: "john.smith@outlook.ca",
+            passwordTitle: "Mot de passe (doit contenir entre 5-15 caractères) :",
+            passwordPlaceholder: "Mot de passe",
+            passwordErrors: {
+              description: "Votre mot de passe doit satisfaire les critères suivants :",
+              upperCase: "Au moins une majuscule",
+              lowerCase: "Au moins une minuscule",
+              digit: "Au moins un chiffre",
+              specialCharacter: "Au moins un caractère spécial",
+              length: "Au moins 5 caractères et maximum 15"
+            },
+            passwordConfirmationTitle: "Confirmer le mot de passe :",
+            passwordConfirmationPlaceholder: "Mot de passe",
+            passwordConfirmationError: "Doit correspondre au mot de passe"
+          }
+        },
+        button: "Créer compte"
+      }
     },
 
     //Home Page
@@ -873,7 +972,8 @@ let LOCALIZE = new LocalizedStrings({
       mainMenu: "Menu Principal",
       tabMenu: "Menu des onglets de la BRG-e",
       instructionsMenu: "Menu des instructions",
-      languageToggleBtn: "bouton-de-langue-a-bascule"
+      languageToggleBtn: "bouton-de-langue-a-bascule",
+      authenticationMenu: "Menu d'authentification"
     },
 
     //Commons


### PR DESCRIPTION
# Description

I implemented some new authentication components, meaning one for the login and one for the account creation.

**Login:**
There is no validation at all in this component. As soon as you click _Login_, you'll be redirected to the home page with a welcome message. Basic authentication logic has been used to produce this fake login behavior. This will be removed once we'll introduce the back end implementation of the login feature.

Note that as soon as you refresh or change the page, the login process will restart, meaning that you will not stay logged in for now.

**Created Account:**
In this component, there is a lot of validation. All fields are validated using RegEx validation (see PR https://github.com/code-for-canada/project-thundercat/pull/154). Also, the _Create account_ button stay disabled as long as all the validations are not satisfied. We'll have to implement the Submit data in the back end in the future for this component.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**Login Page:**

![image](https://user-images.githubusercontent.com/23021242/55151950-b98a5000-5125-11e9-93b7-1a3c6173720d.png)

**As soon as you click _Login_:**

![image](https://user-images.githubusercontent.com/23021242/55152095-09691700-5126-11e9-958f-36e1a15ec982.png)

**Create Account Page:**

![image](https://user-images.githubusercontent.com/23021242/55152154-24d42200-5126-11e9-88b6-c8cc97656135.png)

**Validation Examples:**

_First Name contains a special character_
![image](https://user-images.githubusercontent.com/23021242/55152240-53ea9380-5126-11e9-88ee-f522066ae50c.png)

_Missing '@' in Email Address_
![image](https://user-images.githubusercontent.com/23021242/55152322-83999b80-5126-11e9-88ec-2177742be0a3.png)

_Password that doesn't satisfy all the requirements_
![image](https://user-images.githubusercontent.com/23021242/55152378-a4fa8780-5126-11e9-883d-dbca63d4d697.png)

_Password Confirmation that isn't the same as the Password_
![image](https://user-images.githubusercontent.com/23021242/55152417-bd6aa200-5126-11e9-8526-14162089c505.png)

**When every validations are satisfied (the button becomes enabled):**

![image](https://user-images.githubusercontent.com/23021242/55152518-f0ad3100-5126-11e9-8b88-c91ba70617e2.png)

# Testing

Manual steps to reproduce this functionality:

1.  Go to _Home_ page.
2.  Play with the _Login_ and _Create Account_ forms and make sure everything works/looks good.

**Note that only front end implementation has been done, so there is no submission, logging control, logout functionality, etc.**

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
