### PR TITLE
[View Emails/Task] Created new generic collapsing item component to view emails and tasks

### DIFF
--- a/frontend/src/components/eMIB/CollapsingItemContainer.jsx
+++ b/frontend/src/components/eMIB/CollapsingItemContainer.jsx
@@ -1,0 +1,82 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import "../../css/collapsing-item.css";
+
+const styles = {
+  container: {
+    position: "relative"
+  },
+  button: {
+    width: "100%",
+    textAlign: "left"
+  },
+  envelopeIcon: {
+    marginRight: 6
+  },
+  collapsingIcon: {
+    position: "absolute",
+    top: 0,
+    right: 0,
+    margin: "11px 24px 0 0",
+    color: "#00565E",
+    pointerEvents: "none"
+  },
+  contentContainer: {
+    margin: 12
+  }
+};
+
+export const ICON_TYPE = {
+  email: "fas fa-envelope",
+  task: "fas fa-tasks"
+};
+
+class CollapsingItemContainer extends Component {
+  static propTypes = {
+    iconType: PropTypes.string,
+    title: PropTypes.string.isRequired,
+    body: PropTypes.object.isRequired
+  };
+
+  state = {
+    isHidden: true,
+    buttonClass: "btn btn-secondary",
+    iconClass: "fas fa-angle-down",
+    containerClass: ""
+  };
+
+  expandItem = () => {
+    if (this.state.isHidden) {
+      this.setState({
+        isHidden: false,
+        buttonClass: "btn btn-primary expanded-button-style",
+        iconClass: "fas fa-angle-up expand-icon-style",
+        containerClass: "expanded-container-style"
+      });
+    } else {
+      this.setState({
+        isHidden: true,
+        buttonClass: "btn btn-secondary",
+        iconClass: "fas fa-angle-down",
+        containerClass: ""
+      });
+    }
+  };
+
+  render() {
+    const { iconType, title, body } = this.props;
+    const { isHidden, buttonClass, iconClass, containerClass } = this.state;
+    return (
+      <div className={`${containerClass} collapsing-item-container`} style={styles.container}>
+        <button className={buttonClass} style={styles.button} onClick={this.expandItem}>
+          <span className={iconType} style={styles.envelopeIcon} />
+          {title}
+        </button>
+        <span className={`${iconClass} expand-icon`} style={styles.collapsingIcon} />
+        {!isHidden && <div style={styles.contentContainer}>{body}</div>}
+      </div>
+    );
+  }
+}
+
+export default CollapsingItemContainer;

--- a/frontend/src/components/eMIB/CollapsingItemContainer.jsx
+++ b/frontend/src/components/eMIB/CollapsingItemContainer.jsx
@@ -13,12 +13,11 @@ const styles = {
   envelopeIcon: {
     marginRight: 6
   },
-  collapsingIcon: {
+  expandIcon: {
     position: "absolute",
     top: 0,
     right: 0,
     margin: "11px 24px 0 0",
-    color: "#00565E",
     pointerEvents: "none"
   },
   contentContainer: {
@@ -41,7 +40,7 @@ class CollapsingItemContainer extends Component {
   state = {
     isCollapsed: true,
     buttonClass: "btn btn-secondary",
-    iconClass: "fas fa-angle-down",
+    iconClass: "fas fa-angle-down blue-expand-icon",
     containerClass: ""
   };
 
@@ -50,14 +49,14 @@ class CollapsingItemContainer extends Component {
       this.setState({
         isCollapsed: false,
         buttonClass: "btn btn-primary expanded-button-style",
-        iconClass: "fas fa-angle-up expand-icon-style",
+        iconClass: "fas fa-angle-up white-expand-icon",
         containerClass: "expanded-container-style"
       });
     } else {
       this.setState({
         isCollapsed: true,
         buttonClass: "btn btn-secondary",
-        iconClass: "fas fa-angle-down",
+        iconClass: "fas fa-angle-down blue-expand-icon",
         containerClass: ""
       });
     }
@@ -72,7 +71,7 @@ class CollapsingItemContainer extends Component {
           <span className={iconType} style={styles.envelopeIcon} />
           {title}
         </button>
-        <span className={`${iconClass} expand-icon`} style={styles.collapsingIcon} />
+        <span id="white-expand-icon-on-hover" className={iconClass} style={styles.expandIcon} />
         {!isCollapsed && <div style={styles.contentContainer}>{body}</div>}
       </div>
     );

--- a/frontend/src/components/eMIB/CollapsingItemContainer.jsx
+++ b/frontend/src/components/eMIB/CollapsingItemContainer.jsx
@@ -39,23 +39,23 @@ class CollapsingItemContainer extends Component {
   };
 
   state = {
-    isHidden: true,
+    isCollapsed: true,
     buttonClass: "btn btn-secondary",
     iconClass: "fas fa-angle-down",
     containerClass: ""
   };
 
   expandItem = () => {
-    if (this.state.isHidden) {
+    if (this.state.isCollapsed) {
       this.setState({
-        isHidden: false,
+        isCollapsed: false,
         buttonClass: "btn btn-primary expanded-button-style",
         iconClass: "fas fa-angle-up expand-icon-style",
         containerClass: "expanded-container-style"
       });
     } else {
       this.setState({
-        isHidden: true,
+        isCollapsed: true,
         buttonClass: "btn btn-secondary",
         iconClass: "fas fa-angle-down",
         containerClass: ""
@@ -65,7 +65,7 @@ class CollapsingItemContainer extends Component {
 
   render() {
     const { iconType, title, body } = this.props;
-    const { isHidden, buttonClass, iconClass, containerClass } = this.state;
+    const { isCollapsed, buttonClass, iconClass, containerClass } = this.state;
     return (
       <div className={`${containerClass} collapsing-item-container`} style={styles.container}>
         <button className={buttonClass} style={styles.button} onClick={this.expandItem}>
@@ -73,7 +73,7 @@ class CollapsingItemContainer extends Component {
           {title}
         </button>
         <span className={`${iconClass} expand-icon`} style={styles.collapsingIcon} />
-        {!isHidden && <div style={styles.contentContainer}>{body}</div>}
+        {!isCollapsed && <div style={styles.contentContainer}>{body}</div>}
       </div>
     );
   }

--- a/frontend/src/components/eMIB/CollapsingItemContainer.jsx
+++ b/frontend/src/components/eMIB/CollapsingItemContainer.jsx
@@ -63,10 +63,10 @@ class CollapsingItemContainer extends Component {
     return (
       <div className={`${containerClass} collapsing-item-container`} style={styles.container}>
         <button className={buttonClass} style={styles.button} onClick={this.expandItem}>
-          <span className={iconType} style={styles.envelopeIcon} />
+          <i className={iconType} style={styles.envelopeIcon} />
           {title}
         </button>
-        <span id="white-expand-icon-on-hover" className={iconClass} style={styles.expandIcon} />
+        <i id="white-expand-icon-on-hover" className={iconClass} style={styles.expandIcon} />
         {!isCollapsed && <div style={styles.contentContainer}>{body}</div>}
       </div>
     );

--- a/frontend/src/components/eMIB/CollapsingItemContainer.jsx
+++ b/frontend/src/components/eMIB/CollapsingItemContainer.jsx
@@ -42,11 +42,7 @@ class CollapsingItemContainer extends Component {
   };
 
   expandItem = () => {
-    if (this.state.isCollapsed) {
-      this.setState({ isCollapsed: false });
-    } else {
-      this.setState({ isCollapsed: true });
-    }
+    this.setState({ isCollapsed: !this.state.isCollapsed });
   };
 
   render() {

--- a/frontend/src/components/eMIB/CollapsingItemContainer.jsx
+++ b/frontend/src/components/eMIB/CollapsingItemContainer.jsx
@@ -46,25 +46,27 @@ class CollapsingItemContainer extends Component {
 
   expandItem = () => {
     if (this.state.isCollapsed) {
-      this.setState({
-        isCollapsed: false,
-        buttonClass: "btn btn-primary expanded-button-style",
-        iconClass: "fas fa-angle-up white-expand-icon",
-        containerClass: "expanded-container-style"
-      });
+      this.setState({ isCollapsed: false });
     } else {
-      this.setState({
-        isCollapsed: true,
-        buttonClass: "btn btn-secondary",
-        iconClass: "fas fa-angle-down blue-expand-icon",
-        containerClass: ""
-      });
+      this.setState({ isCollapsed: true });
     }
   };
 
   render() {
     const { iconType, title, body } = this.props;
-    const { isCollapsed, buttonClass, iconClass, containerClass } = this.state;
+    const { isCollapsed } = this.state;
+    let { buttonClass, iconClass, containerClass } = "";
+
+    if (isCollapsed) {
+      buttonClass = "btn btn-secondary";
+      iconClass = "fas fa-angle-down blue-expand-icon";
+      containerClass = "";
+    } else if (!isCollapsed) {
+      buttonClass = "btn btn-primary expanded-button-style";
+      iconClass = "fas fa-angle-up white-expand-icon";
+      containerClass = "expanded-container-style";
+    }
+
     return (
       <div className={`${containerClass} collapsing-item-container`} style={styles.container}>
         <button className={buttonClass} style={styles.button} onClick={this.expandItem}>

--- a/frontend/src/components/eMIB/CollapsingItemContainer.jsx
+++ b/frontend/src/components/eMIB/CollapsingItemContainer.jsx
@@ -38,10 +38,7 @@ class CollapsingItemContainer extends Component {
   };
 
   state = {
-    isCollapsed: true,
-    buttonClass: "btn btn-secondary",
-    iconClass: "fas fa-angle-down blue-expand-icon",
-    containerClass: ""
+    isCollapsed: true
   };
 
   expandItem = () => {

--- a/frontend/src/css/collapsing-item.css
+++ b/frontend/src/css/collapsing-item.css
@@ -2,16 +2,20 @@
 collapsing-item.css is used for the CollapsingItemContainer.jsx styles that cannot be added inside a const
 */
 
-.collapsing-item-container:hover .expand-icon {
-  color: white !important;
+.collapsing-item-container:hover #white-expand-icon-on-hover {
+  color: white;
 }
 
 .expanded-button-style {
   border-radius: 5px 5px 0 0;
 }
 
-.expand-icon-style {
-  color: white !important;
+.white-expand-icon {
+  color: white;
+}
+
+.blue-expand-icon {
+  color: #00565e;
 }
 
 .expanded-container-style {

--- a/frontend/src/css/collapsing-item.css
+++ b/frontend/src/css/collapsing-item.css
@@ -1,0 +1,24 @@
+/*
+collapsing-item.css is used for the CollapsingItemContainer.jsx styles that cannot be added inside a const
+*/
+
+.collapsing-item-container:hover .expand-icon {
+  color: white !important;
+}
+
+.expanded-button-style {
+  border-radius: 5px 5px 0 0;
+}
+
+.expand-icon-style {
+  color: white !important;
+}
+
+.expanded-container-style {
+  width: "100%";
+  min-height: 200px;
+  border-style: solid;
+  border-color: #00565e;
+  border-width: 0 1px 1px 1px;
+  border-radius: 5px;
+}

--- a/frontend/src/tests/components/eMIB/CollapsingItemContainer.test.js
+++ b/frontend/src/tests/components/eMIB/CollapsingItemContainer.test.js
@@ -1,0 +1,132 @@
+import React from "react";
+import { shallow } from "enzyme";
+import CollapsingItemContainer, {
+  ICON_TYPE
+} from "../../../components/eMIB/CollapsingItemContainer";
+
+const body = { body: <div>body</div> };
+
+it("renders the right icon types (email, task)", () => {
+  //email
+  const emailWrapper = shallow(
+    <CollapsingItemContainer iconType={ICON_TYPE.email} title={"title"} body={body} />
+  );
+
+  //task
+  const taskWrapper = shallow(
+    <CollapsingItemContainer iconType={ICON_TYPE.task} title={"title"} body={<div>body</div>} />
+  );
+
+  const buttonWithEmailIcon = (
+    <button>
+      <span className="fas fa-envelope" />
+      title
+    </button>
+  );
+
+  const buttonWithTaskIcon = (
+    <button>
+      <span className="fas fa-tasks" />
+      title
+    </button>
+  );
+
+  //email
+  expect(emailWrapper.containsMatchingElement(buttonWithEmailIcon)).toEqual(true);
+  expect(emailWrapper.containsMatchingElement(buttonWithTaskIcon)).toEqual(false);
+
+  //task
+  expect(taskWrapper.containsMatchingElement(buttonWithEmailIcon)).toEqual(false);
+  expect(taskWrapper.containsMatchingElement(buttonWithTaskIcon)).toEqual(true);
+});
+
+it("renders the right arrow (up, down) icons when closed or expanded", () => {
+  const simulateExpanded = () => {
+    wrapper.setState({
+      buttonClass: "btn btn-primary expanded-button-style",
+      iconClass: "fas fa-angle-up expand-icon-style",
+      containerClass: "expanded-container-style"
+    });
+  };
+
+  const simulateClosed = () => {
+    wrapper.setState({
+      buttonClass: "btn btn-secondary",
+      iconClass: "fas fa-angle-down",
+      containerClass: ""
+    });
+  };
+
+  const wrapper = shallow(
+    <CollapsingItemContainer iconType={ICON_TYPE.email} title={"title"} body={body} />
+  );
+
+  const arrowDownIconDisplayed = (
+    <div className=" collapsing-item-container">
+      <button className="btn btn-secondary">
+        <span className={ICON_TYPE.email} />
+        title
+      </button>
+      <span className="fas fa-angle-down expand-icon" />
+    </div>
+  );
+  const arrowUpIconDisplayed = (
+    <div className="expanded-container-style collapsing-item-container">
+      <button>
+        <span className={ICON_TYPE.email} />
+        title
+      </button>
+      <span className="fas fa-angle-up expand-icon-style expand-icon" />
+      <div>{body}</div>
+    </div>
+  );
+
+  //arrow 'down' icon displayed
+  wrapper.setState({ isHidden: true });
+  simulateClosed();
+  expect(wrapper.containsMatchingElement(arrowDownIconDisplayed)).toEqual(true);
+  expect(wrapper.containsMatchingElement(arrowUpIconDisplayed)).toEqual(false);
+
+  //arrow 'up' icon displayed
+  wrapper.setState({ isHidden: false });
+  simulateExpanded();
+  expect(wrapper.containsMatchingElement(arrowDownIconDisplayed)).toEqual(false);
+  expect(wrapper.containsMatchingElement(arrowUpIconDisplayed)).toEqual(true);
+});
+
+it("renders title and/or body depending on the 'isHidden' state", () => {
+  const wrapper = shallow(
+    <CollapsingItemContainer iconType={ICON_TYPE.email} title={"title"} body={body} />
+  );
+
+  //display only title
+  const contentWhenClosed = (
+    <div>
+      <button>
+        <span />
+        title
+      </button>
+      <span />
+    </div>
+  );
+
+  //display title and body
+  const contentWhenExpanded = (
+    <div>
+      <button>
+        <span />
+        title
+      </button>
+      <span />
+      <div>{body}</div>
+    </div>
+  );
+
+  //collapsing item is closed
+  wrapper.setState({ isHidden: true });
+  expect(wrapper.containsMatchingElement(contentWhenClosed)).toEqual(true);
+
+  //collapsing item is expanded
+  wrapper.setState({ isHidden: false });
+  expect(wrapper.containsMatchingElement(contentWhenExpanded)).toEqual(true);
+});

--- a/frontend/src/tests/components/eMIB/CollapsingItemContainer.test.js
+++ b/frontend/src/tests/components/eMIB/CollapsingItemContainer.test.js
@@ -4,14 +4,13 @@ import CollapsingItemContainer, {
   ICON_TYPE
 } from "../../../components/eMIB/CollapsingItemContainer";
 
-const body = { body: <div>body</div> };
 describe("Icons content types", () => {
   const emailIcon = <i className="fas fa-envelope" />;
   const taskIcon = <i className="fas fa-tasks" />;
 
   it("renders email icon", () => {
     const emailWrapper = shallow(
-      <CollapsingItemContainer iconType={ICON_TYPE.email} title={"title"} body={body} />
+      <CollapsingItemContainer iconType={ICON_TYPE.email} title={"title"} body={<div>body</div>} />
     );
     expect(emailWrapper.containsMatchingElement(emailIcon)).toEqual(true);
     expect(emailWrapper.containsMatchingElement(taskIcon)).toEqual(false);
@@ -28,7 +27,7 @@ describe("Icons content types", () => {
 
 describe("Icons collapsing types", () => {
   const wrapper = shallow(
-    <CollapsingItemContainer iconType={ICON_TYPE.email} title={"title"} body={body} />
+    <CollapsingItemContainer iconType={ICON_TYPE.email} title={"title"} body={<div>body</div>} />
   );
 
   const arrowDownIconDisplayed = <i className="fas fa-angle-down blue-expand-icon" />;
@@ -47,39 +46,25 @@ describe("Icons collapsing types", () => {
   });
 });
 
-/*it("renders title and/or body depending on the 'isCollapsed ' state", () => {
+it("renders title and/or body depending on the 'isCollapsed ' state", () => {
   const wrapper = shallow(
-    <CollapsingItemContainer iconType={ICON_TYPE.email} title={"title"} body={body} />
+    <CollapsingItemContainer iconType={ICON_TYPE.email} title={"title"} body={<div>body</div>} />
   );
-
-  //display only title
-  const contentWhenClosed = (
-    <div>
-      <button>
-        <span />
-        title
-      </button>
-      <span />
-    </div>
+  const titleComponent = (
+    <button>
+      <i />
+      title
+    </button>
   );
-
-  //display title and body
-  const contentWhenExpanded = (
-    <div>
-      <button>
-        <span />
-        title
-      </button>
-      <span />
-      <div>{body}</div>
-    </div>
-  );
+  const bodyComponent = <div>body</div>;
 
   //collapsing item is closed
   wrapper.setState({ isCollapsed: true });
-  expect(wrapper.containsMatchingElement(contentWhenClosed)).toEqual(true);
+  expect(wrapper.containsMatchingElement(titleComponent)).toEqual(true);
+  expect(wrapper.containsMatchingElement(bodyComponent)).toEqual(false);
 
   //collapsing item is expanded
   wrapper.setState({ isCollapsed: false });
-  expect(wrapper.containsMatchingElement(contentWhenExpanded)).toEqual(true);
-});*/
+  expect(wrapper.containsMatchingElement(titleComponent)).toEqual(true);
+  expect(wrapper.containsMatchingElement(bodyComponent)).toEqual(true);
+});

--- a/frontend/src/tests/components/eMIB/CollapsingItemContainer.test.js
+++ b/frontend/src/tests/components/eMIB/CollapsingItemContainer.test.js
@@ -44,7 +44,7 @@ it("renders the right arrow (up, down) icons when closed or expanded", () => {
   const simulateExpanded = () => {
     wrapper.setState({
       buttonClass: "btn btn-primary expanded-button-style",
-      iconClass: "fas fa-angle-up expand-icon-style",
+      iconClass: "fas fa-angle-up white-expand-icon",
       containerClass: "expanded-container-style"
     });
   };
@@ -52,7 +52,7 @@ it("renders the right arrow (up, down) icons when closed or expanded", () => {
   const simulateClosed = () => {
     wrapper.setState({
       buttonClass: "btn btn-secondary",
-      iconClass: "fas fa-angle-down",
+      iconClass: "fas fa-angle-down blue-expand-icon",
       containerClass: ""
     });
   };
@@ -67,7 +67,7 @@ it("renders the right arrow (up, down) icons when closed or expanded", () => {
         <span className={ICON_TYPE.email} />
         title
       </button>
-      <span className="fas fa-angle-down expand-icon" />
+      <span className="fas fa-angle-down blue-expand-icon" />
     </div>
   );
   const arrowUpIconDisplayed = (
@@ -76,7 +76,7 @@ it("renders the right arrow (up, down) icons when closed or expanded", () => {
         <span className={ICON_TYPE.email} />
         title
       </button>
-      <span className="fas fa-angle-up expand-icon-style expand-icon" />
+      <span className="fas fa-angle-up white-expand-icon" />
       <div>{body}</div>
     </div>
   );

--- a/frontend/src/tests/components/eMIB/CollapsingItemContainer.test.js
+++ b/frontend/src/tests/components/eMIB/CollapsingItemContainer.test.js
@@ -82,19 +82,19 @@ it("renders the right arrow (up, down) icons when closed or expanded", () => {
   );
 
   //arrow 'down' icon displayed
-  wrapper.setState({ isHidden: true });
+  wrapper.setState({ isCollapsed: true });
   simulateClosed();
   expect(wrapper.containsMatchingElement(arrowDownIconDisplayed)).toEqual(true);
   expect(wrapper.containsMatchingElement(arrowUpIconDisplayed)).toEqual(false);
 
   //arrow 'up' icon displayed
-  wrapper.setState({ isHidden: false });
+  wrapper.setState({ isCollapsed: false });
   simulateExpanded();
   expect(wrapper.containsMatchingElement(arrowDownIconDisplayed)).toEqual(false);
   expect(wrapper.containsMatchingElement(arrowUpIconDisplayed)).toEqual(true);
 });
 
-it("renders title and/or body depending on the 'isHidden' state", () => {
+it("renders title and/or body depending on the 'isCollapsed ' state", () => {
   const wrapper = shallow(
     <CollapsingItemContainer iconType={ICON_TYPE.email} title={"title"} body={body} />
   );
@@ -123,10 +123,10 @@ it("renders title and/or body depending on the 'isHidden' state", () => {
   );
 
   //collapsing item is closed
-  wrapper.setState({ isHidden: true });
+  wrapper.setState({ isCollapsed: true });
   expect(wrapper.containsMatchingElement(contentWhenClosed)).toEqual(true);
 
   //collapsing item is expanded
-  wrapper.setState({ isHidden: false });
+  wrapper.setState({ isCollapsed: false });
   expect(wrapper.containsMatchingElement(contentWhenExpanded)).toEqual(true);
 });

--- a/frontend/src/tests/components/eMIB/CollapsingItemContainer.test.js
+++ b/frontend/src/tests/components/eMIB/CollapsingItemContainer.test.js
@@ -41,22 +41,6 @@ it("renders the right icon types (email, task)", () => {
 });
 
 it("renders the right arrow (up, down) icons when closed or expanded", () => {
-  const simulateExpanded = () => {
-    wrapper.setState({
-      buttonClass: "btn btn-primary expanded-button-style",
-      iconClass: "fas fa-angle-up white-expand-icon",
-      containerClass: "expanded-container-style"
-    });
-  };
-
-  const simulateClosed = () => {
-    wrapper.setState({
-      buttonClass: "btn btn-secondary",
-      iconClass: "fas fa-angle-down blue-expand-icon",
-      containerClass: ""
-    });
-  };
-
   const wrapper = shallow(
     <CollapsingItemContainer iconType={ICON_TYPE.email} title={"title"} body={body} />
   );
@@ -81,15 +65,13 @@ it("renders the right arrow (up, down) icons when closed or expanded", () => {
     </div>
   );
 
-  //arrow 'down' icon displayed
+  //arrow 'down' icon displayed (when closed)
   wrapper.setState({ isCollapsed: true });
-  simulateClosed();
   expect(wrapper.containsMatchingElement(arrowDownIconDisplayed)).toEqual(true);
   expect(wrapper.containsMatchingElement(arrowUpIconDisplayed)).toEqual(false);
 
-  //arrow 'up' icon displayed
+  //arrow 'up' icon displayed (when expanded)
   wrapper.setState({ isCollapsed: false });
-  simulateExpanded();
   expect(wrapper.containsMatchingElement(arrowDownIconDisplayed)).toEqual(false);
   expect(wrapper.containsMatchingElement(arrowUpIconDisplayed)).toEqual(true);
 });

--- a/frontend/src/tests/components/eMIB/CollapsingItemContainer.test.js
+++ b/frontend/src/tests/components/eMIB/CollapsingItemContainer.test.js
@@ -5,78 +5,49 @@ import CollapsingItemContainer, {
 } from "../../../components/eMIB/CollapsingItemContainer";
 
 const body = { body: <div>body</div> };
+describe("Icons content types", () => {
+  const emailIcon = <i className="fas fa-envelope" />;
+  const taskIcon = <i className="fas fa-tasks" />;
 
-it("renders the right icon types (email, task)", () => {
-  //email
-  const emailWrapper = shallow(
-    <CollapsingItemContainer iconType={ICON_TYPE.email} title={"title"} body={body} />
-  );
+  it("renders email icon", () => {
+    const emailWrapper = shallow(
+      <CollapsingItemContainer iconType={ICON_TYPE.email} title={"title"} body={body} />
+    );
+    expect(emailWrapper.containsMatchingElement(emailIcon)).toEqual(true);
+    expect(emailWrapper.containsMatchingElement(taskIcon)).toEqual(false);
+  });
 
-  //task
-  const taskWrapper = shallow(
-    <CollapsingItemContainer iconType={ICON_TYPE.task} title={"title"} body={<div>body</div>} />
-  );
-
-  const buttonWithEmailIcon = (
-    <button>
-      <span className="fas fa-envelope" />
-      title
-    </button>
-  );
-
-  const buttonWithTaskIcon = (
-    <button>
-      <span className="fas fa-tasks" />
-      title
-    </button>
-  );
-
-  //email
-  expect(emailWrapper.containsMatchingElement(buttonWithEmailIcon)).toEqual(true);
-  expect(emailWrapper.containsMatchingElement(buttonWithTaskIcon)).toEqual(false);
-
-  //task
-  expect(taskWrapper.containsMatchingElement(buttonWithEmailIcon)).toEqual(false);
-  expect(taskWrapper.containsMatchingElement(buttonWithTaskIcon)).toEqual(true);
+  it("renders task icon", () => {
+    const taskWrapper = shallow(
+      <CollapsingItemContainer iconType={ICON_TYPE.task} title={"title"} body={<div>body</div>} />
+    );
+    expect(taskWrapper.containsMatchingElement(emailIcon)).toEqual(false);
+    expect(taskWrapper.containsMatchingElement(taskIcon)).toEqual(true);
+  });
 });
 
-it("renders the right arrow (up, down) icons when closed or expanded", () => {
+describe("Icons collapsing types", () => {
   const wrapper = shallow(
     <CollapsingItemContainer iconType={ICON_TYPE.email} title={"title"} body={body} />
   );
 
-  const arrowDownIconDisplayed = (
-    <div className=" collapsing-item-container">
-      <button className="btn btn-secondary">
-        <span className={ICON_TYPE.email} />
-        title
-      </button>
-      <span className="fas fa-angle-down blue-expand-icon" />
-    </div>
-  );
-  const arrowUpIconDisplayed = (
-    <div className="expanded-container-style collapsing-item-container">
-      <button>
-        <span className={ICON_TYPE.email} />
-        title
-      </button>
-      <span className="fas fa-angle-up white-expand-icon" />
-      <div>{body}</div>
-    </div>
-  );
+  const arrowDownIconDisplayed = <i className="fas fa-angle-down blue-expand-icon" />;
+  const arrowUpIconDisplayed = <i className="fas fa-angle-up white-expand-icon" />;
 
-  //arrow 'down' icon displayed (when closed)
-  wrapper.setState({ isCollapsed: true });
-  expect(wrapper.containsMatchingElement(arrowDownIconDisplayed)).toEqual(true);
-  expect(wrapper.containsMatchingElement(arrowUpIconDisplayed)).toEqual(false);
+  it("renders arrow up icon", () => {
+    wrapper.setState({ isCollapsed: true });
+    expect(wrapper.containsMatchingElement(arrowDownIconDisplayed)).toEqual(true);
+    expect(wrapper.containsMatchingElement(arrowUpIconDisplayed)).toEqual(false);
+  });
 
-  //arrow 'up' icon displayed (when expanded)
-  wrapper.setState({ isCollapsed: false });
-  expect(wrapper.containsMatchingElement(arrowDownIconDisplayed)).toEqual(false);
-  expect(wrapper.containsMatchingElement(arrowUpIconDisplayed)).toEqual(true);
+  it("renders arrow down icon", () => {
+    wrapper.setState({ isCollapsed: false });
+    expect(wrapper.containsMatchingElement(arrowDownIconDisplayed)).toEqual(false);
+    expect(wrapper.containsMatchingElement(arrowUpIconDisplayed)).toEqual(true);
+  });
 });
 
-it("renders title and/or body depending on the 'isCollapsed ' state", () => {
+/*it("renders title and/or body depending on the 'isCollapsed ' state", () => {
   const wrapper = shallow(
     <CollapsingItemContainer iconType={ICON_TYPE.email} title={"title"} body={body} />
   );
@@ -111,4 +82,4 @@ it("renders title and/or body depending on the 'isCollapsed ' state", () => {
   //collapsing item is expanded
   wrapper.setState({ isCollapsed: false });
   expect(wrapper.containsMatchingElement(contentWhenExpanded)).toEqual(true);
-});
+});*/


### PR DESCRIPTION
# Description

I implemented a new generic component called _'CollapsingItemContainer'_ that handle collapsing items to view replies and tasks in the inbox.

**How to use this new component:**

First, you need to import the following:
![image](https://user-images.githubusercontent.com/23021242/55503688-32eddb00-561d-11e9-86b7-f06e74793fc6.png)

Then, use it like that:

![image](https://user-images.githubusercontent.com/23021242/55503737-48fb9b80-561d-11e9-99dc-1ab412cf9c68.png)

You can always change the icon (email or task) by using the following variable:

- ICON_TYPE

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**Collapsing Item Hidden (task icon)**

![image](https://user-images.githubusercontent.com/23021242/55501609-cbce2780-5618-11e9-9b7a-4406f589c61f.png)
(Task content will be done in a future PR, since we don't have the design yet)

**Collapsing Item Hidden (email icon):**

![image](https://user-images.githubusercontent.com/23021242/55425336-39fae780-5550-11e9-9539-f5c368fd1bea.png)
(Task content will be done in a future PR,)

**Expanded View:**

![image](https://user-images.githubusercontent.com/23021242/55503970-ccb58800-561d-11e9-90be-51e27eabb3b0.png)

# Testing

**- Note that this new component is not very testable except if you add it in some component to see what it looks like, as shown in the description (See '_How to use this new component_' in the description).**

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
