### PR TITLE
[Inbox] Add padding to the right side of the emails

### DIFF
--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -22,6 +22,7 @@ const styles = {
   email: {
     textAlign: "left",
     paddingLeft: 16,
+    paddingRight: 16,
     paddingTop: 16
   },
   replyAndUser: {

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -21,9 +21,7 @@ const styles = {
   },
   email: {
     textAlign: "left",
-    paddingLeft: 16,
-    paddingRight: 16,
-    paddingTop: 16
+    padding: 16
   },
   replyAndUser: {
     color: "#00565E"


### PR DESCRIPTION
# Description

Emails hit the side of the notepad. This matches the padding on the left.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

![image](https://user-images.githubusercontent.com/4640747/55578406-d30e3780-56e3-11e9-95f4-3f8ba0209fe4.png)


# Testing

Manual steps to reproduce this functionality:

1.  Go to Inbox page in the sample test.
2.  Notice the padding change.
