### PR TITLE
[Add an Email] Created new component that displays the the response content

### DIFF
--- a/frontend/src/components/eMIB/ResponseItem.jsx
+++ b/frontend/src/components/eMIB/ResponseItem.jsx
@@ -1,0 +1,128 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import "../../css/collapsing-item.css";
+import LOCALIZE from "../../text_resources";
+
+const styles = {
+  responseTypeIcon: {
+    color: "white",
+    margin: "0 8px",
+    padding: 3,
+    backgroundColor: "#00565E"
+  },
+  responseType: {
+    color: "#00565E",
+    textDecoration: "underline"
+  },
+  deleteButton: {
+    float: "right"
+  },
+  editButton: {
+    float: "left"
+  }
+};
+
+export const RESPONSE_TYPE = {
+  reply: "reply",
+  replyAll: "reply all",
+  forward: "forward"
+};
+
+class ResponseItem extends Component {
+  static propTypes = {
+    responseType: PropTypes.string.isRequired,
+    to: PropTypes.string.isRequired,
+    cc: PropTypes.string,
+    response: PropTypes.string.isRequired,
+    reasonsForAction: PropTypes.string.isRequired
+  };
+
+  render() {
+    const { responseType, to, cc, response, reasonsForAction } = this.props;
+    return (
+      <div>
+        <div
+          aria-label={LOCALIZE.ariaLabel.emailHeader}
+          tabIndex="0"
+          aria-describedby="email-header-desc"
+        >
+          <div id="email-header-desc" role="dialog">
+            <p className="font-weight-bold">
+              {LOCALIZE.emibTest.inboxPage.emailResponse.description}
+              {responseType === RESPONSE_TYPE.reply && (
+                <>
+                  <span className="fas fa-reply" style={styles.responseTypeIcon} />
+                  <span style={styles.responseType}>
+                    {LOCALIZE.emibTest.inboxPage.emailResponse.responseType.reply}
+                  </span>
+                </>
+              )}
+              {responseType === RESPONSE_TYPE.replyAll && (
+                <>
+                  <span className="fas fa-reply-all" style={styles.responseTypeIcon} />
+                  <span style={styles.responseType}>
+                    {LOCALIZE.emibTest.inboxPage.emailResponse.responseType.replyAll}
+                  </span>
+                </>
+              )}
+              {responseType === RESPONSE_TYPE.forward && (
+                <>
+                  <span className="fas fa-share-square" style={styles.responseTypeIcon} />
+                  <span style={styles.responseType}>
+                    {LOCALIZE.emibTest.inboxPage.emailResponse.responseType.forward}
+                  </span>
+                </>
+              )}
+            </p>
+            <p>
+              <span className="font-weight-bold">
+                {LOCALIZE.emibTest.inboxPage.emailResponse.to}&nbsp;
+              </span>
+              <span>{to}</span>
+            </p>
+            <p>
+              <span className="font-weight-bold">
+                {LOCALIZE.emibTest.inboxPage.emailResponse.cc}&nbsp;
+              </span>
+              <span>{cc}</span>
+            </p>
+          </div>
+        </div>
+        <hr />
+        <div
+          aria-label={LOCALIZE.ariaLabel.responseDetails}
+          tabIndex="0"
+          aria-describedby="email-response"
+        >
+          <div id="email-response" role="dialog">
+            <p className="font-weight-bold">{LOCALIZE.emibTest.inboxPage.emailResponse.response}</p>
+            <p>{response}</p>
+          </div>
+        </div>
+        <hr />
+        <div
+          aria-label={LOCALIZE.ariaLabel.reasonsForActionDetails}
+          tabIndex="0"
+          aria-describedby="email-reasons-for-action"
+        >
+          <div id="email-reasons-for-action" role="dialog">
+            <p className="font-weight-bold">
+              {LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}
+            </p>
+            <p>{reasonsForAction}</p>
+          </div>
+        </div>
+        <hr />
+        <div aria-label={LOCALIZE.ariaLabel.emailOptions}>
+          <button className="btn btn-primary" style={styles.de}>
+            {LOCALIZE.emibTest.inboxPage.emailResponse.editButton}
+          </button>
+          <button className="btn btn-danger" style={styles.deleteButton}>
+            {LOCALIZE.emibTest.inboxPage.emailResponse.deleteButton}
+          </button>
+        </div>
+      </div>
+    );
+  }
+}
+export default ResponseItem;

--- a/frontend/src/components/eMIB/ResponseItem.jsx
+++ b/frontend/src/components/eMIB/ResponseItem.jsx
@@ -30,7 +30,11 @@ export const RESPONSE_TYPE = {
 
 class ResponseItem extends Component {
   static propTypes = {
-    responseType: PropTypes.string.isRequired,
+    responseType: PropTypes.oneOf([
+      RESPONSE_TYPE.reply,
+      RESPONSE_TYPE.replyAll,
+      RESPONSE_TYPE.forward
+    ]).isRequired,
     to: PropTypes.string.isRequired,
     cc: PropTypes.string,
     response: PropTypes.string.isRequired,

--- a/frontend/src/components/eMIB/ResponseItem.jsx
+++ b/frontend/src/components/eMIB/ResponseItem.jsx
@@ -55,7 +55,7 @@ class ResponseItem extends Component {
               {LOCALIZE.emibTest.inboxPage.emailResponse.description}
               {responseType === RESPONSE_TYPE.reply && (
                 <>
-                  <span className="fas fa-reply" style={styles.responseTypeIcon} />
+                  <i className="fas fa-reply" style={styles.responseTypeIcon} />
                   <span style={styles.responseType}>
                     {LOCALIZE.emibTest.inboxPage.emailResponse.responseType.reply}
                   </span>
@@ -63,7 +63,7 @@ class ResponseItem extends Component {
               )}
               {responseType === RESPONSE_TYPE.replyAll && (
                 <>
-                  <span className="fas fa-reply-all" style={styles.responseTypeIcon} />
+                  <i className="fas fa-reply-all" style={styles.responseTypeIcon} />
                   <span style={styles.responseType}>
                     {LOCALIZE.emibTest.inboxPage.emailResponse.responseType.replyAll}
                   </span>
@@ -71,7 +71,7 @@ class ResponseItem extends Component {
               )}
               {responseType === RESPONSE_TYPE.forward && (
                 <>
-                  <span className="fas fa-share-square" style={styles.responseTypeIcon} />
+                  <i className="fas fa-share-square" style={styles.responseTypeIcon} />
                   <span style={styles.responseType}>
                     {LOCALIZE.emibTest.inboxPage.emailResponse.responseType.forward}
                   </span>

--- a/frontend/src/tests/components/eMIB/ResponseItem.test.js
+++ b/frontend/src/tests/components/eMIB/ResponseItem.test.js
@@ -1,0 +1,207 @@
+import React from "react";
+import { shallow } from "enzyme";
+import ResponseItem, { RESPONSE_TYPE } from "../../../components/eMIB/ResponseItem";
+import LOCALIZE from "../../../text_resources";
+
+it("renders the right response types (reply, reply all, forward)", () => {
+  //reply
+  const replyWrapper = shallow(
+    <ResponseItem
+      responseType={RESPONSE_TYPE.reply}
+      to={"to"}
+      cc={"cc"}
+      response={"response"}
+      reasonsForAction={"reasons"}
+    />
+  );
+
+  //reply all
+  const replyAllWrapper = shallow(
+    <ResponseItem
+      responseType={RESPONSE_TYPE.replyAll}
+      to={"to"}
+      cc={"cc"}
+      response={"response"}
+      reasonsForAction={"reasons"}
+    />
+  );
+
+  //forward
+  const forwardWrapper = shallow(
+    <ResponseItem
+      responseType={RESPONSE_TYPE.forward}
+      to={"to"}
+      cc={"cc"}
+      response={"response"}
+      reasonsForAction={"reasons"}
+    />
+  );
+
+  const reply = <span className="fas fa-reply" />;
+  const replyAll = <span className="fas fa-reply-all" />;
+  const forward = <span className="fas fa-share-square" />;
+
+  //reply
+  expect(replyWrapper.containsMatchingElement(reply)).toEqual(true);
+  expect(replyWrapper.containsMatchingElement(replyAll)).toEqual(false);
+  expect(replyWrapper.containsMatchingElement(forward)).toEqual(false);
+
+  //reply all
+  expect(replyAllWrapper.containsMatchingElement(reply)).toEqual(false);
+  expect(replyAllWrapper.containsMatchingElement(replyAll)).toEqual(true);
+  expect(replyAllWrapper.containsMatchingElement(forward)).toEqual(false);
+
+  //forward
+  expect(forwardWrapper.containsMatchingElement(reply)).toEqual(false);
+  expect(forwardWrapper.containsMatchingElement(replyAll)).toEqual(false);
+  expect(forwardWrapper.containsMatchingElement(forward)).toEqual(true);
+});
+
+it("renders email's header (with and without cc, since it is optional)", () => {
+  //with cc field
+  const withCcWrapper = shallow(
+    <ResponseItem
+      responseType={RESPONSE_TYPE.reply}
+      to={"to"}
+      cc={"cc"}
+      response={"response"}
+      reasonsForAction={"reasons"}
+    />
+  );
+
+  //without cc field
+  const withoutCcWrapper = shallow(
+    <ResponseItem
+      responseType={RESPONSE_TYPE.reply}
+      to={"to"}
+      response={"response"}
+      reasonsForAction={"reasons"}
+    />
+  );
+
+  const headerContentWithCc = (
+    <div>
+      <div>
+        <p>
+          {LOCALIZE.emibTest.inboxPage.emailResponse.description}
+          <>
+            <span className="fas fa-reply" />
+            <span>{LOCALIZE.emibTest.inboxPage.emailResponse.responseType.reply}</span>
+          </>
+        </p>
+        <p>
+          <span className="font-weight-bold">
+            {LOCALIZE.emibTest.inboxPage.emailResponse.to}&nbsp;
+          </span>
+          <span>to</span>
+        </p>
+        <p>
+          <span className="font-weight-bold">
+            {LOCALIZE.emibTest.inboxPage.emailResponse.cc}&nbsp;
+          </span>
+          <span>cc</span>
+        </p>
+      </div>
+    </div>
+  );
+
+  const headerContentWithoutCc = (
+    <div>
+      <div>
+        <p>
+          {LOCALIZE.emibTest.inboxPage.emailResponse.description}
+          <>
+            <span className="fas fa-reply" />
+            <span>{LOCALIZE.emibTest.inboxPage.emailResponse.responseType.reply}</span>
+          </>
+        </p>
+        <p>
+          <span className="font-weight-bold">
+            {LOCALIZE.emibTest.inboxPage.emailResponse.to}&nbsp;
+          </span>
+          <span>to</span>
+        </p>
+        <p>
+          <span className="font-weight-bold">
+            {LOCALIZE.emibTest.inboxPage.emailResponse.cc}&nbsp;
+          </span>
+          <span />
+        </p>
+      </div>
+    </div>
+  );
+
+  expect(withCcWrapper.containsMatchingElement(headerContentWithCc)).toEqual(true);
+  expect(withoutCcWrapper.containsMatchingElement(headerContentWithoutCc)).toEqual(true);
+});
+
+it("renders email's response", () => {
+  const wrapper = shallow(
+    <ResponseItem
+      responseType={RESPONSE_TYPE.reply}
+      to={"to"}
+      cc={"cc"}
+      response={"response"}
+      reasonsForAction={"reasons"}
+    />
+  );
+
+  const responseContent = (
+    <div>
+      <div>
+        <p>{LOCALIZE.emibTest.inboxPage.emailResponse.response}</p>
+        <p>response</p>
+      </div>
+    </div>
+  );
+
+  expect(wrapper.containsMatchingElement(responseContent)).toEqual(true);
+});
+
+it("renders email's reasons for action", () => {
+  const wrapper = shallow(
+    <ResponseItem
+      responseType={RESPONSE_TYPE.reply}
+      to={"to"}
+      cc={"cc"}
+      response={"response"}
+      reasonsForAction={"reasons"}
+    />
+  );
+
+  const reasonsForActionContent = (
+    <div>
+      <div>
+        <p>{LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}</p>
+        <p>reasons</p>
+      </div>
+    </div>
+  );
+
+  expect(wrapper.containsMatchingElement(reasonsForActionContent)).toEqual(true);
+});
+
+it("renders email's buttons", () => {
+  const wrapper = shallow(
+    <ResponseItem
+      responseType={RESPONSE_TYPE.reply}
+      to={"to"}
+      cc={"cc"}
+      response={"response"}
+      reasonsForAction={"reasons"}
+    />
+  );
+
+  const buttonZoneContent = (
+    <div>
+      <button className="btn btn-primary">
+        {LOCALIZE.emibTest.inboxPage.emailResponse.editButton}
+      </button>
+      <button className="btn btn-danger">
+        {LOCALIZE.emibTest.inboxPage.emailResponse.deleteButton}
+      </button>
+    </div>
+  );
+
+  expect(wrapper.containsMatchingElement(buttonZoneContent)).toEqual(true);
+});

--- a/frontend/src/tests/components/eMIB/ResponseItem.test.js
+++ b/frontend/src/tests/components/eMIB/ResponseItem.test.js
@@ -1,207 +1,88 @@
 import React from "react";
 import { shallow } from "enzyme";
 import ResponseItem, { RESPONSE_TYPE } from "../../../components/eMIB/ResponseItem";
-import LOCALIZE from "../../../text_resources";
 
-it("renders the right response types (reply, reply all, forward)", () => {
-  //reply
-  const replyWrapper = shallow(
-    <ResponseItem
-      responseType={RESPONSE_TYPE.reply}
-      to={"to"}
-      cc={"cc"}
-      response={"response"}
-      reasonsForAction={"reasons"}
-    />
-  );
+describe("Response types", () => {
+  const reply = <i className="fas fa-reply" />;
+  const replyAll = <i className="fas fa-reply-all" />;
+  const forward = <i className="fas fa-share-square" />;
 
-  //reply all
-  const replyAllWrapper = shallow(
-    <ResponseItem
-      responseType={RESPONSE_TYPE.replyAll}
-      to={"to"}
-      cc={"cc"}
-      response={"response"}
-      reasonsForAction={"reasons"}
-    />
-  );
+  it("renders reply response", () => {
+    const wrapper = shallow(
+      <ResponseItem
+        responseType={RESPONSE_TYPE.reply}
+        to={"to"}
+        cc={"cc"}
+        response={"response"}
+        reasonsForAction={"reasons"}
+      />
+    );
 
-  //forward
-  const forwardWrapper = shallow(
-    <ResponseItem
-      responseType={RESPONSE_TYPE.forward}
-      to={"to"}
-      cc={"cc"}
-      response={"response"}
-      reasonsForAction={"reasons"}
-    />
-  );
+    expect(wrapper.containsMatchingElement(reply)).toEqual(true);
+    expect(wrapper.containsMatchingElement(replyAll)).toEqual(false);
+    expect(wrapper.containsMatchingElement(forward)).toEqual(false);
+  });
 
-  const reply = <span className="fas fa-reply" />;
-  const replyAll = <span className="fas fa-reply-all" />;
-  const forward = <span className="fas fa-share-square" />;
+  it("renders reply all response", () => {
+    const wrapper = shallow(
+      <ResponseItem
+        responseType={RESPONSE_TYPE.replyAll}
+        to={"to"}
+        cc={"cc"}
+        response={"response"}
+        reasonsForAction={"reasons"}
+      />
+    );
 
-  //reply
-  expect(replyWrapper.containsMatchingElement(reply)).toEqual(true);
-  expect(replyWrapper.containsMatchingElement(replyAll)).toEqual(false);
-  expect(replyWrapper.containsMatchingElement(forward)).toEqual(false);
+    expect(wrapper.containsMatchingElement(reply)).toEqual(false);
+    expect(wrapper.containsMatchingElement(replyAll)).toEqual(true);
+    expect(wrapper.containsMatchingElement(forward)).toEqual(false);
+  });
 
-  //reply all
-  expect(replyAllWrapper.containsMatchingElement(reply)).toEqual(false);
-  expect(replyAllWrapper.containsMatchingElement(replyAll)).toEqual(true);
-  expect(replyAllWrapper.containsMatchingElement(forward)).toEqual(false);
+  it("renders forward response", () => {
+    const wrapper = shallow(
+      <ResponseItem
+        responseType={RESPONSE_TYPE.forward}
+        to={"to"}
+        cc={"cc"}
+        response={"response"}
+        reasonsForAction={"reasons"}
+      />
+    );
 
-  //forward
-  expect(forwardWrapper.containsMatchingElement(reply)).toEqual(false);
-  expect(forwardWrapper.containsMatchingElement(replyAll)).toEqual(false);
-  expect(forwardWrapper.containsMatchingElement(forward)).toEqual(true);
+    expect(wrapper.containsMatchingElement(reply)).toEqual(false);
+    expect(wrapper.containsMatchingElement(replyAll)).toEqual(false);
+    expect(wrapper.containsMatchingElement(forward)).toEqual(true);
+  });
 });
 
-it("renders email's header (with and without cc, since it is optional)", () => {
-  //with cc field
-  const withCcWrapper = shallow(
-    <ResponseItem
-      responseType={RESPONSE_TYPE.reply}
-      to={"to"}
-      cc={"cc"}
-      response={"response"}
-      reasonsForAction={"reasons"}
-    />
-  );
+describe("Email header", () => {
+  const headerWithCc = <span>cc</span>;
 
-  //without cc field
-  const withoutCcWrapper = shallow(
-    <ResponseItem
-      responseType={RESPONSE_TYPE.reply}
-      to={"to"}
-      response={"response"}
-      reasonsForAction={"reasons"}
-    />
-  );
+  it("renders email's header with cc)", () => {
+    const wrapper = shallow(
+      <ResponseItem
+        responseType={RESPONSE_TYPE.reply}
+        to={"to"}
+        cc={"cc"}
+        response={"response"}
+        reasonsForAction={"reasons"}
+      />
+    );
 
-  const headerContentWithCc = (
-    <div>
-      <div>
-        <p>
-          {LOCALIZE.emibTest.inboxPage.emailResponse.description}
-          <>
-            <span className="fas fa-reply" />
-            <span>{LOCALIZE.emibTest.inboxPage.emailResponse.responseType.reply}</span>
-          </>
-        </p>
-        <p>
-          <span className="font-weight-bold">
-            {LOCALIZE.emibTest.inboxPage.emailResponse.to}&nbsp;
-          </span>
-          <span>to</span>
-        </p>
-        <p>
-          <span className="font-weight-bold">
-            {LOCALIZE.emibTest.inboxPage.emailResponse.cc}&nbsp;
-          </span>
-          <span>cc</span>
-        </p>
-      </div>
-    </div>
-  );
+    expect(wrapper.containsMatchingElement(headerWithCc)).toEqual(true);
+  });
 
-  const headerContentWithoutCc = (
-    <div>
-      <div>
-        <p>
-          {LOCALIZE.emibTest.inboxPage.emailResponse.description}
-          <>
-            <span className="fas fa-reply" />
-            <span>{LOCALIZE.emibTest.inboxPage.emailResponse.responseType.reply}</span>
-          </>
-        </p>
-        <p>
-          <span className="font-weight-bold">
-            {LOCALIZE.emibTest.inboxPage.emailResponse.to}&nbsp;
-          </span>
-          <span>to</span>
-        </p>
-        <p>
-          <span className="font-weight-bold">
-            {LOCALIZE.emibTest.inboxPage.emailResponse.cc}&nbsp;
-          </span>
-          <span />
-        </p>
-      </div>
-    </div>
-  );
+  it("renders email's header without cc)", () => {
+    const wrapper = shallow(
+      <ResponseItem
+        responseType={RESPONSE_TYPE.reply}
+        to={"to"}
+        response={"response"}
+        reasonsForAction={"reasons"}
+      />
+    );
 
-  expect(withCcWrapper.containsMatchingElement(headerContentWithCc)).toEqual(true);
-  expect(withoutCcWrapper.containsMatchingElement(headerContentWithoutCc)).toEqual(true);
-});
-
-it("renders email's response", () => {
-  const wrapper = shallow(
-    <ResponseItem
-      responseType={RESPONSE_TYPE.reply}
-      to={"to"}
-      cc={"cc"}
-      response={"response"}
-      reasonsForAction={"reasons"}
-    />
-  );
-
-  const responseContent = (
-    <div>
-      <div>
-        <p>{LOCALIZE.emibTest.inboxPage.emailResponse.response}</p>
-        <p>response</p>
-      </div>
-    </div>
-  );
-
-  expect(wrapper.containsMatchingElement(responseContent)).toEqual(true);
-});
-
-it("renders email's reasons for action", () => {
-  const wrapper = shallow(
-    <ResponseItem
-      responseType={RESPONSE_TYPE.reply}
-      to={"to"}
-      cc={"cc"}
-      response={"response"}
-      reasonsForAction={"reasons"}
-    />
-  );
-
-  const reasonsForActionContent = (
-    <div>
-      <div>
-        <p>{LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}</p>
-        <p>reasons</p>
-      </div>
-    </div>
-  );
-
-  expect(wrapper.containsMatchingElement(reasonsForActionContent)).toEqual(true);
-});
-
-it("renders email's buttons", () => {
-  const wrapper = shallow(
-    <ResponseItem
-      responseType={RESPONSE_TYPE.reply}
-      to={"to"}
-      cc={"cc"}
-      response={"response"}
-      reasonsForAction={"reasons"}
-    />
-  );
-
-  const buttonZoneContent = (
-    <div>
-      <button className="btn btn-primary">
-        {LOCALIZE.emibTest.inboxPage.emailResponse.editButton}
-      </button>
-      <button className="btn btn-danger">
-        {LOCALIZE.emibTest.inboxPage.emailResponse.deleteButton}
-      </button>
-    </div>
-  );
-
-  expect(wrapper.containsMatchingElement(buttonZoneContent)).toEqual(true);
+    expect(wrapper.containsMatchingElement(headerWithCc)).toEqual(false);
+  });
 });

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -335,7 +335,21 @@ let LOCALIZE = new LocalizedStrings({
         addTask: "Create a task",
         replyTextPart1: "You responded with ",
         replyTextPart2: " emails and ",
-        replyTextPart3: " tasks"
+        replyTextPart3: " tasks",
+        emailResponse: {
+          responseType: {
+            reply: "reply",
+            replyAll: "reply all",
+            forward: "forward"
+          },
+          description: "For this response, you've chosen to:",
+          to: "To:",
+          cc: "Cc:",
+          response: "Your response:",
+          reasonsForAction: "Your reasons for action:",
+          editButton: "Edit response",
+          deleteButton: "Delete response"
+        }
       },
 
       //Confirmation Page
@@ -484,7 +498,11 @@ let LOCALIZE = new LocalizedStrings({
       tabMenu: "eMIB Tab Menu",
       instructionsMenu: "Instructions Menu",
       languageToggleBtn: "language-toggle-button",
-      authenticationMenu: "Authentication Menu"
+      authenticationMenu: "Authentication Menu",
+      emailHeader: "email header",
+      responseDetails: "response details",
+      reasonsForActionDetails: "reasons for action details",
+      emailOptions: "email options"
     },
 
     //Commons
@@ -853,7 +871,21 @@ let LOCALIZE = new LocalizedStrings({
         addTask: "FR Create a task",
         replyTextPart1: "FR You responded with ",
         replyTextPart2: " FR emails and ",
-        replyTextPart3: " FR tasks"
+        replyTextPart3: " FR tasks",
+        emailResponse: {
+          responseType: {
+            reply: "répondre",
+            replyAll: "répondre à tous",
+            forward: "transmettre"
+          },
+          description: "FR For this response, you've chosen to:",
+          to: "À :",
+          cc: "Cc :",
+          response: "FR Your response:",
+          reasonsForAction: "FR Your reasons for action:",
+          editButton: "Modifier réponse",
+          deleteButton: "Supprimer résponse"
+        }
       },
 
       //Confirmation Page
@@ -1006,7 +1038,11 @@ let LOCALIZE = new LocalizedStrings({
       tabMenu: "Menu des onglets de la BRG-e",
       instructionsMenu: "Menu des instructions",
       languageToggleBtn: "bouton-de-langue-a-bascule",
-      authenticationMenu: "Menu d'authentification"
+      authenticationMenu: "Menu d'authentification",
+      emailHeader: "en-tête du courriel",
+      responseDetails: "détails de la réponse",
+      reasonsForActionDetails: "motifs de l'action",
+      emailOptions: "options de messagerie"
     },
 
     //Commons


### PR DESCRIPTION
# Description

I implemented a new component called '_ResponseItem_' that handle the display of the responses. 

**This component needs to be used as part as the body of the _'CollapsingItemContainer'_ component.**

**How to use this new component:**

First, you need to import the following:
![image](https://user-images.githubusercontent.com/23021242/55425160-bf31cc80-554f-11e9-912c-6286304de3c1.png)

Then, use them like that:
![image](https://user-images.githubusercontent.com/23021242/55425127-b2ad7400-554f-11e9-90bf-795f1fa15504.png)

You can always change the icon (email or task) and change the response type (reply, reply all, forward) using the following variables:

- ICON_TYPE
- RESPONSE_TYPE

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**Collapsing Item Hidden (email icon):**

![image](https://user-images.githubusercontent.com/23021242/55425336-39fae780-5550-11e9-9539-f5c368fd1bea.png)

**Once Expanded (response type = reply):**

![image](https://user-images.githubusercontent.com/23021242/55425407-69115900-5550-11e9-9f05-31e68fac17e0.png)

**Once Expanded (response type = reply all):**

![image](https://user-images.githubusercontent.com/23021242/55425447-7e868300-5550-11e9-8eda-d15e6b8bcefe.png)

**Once Expanded (response type = forward):**

![image](https://user-images.githubusercontent.com/23021242/55425474-8f36f900-5550-11e9-9eec-de3b6ab48ce2.png)

# Testing

**- Note that this new component is not very testable except if you add it in some component to see what it looks like, as shown in the description (See '_How to use this new component_' in the description).**

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
