### PR TITLE
[Add Email] Created the add email form

### DIFF
--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -4,7 +4,8 @@ import LOCALIZE from "../../text_resources";
 const styles = {
   container: {
     maxHeight: "calc(100vh - 300px)",
-    overflow: "auto"
+    overflow: "auto",
+    width: 700
   },
   header: {
     responseTypeIcons: {

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -1,10 +1,140 @@
 import React, { Component } from "react";
+import LOCALIZE from "../../text_resources";
+
+const styles = {
+  header: {
+    responseTypeIcons: {
+      color: "#00565E",
+      margin: "0 8px",
+      padding: 3,
+      border: "1px solid #00565E",
+      borderRadius: 4
+    },
+    responseType: {
+      color: "#00565E",
+      textDecoration: "underline"
+    },
+    textFieldBoxPadding: {
+      padding: "0 6px"
+    },
+    textField: {
+      padding: "4px 12px",
+      border: "1px solid #00565E",
+      borderRadius: 4,
+      width: "calc(100% - 36px)"
+    },
+    titleStyle: {
+      float: "left",
+      width: 24,
+      height: 32,
+      lineHeight: "2.1em"
+    }
+  },
+  response: {
+    textArea: {
+      padding: "6px 12px",
+      border: "1px solid #00565E",
+      borderRadius: 4,
+      width: "99.3%",
+      height: 225,
+      resize: "none"
+    }
+  },
+  hr: {
+    margin: "12px 0 6px 0"
+  },
+  reasonsForAction: {
+    textArea: {
+      padding: "6px 12px",
+      border: "1px solid #00565E",
+      borderRadius: 4,
+      width: "99.3%",
+      height: 150,
+      resize: "none"
+    }
+  }
+};
 
 class EditEmail extends Component {
   render() {
     return (
       <div>
-        <div>Email Body is Under Construction</div>
+        <form>
+          <div>
+            <p className="font-weight-bold">
+              {LOCALIZE.emibTest.inboxPage.addEmailResponse.selectResponseType}{" "}
+              <>
+                <i className="fas fa-reply" style={styles.header.responseTypeIcons} />
+                <span style={styles.header.responseType}>
+                  {LOCALIZE.emibTest.inboxPage.emailCommons.reply}
+                </span>
+              </>
+              <>
+                <i className="fas fa-reply-all" style={styles.header.responseTypeIcons} />
+                <span style={styles.header.responseType}>
+                  {LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
+                </span>
+              </>
+              <>
+                <i className="fas fa-share-square" style={styles.header.responseTypeIcons} />
+                <span style={styles.header.responseType}>
+                  {LOCALIZE.emibTest.inboxPage.emailCommons.forward}
+                </span>
+              </>
+            </p>
+          </div>
+          <div>
+            <p className="font-weight-bold">
+              <span style={styles.header.titleStyle}>
+                {LOCALIZE.emibTest.inboxPage.emailCommons.to}
+              </span>
+              <span style={styles.header.textFieldBoxPadding}>
+                <input type="text" placeholder="John Smith" style={styles.header.textField} />
+              </span>
+            </p>
+          </div>
+          <div>
+            <p className="font-weight-bold">
+              <span style={styles.header.titleStyle}>
+                {LOCALIZE.emibTest.inboxPage.emailCommons.cc}
+              </span>
+              <span style={styles.header.textFieldBoxPadding}>
+                <input type="text" placeholder="John Smith" style={styles.header.textField} />
+              </span>
+            </p>
+          </div>
+          <div>
+            <p className="font-weight-bold">
+              {LOCALIZE.emibTest.inboxPage.addEmailResponse.response}
+            </p>
+            <fieldset>
+              <label htmlFor="your-response-text-area" className="invisible position-absolute">
+                {LOCALIZE.emibTest.inboxPage.addEmailResponse.response}
+              </label>
+              <textarea
+                id="your-response-text-area"
+                maxLength="500"
+                style={styles.response.textArea}
+              />
+            </fieldset>
+          </div>
+          <hr style={styles.hr} />
+          <div>
+            <p className="font-weight-bold">
+              {LOCALIZE.emibTest.inboxPage.addEmailResponse.reasonsForAction}
+            </p>
+            <fieldset>
+              <label htmlFor="reasons-for-action-text-area" className="invisible position-absolute">
+                {LOCALIZE.emibTest.inboxPage.addEmailResponse.reasonsForAction}
+              </label>
+              <textarea
+                id="reasons-for-action-text-area"
+                maxLength="100"
+                style={styles.reasonsForAction.textArea}
+              />
+            </fieldset>
+          </div>
+        </form>
       </div>
     );
   }

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -130,7 +130,7 @@ class EditEmail extends Component {
                 <input
                   id="to-field"
                   type="text"
-                  placeholder="John Smith"
+                  placeholder={LOCALIZE.emibTest.inboxPage.addEmailResponse.headerFieldPlaceholder}
                   style={styles.header.textField}
                 />
               </span>
@@ -145,7 +145,7 @@ class EditEmail extends Component {
                 <input
                   id="cc-field"
                   type="text"
-                  placeholder="John Smith"
+                  placeholder={LOCALIZE.emibTest.inboxPage.addEmailResponse.headerFieldPlaceholder}
                   style={styles.header.textField}
                 />
               </span>

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -15,6 +15,9 @@ const styles = {
       borderRadius: 4,
       cursor: "pointer"
     },
+    radioButtonZone: {
+      marginBottom: 12
+    },
     responseTypeRadio: {
       all: "unset",
       color: "#00565E",
@@ -76,56 +79,80 @@ class EditEmail extends Component {
             <p className="font-weight-bold" style={styles.header.title}>
               {LOCALIZE.emibTest.inboxPage.addEmailResponse.selectResponseType}
             </p>
-            <div style={styles.header.responseTypeRadio}>
-              <input type="radio" name="responseTypeRadio" style={styles.header.radioPadding} />
-              <i className="fas fa-reply" style={styles.header.responseTypeIcons} />
-              <span style={styles.header.radioText}>
-                {LOCALIZE.emibTest.inboxPage.emailCommons.reply}
-              </span>
-            </div>
-            <br />
-            <div style={styles.header.responseTypeRadio}>
-              <input type="radio" name="responseTypeRadio" style={styles.header.radioPadding} />
-              <i className="fas fa-reply-all" style={styles.header.responseTypeIcons} />
-              <span style={styles.header.radioText}>
-                {LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
-              </span>
-            </div>
-            <br />
-            <div style={styles.header.responseTypeRadio}>
-              <input type="radio" name="responseTypeRadio" style={styles.header.radioPadding} />
-              <i className="fas fa-share-square" style={styles.header.responseTypeIcons} />
-              <span style={styles.header.radioText}>
-                {LOCALIZE.emibTest.inboxPage.emailCommons.forward}
-              </span>
+            <div style={styles.header.radioButtonZone}>
+              <div style={styles.header.responseTypeRadio}>
+                <input
+                  id="reply-radio"
+                  type="radio"
+                  name="responseTypeRadio"
+                  style={styles.header.radioPadding}
+                />
+                <label htmlFor="reply-radio" style={styles.header.radioText}>
+                  <i className="fas fa-reply" style={styles.header.responseTypeIcons} />
+                  {LOCALIZE.emibTest.inboxPage.emailCommons.reply}
+                </label>
+              </div>
+              <br />
+              <div style={styles.header.responseTypeRadio}>
+                <input
+                  id="reply-all-radio"
+                  type="radio"
+                  name="responseTypeRadio"
+                  style={styles.header.radioPadding}
+                />
+                <label htmlFor="reply-all-radio" style={styles.header.radioText}>
+                  <i className="fas fa-reply-all" style={styles.header.responseTypeIcons} />
+                  {LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
+                </label>
+              </div>
+              <br />
+              <div style={styles.header.responseTypeRadio}>
+                <input
+                  id="forward-radio"
+                  type="radio"
+                  name="responseTypeRadio"
+                  style={styles.header.radioPadding}
+                />
+                <label htmlFor="forward-radio" style={styles.header.radioText}>
+                  <i className="fas fa-share-square" style={styles.header.responseTypeIcons} />
+                  {LOCALIZE.emibTest.inboxPage.emailCommons.forward}
+                </label>
+              </div>
             </div>
           </div>
           <div>
-            <p className="font-weight-bold">
-              <span style={styles.header.titleStyle}>
+            <div className="font-weight-bold form-group">
+              <label htmlFor="to-field" style={styles.header.titleStyle}>
                 {LOCALIZE.emibTest.inboxPage.emailCommons.to}
-              </span>
+              </label>
               <span style={styles.header.textFieldBoxPadding}>
-                <input type="text" placeholder="John Smith" style={styles.header.textField} />
+                <input
+                  id="to-field"
+                  type="text"
+                  placeholder="John Smith"
+                  style={styles.header.textField}
+                />
               </span>
-            </p>
+            </div>
           </div>
           <div>
-            <p className="font-weight-bold">
-              <span style={styles.header.titleStyle}>
+            <div className="font-weight-bold form-group">
+              <label htmlFor="cc-field" style={styles.header.titleStyle}>
                 {LOCALIZE.emibTest.inboxPage.emailCommons.cc}
-              </span>
+              </label>
               <span style={styles.header.textFieldBoxPadding}>
-                <input type="text" placeholder="John Smith" style={styles.header.textField} />
+                <input
+                  id="cc-field"
+                  type="text"
+                  placeholder="John Smith"
+                  style={styles.header.textField}
+                />
               </span>
-            </p>
+            </div>
           </div>
           <div>
-            <p className="font-weight-bold">
-              {LOCALIZE.emibTest.inboxPage.addEmailResponse.response}
-            </p>
-            <fieldset>
-              <label htmlFor="your-response-text-area" className="invisible position-absolute">
+            <div className="font-weight-bold form-group">
+              <label htmlFor="your-response-text-area">
                 {LOCALIZE.emibTest.inboxPage.addEmailResponse.response}
               </label>
               <textarea
@@ -133,15 +160,12 @@ class EditEmail extends Component {
                 maxLength="500"
                 style={styles.response.textArea}
               />
-            </fieldset>
+            </div>
           </div>
           <hr style={styles.hr} />
           <div>
-            <p className="font-weight-bold">
-              {LOCALIZE.emibTest.inboxPage.addEmailResponse.reasonsForAction}
-            </p>
-            <fieldset>
-              <label htmlFor="reasons-for-action-text-area" className="invisible position-absolute">
+            <div className="font-weight-bold form-group">
+              <label htmlFor="reasons-for-action-text-area">
                 {LOCALIZE.emibTest.inboxPage.addEmailResponse.reasonsForAction}
               </label>
               <textarea
@@ -149,7 +173,7 @@ class EditEmail extends Component {
                 maxLength="100"
                 style={styles.reasonsForAction.textArea}
               />
-            </fieldset>
+            </div>
           </div>
         </form>
       </div>

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -2,6 +2,10 @@ import React, { Component } from "react";
 import LOCALIZE from "../../text_resources";
 
 const styles = {
+  container: {
+    maxHeight: "calc(100vh - 300px)",
+    overflow: "auto"
+  },
   header: {
     responseTypeIcons: {
       color: "#00565E",
@@ -66,7 +70,7 @@ const styles = {
 class EditEmail extends Component {
   render() {
     return (
-      <div>
+      <div style={styles.container}>
         <form>
           <div>
             <p className="font-weight-bold" style={styles.header.title}>

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -8,10 +8,18 @@ const styles = {
       margin: "0 8px",
       padding: 3,
       border: "1px solid #00565E",
-      borderRadius: 4
+      borderRadius: 4,
+      cursor: "pointer"
     },
-    responseType: {
+    responseTypeRadio: {
+      all: "unset",
       color: "#00565E",
+      cursor: "pointer"
+    },
+    radioPadding: {
+      marginBottom: 16
+    },
+    radioText: {
       textDecoration: "underline"
     },
     textFieldBoxPadding: {
@@ -61,27 +69,32 @@ class EditEmail extends Component {
       <div>
         <form>
           <div>
-            <p className="font-weight-bold">
-              {LOCALIZE.emibTest.inboxPage.addEmailResponse.selectResponseType}{" "}
-              <>
-                <i className="fas fa-reply" style={styles.header.responseTypeIcons} />
-                <span style={styles.header.responseType}>
-                  {LOCALIZE.emibTest.inboxPage.emailCommons.reply}
-                </span>
-              </>
-              <>
-                <i className="fas fa-reply-all" style={styles.header.responseTypeIcons} />
-                <span style={styles.header.responseType}>
-                  {LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
-                </span>
-              </>
-              <>
-                <i className="fas fa-share-square" style={styles.header.responseTypeIcons} />
-                <span style={styles.header.responseType}>
-                  {LOCALIZE.emibTest.inboxPage.emailCommons.forward}
-                </span>
-              </>
+            <p className="font-weight-bold" style={styles.header.title}>
+              {LOCALIZE.emibTest.inboxPage.addEmailResponse.selectResponseType}
             </p>
+            <div style={styles.header.responseTypeRadio}>
+              <input type="radio" name="responseTypeRadio" style={styles.header.radioPadding} />
+              <i className="fas fa-reply" style={styles.header.responseTypeIcons} />
+              <span style={styles.header.radioText}>
+                {LOCALIZE.emibTest.inboxPage.emailCommons.reply}
+              </span>
+            </div>
+            <br />
+            <div style={styles.header.responseTypeRadio}>
+              <input type="radio" name="responseTypeRadio" style={styles.header.radioPadding} />
+              <i className="fas fa-reply-all" style={styles.header.responseTypeIcons} />
+              <span style={styles.header.radioText}>
+                {LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
+              </span>
+            </div>
+            <br />
+            <div style={styles.header.responseTypeRadio}>
+              <input type="radio" name="responseTypeRadio" style={styles.header.radioPadding} />
+              <i className="fas fa-share-square" style={styles.header.responseTypeIcons} />
+              <span style={styles.header.radioText}>
+                {LOCALIZE.emibTest.inboxPage.emailCommons.forward}
+              </span>
+            </div>
           </div>
           <div>
             <p className="font-weight-bold">

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -37,11 +37,11 @@ const styles = {
       padding: "4px 12px",
       border: "1px solid #00565E",
       borderRadius: 4,
-      width: "calc(100% - 36px)"
+      width: "calc(100% - 40px)"
     },
     titleStyle: {
       float: "left",
-      width: 24,
+      width: 28,
       height: 32,
       lineHeight: "2.1em"
     }
@@ -49,9 +49,10 @@ const styles = {
   response: {
     textArea: {
       padding: "6px 12px",
+      margin: "0 6px",
       border: "1px solid #00565E",
       borderRadius: 4,
-      width: "99.3%",
+      width: "calc(100% - 12px)",
       height: 225,
       resize: "none"
     }
@@ -62,9 +63,10 @@ const styles = {
   reasonsForAction: {
     textArea: {
       padding: "6px 12px",
+      margin: "0 6px",
       border: "1px solid #00565E",
       borderRadius: 4,
-      width: "99.3%",
+      width: "calc(100% - 12px)",
       height: 150,
       resize: "none"
     }

--- a/frontend/src/components/eMIB/EditEmailActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditEmailActionDialog.jsx
@@ -31,7 +31,8 @@ const styles = {
     backgroundColor: "#00565E",
     color: "white",
     fontSize: 16,
-    fontWeight: 600
+    fontWeight: 600,
+    borderRadius: "10px 10px 0px 0px"
   }
 };
 

--- a/frontend/src/components/eMIB/ResponseItem.jsx
+++ b/frontend/src/components/eMIB/ResponseItem.jsx
@@ -59,7 +59,7 @@ class ResponseItem extends Component {
                 <>
                   <i className="fas fa-reply" style={styles.responseTypeIcon} />
                   <span style={styles.responseType}>
-                    {LOCALIZE.emibTest.inboxPage.emailResponse.responseType.reply}
+                    {LOCALIZE.emibTest.inboxPage.emailCommons.reply}
                   </span>
                 </>
               )}
@@ -67,7 +67,7 @@ class ResponseItem extends Component {
                 <>
                   <i className="fas fa-reply-all" style={styles.responseTypeIcon} />
                   <span style={styles.responseType}>
-                    {LOCALIZE.emibTest.inboxPage.emailResponse.responseType.replyAll}
+                    {LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
                   </span>
                 </>
               )}
@@ -75,20 +75,20 @@ class ResponseItem extends Component {
                 <>
                   <i className="fas fa-share-square" style={styles.responseTypeIcon} />
                   <span style={styles.responseType}>
-                    {LOCALIZE.emibTest.inboxPage.emailResponse.responseType.forward}
+                    {LOCALIZE.emibTest.inboxPage.emailCommons.forward}
                   </span>
                 </>
               )}
             </p>
             <p>
               <span className="font-weight-bold">
-                {LOCALIZE.emibTest.inboxPage.emailResponse.to}&nbsp;
+                {LOCALIZE.emibTest.inboxPage.emailCommons.to}&nbsp;
               </span>
               <span>{to}</span>
             </p>
             <p>
               <span className="font-weight-bold">
-                {LOCALIZE.emibTest.inboxPage.emailResponse.cc}&nbsp;
+                {LOCALIZE.emibTest.inboxPage.emailCommons.cc}&nbsp;
               </span>
               <span>{cc}</span>
             </p>

--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -196,5 +196,5 @@ Progess Steps
   left: 50%;
   transform: translate(-50%, -50%) !important;
   min-width: 500px !important;
-  max-width: 1000px !important;
+  max-width: 750px !important;
 }

--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -196,5 +196,5 @@ Progess Steps
   left: 50%;
   transform: translate(-50%, -50%) !important;
   min-width: 500px !important;
-  max-width: 750px !important;
+  max-width: 1000px !important;
 }

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -806,7 +806,10 @@ let LOCALIZE = new LocalizedStrings({
         },
         emailCommons: {
           to: "À :",
-          cc: "Cc :"
+          cc: "Cc :",
+          reply: "répondre",
+          replyAll: "répondre à tous",
+          forward: "transmettre"
         },
         addEmailResponse: {
           selectResponseType:
@@ -815,11 +818,6 @@ let LOCALIZE = new LocalizedStrings({
           reasonsForAction: "FR Add reasons for actions here (optional)"
         },
         emailResponse: {
-          responseType: {
-            reply: "répondre",
-            replyAll: "répondre à tous",
-            forward: "transmettre"
-          },
           description: "FR For this response, you've chosen to:",
           response: "FR Your response:",
           reasonsForAction: "FR Your reasons for action:",

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -343,15 +343,20 @@ let LOCALIZE = new LocalizedStrings({
           editTask: "Edit task",
           save: "Save response"
         },
-        emailResponse: {
-          responseType: {
-            reply: "reply",
-            replyAll: "reply all",
-            forward: "forward"
-          },
-          description: "For this response, you've chosen to:",
+        emailCommons: {
           to: "To:",
           cc: "Cc:",
+          reply: "reply",
+          replyAll: "reply all",
+          forward: "forward"
+        },
+        addEmailResponse: {
+          selectResponseType: "Please select how you would like to respond to the original email:",
+          response: "Your response:",
+          reasonsForAction: "Add reasons for actions here (optional)"
+        },
+        emailResponse: {
+          description: "For this response, you've chosen to:",
           response: "Your response:",
           reasonsForAction: "Your reasons for action:",
           editButton: "Edit response",
@@ -799,6 +804,16 @@ let LOCALIZE = new LocalizedStrings({
           editTask: "FR Edit task",
           save: "FR Save response"
         },
+        emailCommons: {
+          to: "À :",
+          cc: "Cc :"
+        },
+        addEmailResponse: {
+          selectResponseType:
+            "FR Please select how you would like to respond to the original email:",
+          response: "FR Your response:",
+          reasonsForAction: "FR Add reasons for actions here (optional)"
+        },
         emailResponse: {
           responseType: {
             reply: "répondre",
@@ -806,8 +821,6 @@ let LOCALIZE = new LocalizedStrings({
             forward: "transmettre"
           },
           description: "FR For this response, you've chosen to:",
-          to: "À :",
-          cc: "Cc :",
           response: "FR Your response:",
           reasonsForAction: "FR Your reasons for action:",
           editButton: "Modifier réponse",

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -352,6 +352,7 @@ let LOCALIZE = new LocalizedStrings({
         },
         addEmailResponse: {
           selectResponseType: "Please select how you would like to respond to the original email:",
+          headerFieldPlaceholder: "JohnSmith",
           response: "Your response:",
           reasonsForAction: "Add reasons for actions here (optional)"
         },
@@ -814,6 +815,7 @@ let LOCALIZE = new LocalizedStrings({
         addEmailResponse: {
           selectResponseType:
             "FR Please select how you would like to respond to the original email:",
+          headerFieldPlaceholder: "JohnSmith",
           response: "FR Your response:",
           reasonsForAction: "FR Add reasons for actions here (optional)"
         },


### PR DESCRIPTION
# Description

I created a form that will allow the candidates to add an email response for the specified email. This form is displayed when you click on **'Add email response'** in the inbox.

**Note that the radio buttons are not functional and the **Save response** button has the same behavior than before.**

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**Add Email Form - Part 1:**

![image](https://user-images.githubusercontent.com/23021242/55639800-3bb6ec00-5798-11e9-94bc-047dd6ca043e.png)

**Add Email Form - Part 2:**

![image](https://user-images.githubusercontent.com/23021242/55639852-512c1600-5798-11e9-8492-b359efc2fce3.png)

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB Sample Test.
2.  Complete the _pre-test_ process.
3.  Open the _Inbox_ tab.
4.  Click on _Add email response_ and make sure that the form looks good.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 10+, Firefox, and Chrome
