### PR TITLE
[Inbox] Add email action counts into redux

### DIFF
--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -46,10 +46,11 @@ const styles = {
 class Email extends Component {
   static propTypes = {
     email: PropTypes.object.isRequired,
-    addEmail: PropTypes.func.isRequired,
-    addTask: PropTypes.func.isRequired,
     emailCount: PropTypes.number,
-    taskCount: PropTypes.number
+    taskCount: PropTypes.number,
+    // Provided by Redux.
+    addEmail: PropTypes.func.isRequired,
+    addTask: PropTypes.func.isRequired
   };
 
   state = {

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -158,9 +158,6 @@ class Email extends Component {
 }
 
 export { Email as UnconnectedEmail };
-const mapStateToProps = (state, ownProps) => {
-  return {};
-};
 
 const mapDispatchToProps = dispatch =>
   bindActionCreators(

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -48,7 +48,8 @@ class Email extends Component {
     email: PropTypes.object.isRequired,
     addEmail: PropTypes.func.isRequired,
     addTask: PropTypes.func.isRequired,
-    isRepliedTo: PropTypes.bool.isRequired
+    emailCount: PropTypes.number,
+    taskCount: PropTypes.number
   };
 
   state = {
@@ -81,7 +82,7 @@ class Email extends Component {
   };
 
   render() {
-    const email = this.props.email;
+    const { email, emailCount, taskCount } = this.props;
 
     return (
       <div style={styles.email}>
@@ -90,12 +91,14 @@ class Email extends Component {
             {LOCALIZE.emibTest.inboxPage.emailId.toUpperCase()}
             {email.id + 1}
           </h2>
-          {this.props.isRepliedTo && (
+          {true && (
             <div className="font-weight-bold" style={styles.replyStatus}>
               <i className="fas fa-sign-out-alt" style={styles.replyAndUser} />
-              {LOCALIZE.emibTest.inboxPage.replyTextPart1}0
-              {LOCALIZE.emibTest.inboxPage.replyTextPart2}0
-              {LOCALIZE.emibTest.inboxPage.replyTextPart3}
+              {LOCALIZE.formatString(
+                LOCALIZE.emibTest.inboxPage.yourActions,
+                emailCount,
+                taskCount
+              )}
             </div>
           )}
         </div>

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -84,6 +84,7 @@ class Email extends Component {
 
   render() {
     const { email, emailCount, taskCount } = this.props;
+    const hasTakenAction = emailCount + taskCount > 0;
 
     return (
       <div style={styles.email}>
@@ -92,7 +93,7 @@ class Email extends Component {
             {LOCALIZE.emibTest.inboxPage.emailId.toUpperCase()}
             {email.id + 1}
           </h2>
-          {true && (
+          {hasTakenAction && (
             <div className="font-weight-bold" style={styles.replyStatus}>
               <i className="fas fa-sign-out-alt" style={styles.replyAndUser} />
               {LOCALIZE.formatString(

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -1,8 +1,11 @@
 import React, { Component } from "react";
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
 import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
 import "../../css/inbox.css";
 import EditEmailActionDialog, { ACTION_TYPE, EDIT_MODE } from "./EditEmailActionDialog";
+import { addEmail, addTask } from "../../modules/EmibInboxRedux";
 
 const styles = {
   header: {
@@ -43,7 +46,8 @@ const styles = {
 class Email extends Component {
   static propTypes = {
     email: PropTypes.object.isRequired,
-    respondToEmail: PropTypes.func.isRequired,
+    addEmail: PropTypes.func.isRequired,
+    addTask: PropTypes.func.isRequired,
     isRepliedTo: PropTypes.bool.isRequired
   };
 
@@ -69,13 +73,11 @@ class Email extends Component {
   };
 
   replyToEmail = () => {
-    //TODO mcherry: replace the following with change to redux state
-    this.props.respondToEmail(this.props.email.id);
+    this.props.addEmail(this.props.email.id);
   };
 
   addTaskToEmail = () => {
-    //TODO mcherry: replace the following with change to redux state
-    this.props.respondToEmail(this.props.email.id);
+    this.props.addTask(this.props.email.id);
   };
 
   render() {
@@ -151,4 +153,22 @@ class Email extends Component {
     );
   }
 }
-export default Email;
+
+export { Email as UnconnectedEmail };
+const mapStateToProps = (state, ownProps) => {
+  return {};
+};
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators(
+    {
+      addEmail,
+      addTask
+    },
+    dispatch
+  );
+
+export default connect(
+  null,
+  mapDispatchToProps
+)(Email);

--- a/frontend/src/components/eMIB/Inbox.jsx
+++ b/frontend/src/components/eMIB/Inbox.jsx
@@ -72,11 +72,8 @@ class Inbox extends Component {
         <div className="inbox-grid-content-cell" style={styles.bodyContent}>
           <Email
             email={emails[this.state.currentEmail]}
-            isRepliedTo={
-              emailSummaries[this.state.currentEmail].emailCount +
-                emailSummaries[this.state.currentEmail].taskCount >
-              0
-            }
+            emailCount={emailSummaries[this.state.currentEmail].emailCount}
+            taskCount={emailSummaries[this.state.currentEmail].taskCount}
           />
         </div>
       </div>

--- a/frontend/src/components/eMIB/Inbox.jsx
+++ b/frontend/src/components/eMIB/Inbox.jsx
@@ -26,14 +26,6 @@ const styles = {
   }
 };
 
-function initializeFalseArray(length) {
-  let arr = [];
-  for (let i = 0; i < length; i++) {
-    arr.push(false);
-  }
-  return arr;
-}
-
 class Inbox extends Component {
   static propTypes = {
     // Provided by redux
@@ -43,8 +35,7 @@ class Inbox extends Component {
   };
 
   state = {
-    currentEmail: 0,
-    emailResponses: initializeFalseArray(this.props.emails.length)
+    currentEmail: 0
   };
 
   changeEmail = index => {
@@ -52,14 +43,8 @@ class Inbox extends Component {
     this.setState({ currentEmail: index });
   };
 
-  respondToEmail = index => {
-    let emailResponses = Array.from(this.state.emailResponses);
-    emailResponses[index] = true;
-    this.setState({ emailResponses: emailResponses });
-  };
-
   render() {
-    const { emails } = this.props;
+    const { emails, emailSummaries } = this.props;
     return (
       <div className="inbox-grid">
         <nav
@@ -75,7 +60,9 @@ class Inbox extends Component {
                   email={email}
                   selectEmail={this.changeEmail}
                   isRead={this.props.emailSummaries[index].isRead}
-                  isRepliedTo={this.state.emailResponses[index]}
+                  isRepliedTo={
+                    emailSummaries[index].emailCount + emailSummaries[index].taskCount > 0
+                  }
                   isSelected={index === this.state.currentEmail}
                 />
               </div>
@@ -85,8 +72,11 @@ class Inbox extends Component {
         <div className="inbox-grid-content-cell" style={styles.bodyContent}>
           <Email
             email={emails[this.state.currentEmail]}
-            respondToEmail={this.respondToEmail}
-            isRepliedTo={this.state.emailResponses[this.state.currentEmail]}
+            isRepliedTo={
+              emailSummaries[this.state.currentEmail].emailCount +
+                emailSummaries[this.state.currentEmail].taskCount >
+              0
+            }
           />
         </div>
       </div>

--- a/frontend/src/modules/EmibInboxRedux.js
+++ b/frontend/src/modules/EmibInboxRedux.js
@@ -4,16 +4,22 @@ import { SET_LANGUAGE } from "./LocalizeRedux";
 export const initializeEmailSummaries = length => {
   let emailSummaries = [];
   for (let i = 0; i < length; i++) {
-    emailSummaries.push({ isRead: false });
+    emailSummaries.push({ isRead: false, emailCount: 0, taskCount: 0 });
   }
   return emailSummaries;
 };
 
 // Action Types
 const READ_EMAIL = "emibInbox/READ_EMAIL";
+const ADD_EMAIL = "emibInbox/ADD_EMAIL";
+const ADD_TASK = "emibInbox/ADD_TASK";
 
 // Action Creators
 const readEmail = emailIndex => ({ type: READ_EMAIL, emailIndex });
+// emailIndex refers to the index of the original parent email.
+const addEmail = emailIndex => ({ type: ADD_EMAIL, emailIndex });
+// emailIndex refers to the index of the original parent email.
+const addTask = emailIndex => ({ type: ADD_TASK, emailIndex });
 
 // Initial State
 // emails - represents an array of emails in the currently selected language.
@@ -39,11 +45,24 @@ const emibInbox = (state = initialState, action) => {
         ...state,
         emailSummaries: updatedEmailSummaries
       };
-
+    case ADD_EMAIL:
+      let modifiedEmailSummaries = Array.from(state.emailSummaries);
+      modifiedEmailSummaries[action.emailIndex].emailCount++;
+      return {
+        ...state,
+        emailSummaries: modifiedEmailSummaries
+      };
+    case ADD_TASK:
+      let duplicatedEmailSummaries = Array.from(state.emailSummaries);
+      duplicatedEmailSummaries[action.emailIndex].taskCount++;
+      return {
+        ...state,
+        emailSummaries: duplicatedEmailSummaries
+      };
     default:
       return state;
   }
 };
 
 export default emibInbox;
-export { initialState, readEmail };
+export { initialState, readEmail, addEmail, addTask };

--- a/frontend/src/tests/components/eMIB/Email.test.js
+++ b/frontend/src/tests/components/eMIB/Email.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow, mount } from "enzyme";
-import Email from "../../../components/eMIB/Email";
+import { UnconnectedEmail as Email } from "../../../components/eMIB/Email";
 
 const emailStub = {
   id: 1,
@@ -13,41 +13,29 @@ const emailStub = {
 
 const hasAction = <i className="fas fa-sign-out-alt" style={{ color: "#00565E" }} />;
 
-it("default email renders with jubject as an h3", () => {
+it("default email renders with subject as an h3", () => {
   const wrapper = shallow(
-    <Email email={emailStub} respondToEmail={() => {}} isRepliedTo={false} />
+    <Email email={emailStub} addEmail={() => {}} addTask={() => {}} emailCount={0} taskCount={0} />
   );
   const subject = <h3>Subject 1</h3>;
   expect(wrapper.contains(subject)).toEqual(true);
   expect(wrapper.contains(hasAction)).toEqual(false);
 });
 
-it("shows action when set to true in props", () => {
-  const wrapper = shallow(<Email email={emailStub} respondToEmail={() => {}} isRepliedTo={true} />);
+it("shows action when email count is non zero", () => {
+  const wrapper = shallow(
+    <Email email={emailStub} addEmail={() => {}} addTask={() => {}} emailCount={1} taskCount={0} />
+  );
   const subject = <h3>Subject 1</h3>;
   expect(wrapper.contains(subject)).toEqual(true);
   expect(wrapper.contains(hasAction)).toEqual(true);
 });
 
-it("reply and task buttons trigger the function", () => {
-  const submitMock = jest.fn();
-  const wrapper = mount(
-    <Email email={emailStub} respondToEmail={submitMock} isRepliedTo={false} />
+it("shows action when task count is non zero", () => {
+  const wrapper = shallow(
+    <Email email={emailStub} addEmail={() => {}} addTask={() => {}} emailCount={0} taskCount={2} />
   );
   const subject = <h3>Subject 1</h3>;
   expect(wrapper.contains(subject)).toEqual(true);
-  wrapper.find("#unit-test-email-reply-button").simulate("click");
-  //Test also needs to triger the save response button in the modal to "save" the response
-  wrapper
-    .find("#unit-test-email-response-button")
-    .first()
-    .simulate("click");
-  expect(submitMock).toHaveBeenCalledTimes(1);
-  wrapper.find("#unit-test-email-task-button").simulate("click");
-  //Test also needs to triger the save response button in the modal to "save" the response
-  wrapper
-    .find("#unit-test-email-response-button")
-    .first()
-    .simulate("click");
-  expect(submitMock).toHaveBeenCalledTimes(2);
+  expect(wrapper.contains(hasAction)).toEqual(true);
 });

--- a/frontend/src/tests/components/eMIB/Inbox.test.js
+++ b/frontend/src/tests/components/eMIB/Inbox.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { mount } from "enzyme";
+import { shallow } from "enzyme";
 import { UnconnectedInbox as Inbox } from "../../../components/eMIB/Inbox";
 import { emailsJson } from "../../../modules/sampleEmibJson";
 
@@ -18,10 +18,14 @@ it("Shows only email 3", () => {
 });
 
 function testCore(selected) {
-  const wrapper = mount(
+  const wrapper = shallow(
     <Inbox
       emails={INBOX_SPECS}
-      emailSummaries={[{ isRead: false }, { isRead: false }, { isRead: false }]}
+      emailSummaries={[
+        { isRead: false, taskCount: 0, emailCount: 0 },
+        { isRead: false, taskCount: 0, emailCount: 0 },
+        { isRead: false, taskCount: 0, emailCount: 0 }
+      ]}
       readEmail={() => {}}
     />
   );

--- a/frontend/src/tests/components/eMIB/Inbox.test.js
+++ b/frontend/src/tests/components/eMIB/Inbox.test.js
@@ -2,22 +2,12 @@ import React from "react";
 import { shallow } from "enzyme";
 import { UnconnectedInbox as Inbox } from "../../../components/eMIB/Inbox";
 import { emailsJson } from "../../../modules/sampleEmibJson";
+import EmailPreview from "../../../components/eMIB/EmailPreview";
+import Email from "../../../components/eMIB/Email";
 
 const INBOX_SPECS = emailsJson.emailsEN;
 
-it("Shows only email 1", () => {
-  testCore(0);
-});
-
-it("Shows only email 2", () => {
-  testCore(1);
-});
-
-it("Shows only email 3", () => {
-  testCore(2);
-});
-
-function testCore(selected) {
+it("Displays 3 email previews when there are 3 emails", () => {
   const wrapper = shallow(
     <Inbox
       emails={INBOX_SPECS}
@@ -29,17 +19,6 @@ function testCore(selected) {
       readEmail={() => {}}
     />
   );
-  wrapper.setState({ currentEmail: selected });
-  for (let i = 0; i < 3; i++) {
-    const currentEmail = INBOX_SPECS[i];
-    const subjectHeader = <h3>{currentEmail.subject}</h3>;
-    const checkBody = wrapper.contains(subjectHeader);
-    if (i === selected) {
-      // if the current email is selected, the body should be shown
-      expect(checkBody).toEqual(true);
-    }
-    if (i !== selected) {
-      expect(checkBody).toEqual(false);
-    }
-  }
-}
+  expect(wrapper.find(EmailPreview).length).toEqual(INBOX_SPECS.length);
+  expect(wrapper.find(Email).length).toEqual(1);
+});

--- a/frontend/src/tests/modules/EmibInboxRedux.test.js
+++ b/frontend/src/tests/modules/EmibInboxRedux.test.js
@@ -1,4 +1,9 @@
-import emibInbox, { initializeEmailSummaries, readEmail } from "../../modules/EmibInboxRedux";
+import emibInbox, {
+  initializeEmailSummaries,
+  readEmail,
+  addEmail,
+  addTask
+} from "../../modules/EmibInboxRedux";
 import { setLanguage } from "../../modules/LocalizeRedux";
 import { emailsJson } from "../../modules/sampleEmibJson";
 
@@ -27,22 +32,36 @@ describe("EmibInboxRedux", () => {
   describe("read email action", () => {
     it("should update email 0 read state to true", () => {
       const readAction = readEmail(0);
-      expect(emibInbox(stubbedInitialState, readAction).emailSummaries[0]).toEqual({
-        isRead: true
-      });
-      expect(emibInbox(stubbedInitialState, readAction).emailSummaries[1]).toEqual({
-        isRead: false
-      });
+      const newState = emibInbox(stubbedInitialState, readAction);
+      expect(newState.emailSummaries[0].isRead).toEqual(true);
+      expect(newState.emailSummaries[1].isRead).toEqual(false);
     });
 
     it("should update email 1 read state to true", () => {
       const readAction = readEmail(1);
-      expect(emibInbox(stubbedInitialState, readAction).emailSummaries[0]).toEqual({
-        isRead: false
-      });
-      expect(emibInbox(stubbedInitialState, readAction).emailSummaries[1]).toEqual({
-        isRead: true
-      });
+      const newState = emibInbox(stubbedInitialState, readAction);
+      expect(newState.emailSummaries[0].isRead).toEqual(false);
+      expect(newState.emailSummaries[1].isRead).toEqual(true);
+    });
+  });
+
+  describe("add email action", () => {
+    it("should update email 0 count state", () => {
+      const addAction = addEmail(0);
+      const newState = emibInbox(stubbedInitialState, addAction);
+      expect(newState.emailSummaries[0].emailCount).toEqual(1);
+      expect(newState.emailSummaries[0].taskCount).toEqual(0);
+      expect(newState.emailSummaries[1].emailCount).toEqual(0);
+    });
+  });
+
+  describe("add task action", () => {
+    it("should update email 0 count state", () => {
+      const addAction = addTask(0);
+      const newState = emibInbox(stubbedInitialState, addAction);
+      expect(newState.emailSummaries[0].taskCount).toEqual(1);
+      expect(newState.emailSummaries[0].emailCount).toEqual(0);
+      expect(newState.emailSummaries[1].taskCount).toEqual(0);
     });
   });
 });

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -333,9 +333,7 @@ let LOCALIZE = new LocalizedStrings({
         date: "Date",
         addReply: "Add email Response",
         addTask: "Create a task",
-        replyTextPart1: "You responded with ",
-        replyTextPart2: " emails and ",
-        replyTextPart3: " tasks",
+        yourActions: `You responded with {0} emails and {1} tasks`,
         editEmailActionDialog: {
           addEmail: "Add email response",
           editEmail: "Edit email response",
@@ -789,9 +787,7 @@ let LOCALIZE = new LocalizedStrings({
         date: "Date",
         addReply: "FR Add email Response",
         addTask: "FR Create a task",
-        replyTextPart1: "FR You responded with ",
-        replyTextPart2: " FR emails and ",
-        replyTextPart3: " FR tasks",
+        yourActions: `FR You responded with {0} emails and {1} tasks`,
         editEmailActionDialog: {
           addEmail: "FR Add email response",
           editEmail: "FR Edit email response",


### PR DESCRIPTION
# Description

Add an email or task updates the counts in redux, and displays the counts at the top of each email.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

<img width="1164" alt="Screen Shot 2019-04-04 at 8 03 18 PM" src="https://user-images.githubusercontent.com/4640747/55596044-b9d1af00-5714-11e9-9a63-eee677189d56.png">

# Testing

Manual steps to reproduce this functionality:

1.  Go to sample test inbox.
2.  Click add task and save.
3. Click add email and save.
4. Notice counts increasing.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 10+, Firefox, and Chrome
