### PR TITLE
[Email] Format email header

### DIFF
--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -55,10 +55,10 @@ class Email extends Component {
     return (
       <div style={styles.email}>
         <div style={styles.header}>
-          <h6 style={styles.emailId}>
+          <h2 style={styles.emailId} className="emailId">
             {LOCALIZE.emibTest.inboxPage.emailId.toUpperCase()}
             {email.id + 1}
-          </h6>
+          </h2>
           {this.props.isRepliedTo && (
             <div className="font-weight-bold" style={styles.replyStatus}>
               <i className="fas fa-sign-out-alt" style={styles.replyAndUser} />

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -9,7 +9,15 @@ const styles = {
   },
   emailId: {
     float: "left",
-    marginRight: 12
+    marginRight: 12,
+    fontSize: 16,
+    fontWeight: 700,
+    fontFamily: '"Nunito Sans", sans-serif',
+    color: "black",
+    marginBottom: 8,
+    marginTop: 0,
+    WebkitMarginAfter: 8,
+    WebkitMarginBefore: 0
   },
   replyStatus: {
     float: "right"

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -12,7 +12,6 @@ const styles = {
     marginRight: 12,
     fontSize: 16,
     fontWeight: 700,
-    fontFamily: '"Nunito Sans", sans-serif',
     color: "black",
     marginBottom: 8,
     marginTop: 0,

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -12,11 +12,9 @@ const styles = {
     marginRight: 12,
     fontSize: 16,
     fontWeight: 700,
-    color: "black",
+    color: "#252525",
     marginBottom: 8,
-    marginTop: 0,
-    WebkitMarginAfter: 8,
-    WebkitMarginBefore: 0
+    marginTop: 0
   },
   replyStatus: {
     float: "right"

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -63,7 +63,7 @@ class Email extends Component {
     return (
       <div style={styles.email}>
         <div style={styles.header}>
-          <h2 style={styles.emailId} className="emailId">
+          <h2 style={styles.emailId}>
             {LOCALIZE.emibTest.inboxPage.emailId.toUpperCase()}
             {email.id + 1}
           </h2>

--- a/frontend/src/components/eMIB/EmailPreview.jsx
+++ b/frontend/src/components/eMIB/EmailPreview.jsx
@@ -119,7 +119,7 @@ class EmailPreview extends Component {
             )}
             &nbsp;
             {LOCALIZE.emibTest.inboxPage.emailId}
-            {email.id + 1}&emsp;
+            {email.id + 1}
             {this.props.isRepliedTo && (
               <i className="fas fa-sign-out-alt" style={{ float: "right", ...imageStyle }} />
             )}

--- a/frontend/src/css/inbox.css
+++ b/frontend/src/css/inbox.css
@@ -19,14 +19,3 @@ styles that cannot be added inside a const
   -ms-grid-column: 2;
   grid-column: 2;
 }
-
-h2.emailId {
-  font-size: 16px;
-  font-weight: 700;
-  color: black;
-  margin-bottom: 8px;
-  margin-top: 0px;
-  -webkit-margin-after: 8px;
-  -webkit-margin-before: 0px;
-  font-family: "Nunito Sans", sans-serif;
-}

--- a/frontend/src/css/inbox.css
+++ b/frontend/src/css/inbox.css
@@ -19,3 +19,14 @@ styles that cannot be added inside a const
   -ms-grid-column: 2;
   grid-column: 2;
 }
+
+h2.emailId {
+  font-size: 16px;
+  font-weight: 700;
+  color: black;
+  margin-bottom: 8px;
+  margin-top: 0px;
+  -webkit-margin-after: 8px;
+  -webkit-margin-before: 0px;
+  font-family: "Nunito Sans", sans-serif;
+}


### PR DESCRIPTION
# Description

Changing the tag of the 'Email #x" from h6 to h2, but making it look like an h6 to meet look and feel.

## Type of change

- Code cleanliness or refactor

## Screenshot

No visual difference (which was the point)

# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Go to Prototype -> Start eMIB -> pre-test instructions -> Start Test
2.  Open the Inbox Tab
3. Look at the email view

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
