### PR TITLE
[Inbox] Abbreviate email preview

### DIFF
--- a/frontend/src/components/eMIB/EmailPreview.jsx
+++ b/frontend/src/components/eMIB/EmailPreview.jsx
@@ -43,6 +43,11 @@ const styles = {
   },
   subjectUnread: {
     fontWeight: "bold"
+  },
+  truncated: {
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis"
   }
 };
 
@@ -78,7 +83,7 @@ class EmailPreview extends Component {
     }
 
     let buttonStyle = { ...styles.button, ...buttonTextColor, ...buttonBackgroundColor };
-    let subject = { ...subjectIsRead, ...subjectIsSelected };
+    let subject = { ...subjectIsRead, ...subjectIsSelected, ...styles.truncated };
     const email = this.props.email;
     return (
       <li
@@ -103,7 +108,7 @@ class EmailPreview extends Component {
             {this.props.isRepliedTo && <i className="fas fa-sign-out-alt" />}
           </div>
           <div style={subject}>{email.subject}</div>
-          <div>{email.from}</div>
+          <div style={styles.truncated}>{email.from}</div>
         </div>
       </li>
     );

--- a/frontend/src/components/eMIB/EmailPreview.jsx
+++ b/frontend/src/components/eMIB/EmailPreview.jsx
@@ -60,6 +60,15 @@ class EmailPreview extends Component {
     isSelected: PropTypes.bool.isRequired
   };
 
+  // if there is a "(" in the From field, remove it and return
+  trimFromName(string) {
+    let index = string.indexOf("(");
+    if (index === -1) {
+      return string;
+    }
+    return string.slice(0, index);
+  }
+
   render() {
     //READ/UNREAD CHECK
     //defaults, or if unread
@@ -108,7 +117,7 @@ class EmailPreview extends Component {
             {this.props.isRepliedTo && <i className="fas fa-sign-out-alt" />}
           </div>
           <div style={subject}>{email.subject}</div>
-          <div style={styles.truncated}>{email.from}</div>
+          <div style={styles.truncated}>{this.trimFromName(email.from)}</div>
         </div>
       </li>
     );

--- a/frontend/src/components/eMIB/EmailPreview.jsx
+++ b/frontend/src/components/eMIB/EmailPreview.jsx
@@ -60,7 +60,9 @@ class EmailPreview extends Component {
     isSelected: PropTypes.bool.isRequired
   };
 
-  // if there is a "(" in the From field, remove it and return
+  // if there is a "(" in the From field of the preview, remove it and return the remainder
+  // When there is a database, the () portion of the To/From may be populated by a seperate field
+  // but this will remove it until the design is finalized
   trimFromName(string) {
     let index = string.indexOf("(");
     if (index === -1) {


### PR DESCRIPTION
# Description

Added formatting to truncate the subject and from lines in the email preview;
Added logic to drop everything after the first "(" in the from line.

## Type of change

- Code cleanliness or refactor

## Screenshot

![image](https://user-images.githubusercontent.com/2746350/55325584-8a404f80-5453-11e9-8f00-83775dc34117.png)

# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Go to Prototype -> Start eMIB
2. Navigate through pre-test instructions
3. Start Test
4. Open the Inbox tab

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
