### PR TITLE
[Inbox] Add email action handles action data

### DIFF
--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import "../../css/collapsing-item.css";
 import LOCALIZE from "../../text_resources";
+import { EMAIL_TYPE } from "./constants";
 
 const styles = {
   responseTypeIcon: {
@@ -24,16 +25,9 @@ const styles = {
   }
 };
 
-export const EMAIL_TYPE = {
-  reply: "reply",
-  replyAll: "reply all",
-  forward: "forward"
-};
-
 class ActionViewEmail extends Component {
   static propTypes = {
-    responseType: PropTypes.oneOf([EMAIL_TYPE.reply, EMAIL_TYPE.replyAll, EMAIL_TYPE.forward])
-      .isRequired,
+    responseType: PropTypes.oneOf(Object.values(EMAIL_TYPE)).isRequired,
     to: PropTypes.string.isRequired,
     cc: PropTypes.string,
     response: PropTypes.string.isRequired,

--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -24,19 +24,16 @@ const styles = {
   }
 };
 
-export const RESPONSE_TYPE = {
+export const EMAIL_TYPE = {
   reply: "reply",
   replyAll: "reply all",
   forward: "forward"
 };
 
-class ResponseItem extends Component {
+class ActionViewEmail extends Component {
   static propTypes = {
-    responseType: PropTypes.oneOf([
-      RESPONSE_TYPE.reply,
-      RESPONSE_TYPE.replyAll,
-      RESPONSE_TYPE.forward
-    ]).isRequired,
+    responseType: PropTypes.oneOf([EMAIL_TYPE.reply, EMAIL_TYPE.replyAll, EMAIL_TYPE.forward])
+      .isRequired,
     to: PropTypes.string.isRequired,
     cc: PropTypes.string,
     response: PropTypes.string.isRequired,
@@ -55,7 +52,7 @@ class ResponseItem extends Component {
           <div id="email-header-desc" role="dialog">
             <p className="font-weight-bold">
               {LOCALIZE.emibTest.inboxPage.emailResponse.description}
-              {responseType === RESPONSE_TYPE.reply && (
+              {responseType === EMAIL_TYPE.reply && (
                 <>
                   <i className="fas fa-reply" style={styles.responseTypeIcon} />
                   <span style={styles.responseType}>
@@ -63,7 +60,7 @@ class ResponseItem extends Component {
                   </span>
                 </>
               )}
-              {responseType === RESPONSE_TYPE.replyAll && (
+              {responseType === EMAIL_TYPE.replyAll && (
                 <>
                   <i className="fas fa-reply-all" style={styles.responseTypeIcon} />
                   <span style={styles.responseType}>
@@ -71,7 +68,7 @@ class ResponseItem extends Component {
                   </span>
                 </>
               )}
-              {responseType === RESPONSE_TYPE.forward && (
+              {responseType === EMAIL_TYPE.forward && (
                 <>
                   <i className="fas fa-share-square" style={styles.responseTypeIcon} />
                   <span style={styles.responseType}>
@@ -131,4 +128,4 @@ class ResponseItem extends Component {
     );
   }
 }
-export default ResponseItem;
+export default ActionViewEmail;

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -1,10 +1,13 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
 import LOCALIZE from "../../text_resources";
 import EditEmail from "./EditEmail";
 import EditTask from "./EditTask";
 import { Modal } from "react-bootstrap";
 import { ACTION_TYPE, EDIT_MODE } from "./constants";
+import { addEmail, addTask } from "../../modules/EmibInboxRedux";
 
 const styles = {
   icon: {
@@ -32,9 +35,11 @@ class EditActionDialog extends Component {
     emailId: PropTypes.number.isRequired,
     showDialog: PropTypes.bool.isRequired,
     handleClose: PropTypes.func.isRequired,
-    saveAction: PropTypes.func.isRequired,
-    actionType: PropTypes.oneOf([ACTION_TYPE.email, ACTION_TYPE.task]).isRequired,
-    editMode: PropTypes.oneOf([EDIT_MODE.create, EDIT_MODE.update]).isRequired
+    actionType: PropTypes.oneOf(Object.values(ACTION_TYPE)).isRequired,
+    editMode: PropTypes.oneOf(Object.values(EDIT_MODE)).isRequired,
+    // Provided from Redux.
+    addEmail: PropTypes.func.isRequired,
+    addTask: PropTypes.func.isRequired
   };
 
   state = {
@@ -42,7 +47,11 @@ class EditActionDialog extends Component {
   };
 
   handleSave = () => {
-    this.props.saveAction(this.props.emailId, this.state.action);
+    if (this.props.actionType === ACTION_TYPE.email) {
+      this.props.addEmail(this.props.emailId, this.state.action);
+    } else if (this.props.actionType === ACTION_TYPE.task) {
+      this.props.addTask(this.props.emailId, this.state.action);
+    }
     this.props.handleClose();
   };
 
@@ -109,4 +118,19 @@ class EditActionDialog extends Component {
     );
   }
 }
-export default EditActionDialog;
+
+export { EditActionDialog as UnconnectedEditActionDialog };
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators(
+    {
+      addEmail,
+      addTask
+    },
+    dispatch
+  );
+
+export default connect(
+  null,
+  mapDispatchToProps
+)(EditActionDialog);

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -4,16 +4,7 @@ import LOCALIZE from "../../text_resources";
 import EditEmail from "./EditEmail";
 import EditTask from "./EditTask";
 import { Modal } from "react-bootstrap";
-
-export const ACTION_TYPE = {
-  email: "email",
-  task: "task"
-};
-
-export const EDIT_MODE = {
-  create: "create",
-  update: "update"
-};
+import { ACTION_TYPE, EDIT_MODE } from "./constants";
 
 const styles = {
   icon: {

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -36,17 +36,17 @@ const styles = {
   }
 };
 
-class EditEmailActionDialog extends Component {
+class EditActionDialog extends Component {
   static propTypes = {
     showDialog: PropTypes.bool.isRequired,
     handleClose: PropTypes.func.isRequired,
-    saveEmail: PropTypes.func.isRequired,
+    saveAction: PropTypes.func.isRequired,
     actionType: PropTypes.oneOf([ACTION_TYPE.email, ACTION_TYPE.task]).isRequired,
     editMode: PropTypes.oneOf([EDIT_MODE.create, EDIT_MODE.update]).isRequired
   };
 
   handleSave = () => {
-    this.props.saveEmail();
+    this.props.saveAction();
     this.props.handleClose();
   };
 
@@ -64,9 +64,9 @@ class EditEmailActionDialog extends Component {
                       <i style={styles.icon} className="fas fa-envelope" />
                       <h3 style={styles.dialogHeaderText}>
                         {editMode === EDIT_MODE.create &&
-                          LOCALIZE.emibTest.inboxPage.editEmailActionDialog.addEmail}
+                          LOCALIZE.emibTest.inboxPage.editActionDialog.addEmail}
                         {editMode === EDIT_MODE.update &&
-                          LOCALIZE.emibTest.inboxPage.editEmailActionDialog.editEmail}
+                          LOCALIZE.emibTest.inboxPage.editActionDialog.editEmail}
                       </h3>
                     </div>
                   )}
@@ -75,9 +75,9 @@ class EditEmailActionDialog extends Component {
                       <i style={styles.icon} className="fas fa-tasks" />
                       <h3 style={styles.dialogHeaderText}>
                         {editMode === EDIT_MODE.create &&
-                          LOCALIZE.emibTest.inboxPage.editEmailActionDialog.addTask}
+                          LOCALIZE.emibTest.inboxPage.editActionDialog.addTask}
                         {editMode === EDIT_MODE.update &&
-                          LOCALIZE.emibTest.inboxPage.editEmailActionDialog.editTask}
+                          LOCALIZE.emibTest.inboxPage.editActionDialog.editTask}
                       </h3>
                     </div>
                   )}
@@ -97,7 +97,7 @@ class EditEmailActionDialog extends Component {
                     className="btn btn-primary"
                     onClick={this.handleSave}
                   >
-                    {LOCALIZE.emibTest.inboxPage.editEmailActionDialog.save}
+                    {LOCALIZE.emibTest.inboxPage.editActionDialog.save}
                   </button>
                 </div>
               </div>
@@ -108,4 +108,4 @@ class EditEmailActionDialog extends Component {
     );
   }
 }
-export default EditEmailActionDialog;
+export default EditActionDialog;

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -38,6 +38,7 @@ const styles = {
 
 class EditActionDialog extends Component {
   static propTypes = {
+    emailId: PropTypes.number.isRequired,
     showDialog: PropTypes.bool.isRequired,
     handleClose: PropTypes.func.isRequired,
     saveAction: PropTypes.func.isRequired,
@@ -45,9 +46,17 @@ class EditActionDialog extends Component {
     editMode: PropTypes.oneOf([EDIT_MODE.create, EDIT_MODE.update]).isRequired
   };
 
+  state = {
+    action: {}
+  };
+
   handleSave = () => {
-    this.props.saveAction();
+    this.props.saveAction(this.props.emailId, this.state.action);
     this.props.handleClose();
+  };
+
+  editAction = updatedAction => {
+    this.setState({ action: updatedAction });
   };
 
   render() {
@@ -85,7 +94,7 @@ class EditActionDialog extends Component {
               }
             </Modal.Header>
             <Modal.Body>
-              {actionType === ACTION_TYPE.email && <EditEmail />}
+              {actionType === ACTION_TYPE.email && <EditEmail onChange={this.editAction} />}
               {actionType === ACTION_TYPE.task && <EditTask />}
             </Modal.Body>
             <Modal.Footer>

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -55,7 +55,7 @@ class EditActionDialog extends Component {
     this.props.handleClose();
   };
 
-  // updatedAction is of shape actionShape
+  // updatedAction is the PropType shape actionShape and represents a single action a candidate takes on an email
   editAction = updatedAction => {
     this.setState({ action: updatedAction });
   };

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -46,6 +46,7 @@ class EditActionDialog extends Component {
     this.props.handleClose();
   };
 
+  // updatedAction is of shape actionShape
   editAction = updatedAction => {
     this.setState({ action: updatedAction });
   };

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
-import { RESPONSE_TYPE } from "./ResponseItem";
+import { EMAIL_TYPE } from "./ActionViewEmail";
 
 const styles = {
   container: {
@@ -81,7 +81,7 @@ class EditEmail extends Component {
   };
 
   state = {
-    emailType: RESPONSE_TYPE.reply,
+    emailType: EMAIL_TYPE.reply,
     toValue: "",
     ccValue: "",
     responseValue: "",
@@ -136,8 +136,8 @@ class EditEmail extends Component {
                   name="responseTypeRadio"
                   style={styles.header.radioPadding}
                   onChange={this.onEmailTypeChange}
-                  value={RESPONSE_TYPE.reply}
-                  checked={emailType === RESPONSE_TYPE.reply}
+                  value={EMAIL_TYPE.reply}
+                  checked={emailType === EMAIL_TYPE.reply}
                 />
                 <label htmlFor="reply-radio" style={styles.header.radioText}>
                   <i className="fas fa-reply" style={styles.header.responseTypeIcons} />
@@ -152,8 +152,8 @@ class EditEmail extends Component {
                   name="responseTypeRadio"
                   style={styles.header.radioPadding}
                   onChange={this.onEmailTypeChange}
-                  value={RESPONSE_TYPE.replyAll}
-                  checked={emailType === RESPONSE_TYPE.replyAll}
+                  value={EMAIL_TYPE.replyAll}
+                  checked={emailType === EMAIL_TYPE.replyAll}
                 />
                 <label htmlFor="reply-all-radio" style={styles.header.radioText}>
                   <i className="fas fa-reply-all" style={styles.header.responseTypeIcons} />
@@ -168,8 +168,8 @@ class EditEmail extends Component {
                   name="responseTypeRadio"
                   style={styles.header.radioPadding}
                   onChange={this.onEmailTypeChange}
-                  value={RESPONSE_TYPE.forward}
-                  checked={emailType === RESPONSE_TYPE.forward}
+                  value={EMAIL_TYPE.forward}
+                  checked={emailType === EMAIL_TYPE.forward}
                 />
                 <label htmlFor="forward-radio" style={styles.header.radioText}>
                   <i className="fas fa-share-square" style={styles.header.responseTypeIcons} />

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
 import { RESPONSE_TYPE } from "./ResponseItem";
 
@@ -75,6 +76,10 @@ const styles = {
 };
 
 class EditEmail extends Component {
+  static propTypes = {
+    onChange: PropTypes.func.isRequired
+  };
+
   state = {
     emailType: RESPONSE_TYPE.reply,
     toValue: "",
@@ -84,23 +89,33 @@ class EditEmail extends Component {
   };
 
   onEmailTypeChange = event => {
-    this.setState({ emailType: event.target.value });
+    const newEmailType = event.target.value;
+    this.setState({ emailType: newEmailType });
+    this.props.onChange({ ...this.state, emailType: newEmailType });
   };
 
   onToValueChange = event => {
-    this.setState({ toValue: event.target.value });
+    const newToValue = event.target.value;
+    this.setState({ toValue: newToValue });
+    this.props.onChange({ ...this.state, toValue: newToValue });
   };
 
   onCcValueChange = event => {
-    this.setState({ ccValue: event.target.value });
+    const newCcValue = event.target.value;
+    this.setState({ ccValue: newCcValue });
+    this.props.onChange({ ...this.state, ccValue: newCcValue });
   };
 
   onResponseValueChange = event => {
-    this.setState({ responseValue: event.target.value });
+    const newResponseValue = event.target.value;
+    this.setState({ responseValue: newResponseValue });
+    this.props.onChange({ ...this.state, responseValue: newResponseValue });
   };
 
   onReasonsForActionValueChange = event => {
-    this.setState({ reasonsForActionValue: event.target.value });
+    const newReasonsForActionValue = event.target.value;
+    this.setState({ reasonsForActionValue: newReasonsForActionValue });
+    this.props.onChange({ ...this.state, reasonsForAction: newReasonsForActionValue });
   };
 
   render() {

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
-import { EMAIL_TYPE } from "./ActionViewEmail";
+import { EMAIL_TYPE } from "./constants";
 
 const styles = {
   container: {

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -87,7 +87,28 @@ class EditEmail extends Component {
     this.setState({ toValue: event.target.value });
   };
 
+  onCcValueChange = event => {
+    this.setState({ ccValue: event.target.value });
+  };
+
+  onResponseValueChange = event => {
+    this.setState({ responseValue: event.target.value });
+  };
+
+  onReasonsForActionValueChange = event => {
+    this.setState({ reasonsForActionValue: event.target.value });
+  };
+
   render() {
+    const { toValue, ccValue, responseValue, reasonsForActionValue } = this.state;
+
+    // TODO: remove when done debugging
+    //=======================================================================
+    console.log("To: ", toValue);
+    console.log("Cc: ", ccValue);
+    console.log("Response: ", responseValue);
+    console.log("Reasons for action: ", reasonsForActionValue);
+    //=======================================================================
     return (
       <div style={styles.container}>
         <form>
@@ -147,6 +168,8 @@ class EditEmail extends Component {
                   type="text"
                   placeholder={LOCALIZE.emibTest.inboxPage.addEmailResponse.headerFieldPlaceholder}
                   style={styles.header.textField}
+                  value={toValue}
+                  onChange={this.onToValueChange}
                 />
               </span>
             </div>
@@ -162,6 +185,8 @@ class EditEmail extends Component {
                   type="text"
                   placeholder={LOCALIZE.emibTest.inboxPage.addEmailResponse.headerFieldPlaceholder}
                   style={styles.header.textField}
+                  value={ccValue}
+                  onChange={this.onCcValueChange}
                 />
               </span>
             </div>
@@ -175,6 +200,8 @@ class EditEmail extends Component {
                 id="your-response-text-area"
                 maxLength="500"
                 style={styles.response.textArea}
+                value={responseValue}
+                onChange={this.onResponseValueChange}
               />
             </div>
           </div>
@@ -188,6 +215,8 @@ class EditEmail extends Component {
                 id="reasons-for-action-text-area"
                 maxLength="100"
                 style={styles.reasonsForAction.textArea}
+                value={reasonsForActionValue}
+                onChange={this.onReasonsForActionValueChange}
               />
             </div>
           </div>

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import LOCALIZE from "../../text_resources";
+import { RESPONSE_TYPE } from "./ResponseItem";
 
 const styles = {
   container: {
@@ -74,6 +75,18 @@ const styles = {
 };
 
 class EditEmail extends Component {
+  state = {
+    emailType: RESPONSE_TYPE.reply,
+    toValue: "",
+    ccValue: "",
+    responseValue: "",
+    reasonsForActionValue: ""
+  };
+
+  onToValueChange = event => {
+    this.setState({ toValue: event.target.value });
+  };
+
   render() {
     return (
       <div style={styles.container}>

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -94,25 +94,25 @@ class EditEmail extends Component {
     this.props.onChange({ ...this.state, emailType: newEmailType });
   };
 
-  onemailToChange = event => {
+  onEmailToChange = event => {
     const newemailTo = event.target.value;
     this.setState({ emailTo: newemailTo });
     this.props.onChange({ ...this.state, emailTo: newemailTo });
   };
 
-  onemailCcChange = event => {
+  onEmailCcChange = event => {
     const newemailCc = event.target.value;
     this.setState({ emailCc: newemailCc });
     this.props.onChange({ ...this.state, emailCc: newemailCc });
   };
 
-  onemailBodyChange = event => {
+  onEmailBodyChange = event => {
     const newemailBody = event.target.value;
     this.setState({ emailBody: newemailBody });
     this.props.onChange({ ...this.state, emailBody: newemailBody });
   };
 
-  onreasonsForActionChange = event => {
+  onReasonsForActionChange = event => {
     const newreasonsForAction = event.target.value;
     this.setState({ reasonsForAction: newreasonsForAction });
     this.props.onChange({ ...this.state, reasonsForAction: newreasonsForAction });
@@ -190,7 +190,7 @@ class EditEmail extends Component {
                   placeholder={LOCALIZE.emibTest.inboxPage.addEmailResponse.headerFieldPlaceholder}
                   style={styles.header.textField}
                   value={emailTo}
-                  onChange={this.onemailToChange}
+                  onChange={this.onEmailToChange}
                 />
               </span>
             </div>
@@ -207,7 +207,7 @@ class EditEmail extends Component {
                   placeholder={LOCALIZE.emibTest.inboxPage.addEmailResponse.headerFieldPlaceholder}
                   style={styles.header.textField}
                   value={emailCc}
-                  onChange={this.onemailCcChange}
+                  onChange={this.onEmailCcChange}
                 />
               </span>
             </div>
@@ -222,7 +222,7 @@ class EditEmail extends Component {
                 maxLength="500"
                 style={styles.response.textArea}
                 value={emailBody}
-                onChange={this.onemailBodyChange}
+                onChange={this.onEmailBodyChange}
               />
             </div>
           </div>
@@ -237,7 +237,7 @@ class EditEmail extends Component {
                 maxLength="100"
                 style={styles.reasonsForAction.textArea}
                 value={reasonsForAction}
-                onChange={this.onreasonsForActionChange}
+                onChange={this.onReasonsForActionChange}
               />
             </div>
           </div>

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -83,6 +83,10 @@ class EditEmail extends Component {
     reasonsForActionValue: ""
   };
 
+  onEmailTypeChange = event => {
+    this.setState({ emailType: event.target.value });
+  };
+
   onToValueChange = event => {
     this.setState({ toValue: event.target.value });
   };
@@ -100,15 +104,8 @@ class EditEmail extends Component {
   };
 
   render() {
-    const { toValue, ccValue, responseValue, reasonsForActionValue } = this.state;
+    const { emailType, toValue, ccValue, responseValue, reasonsForActionValue } = this.state;
 
-    // TODO: remove when done debugging
-    //=======================================================================
-    console.log("To: ", toValue);
-    console.log("Cc: ", ccValue);
-    console.log("Response: ", responseValue);
-    console.log("Reasons for action: ", reasonsForActionValue);
-    //=======================================================================
     return (
       <div style={styles.container}>
         <form>
@@ -123,6 +120,9 @@ class EditEmail extends Component {
                   type="radio"
                   name="responseTypeRadio"
                   style={styles.header.radioPadding}
+                  onChange={this.onEmailTypeChange}
+                  value={RESPONSE_TYPE.reply}
+                  checked={emailType === RESPONSE_TYPE.reply}
                 />
                 <label htmlFor="reply-radio" style={styles.header.radioText}>
                   <i className="fas fa-reply" style={styles.header.responseTypeIcons} />
@@ -136,6 +136,9 @@ class EditEmail extends Component {
                   type="radio"
                   name="responseTypeRadio"
                   style={styles.header.radioPadding}
+                  onChange={this.onEmailTypeChange}
+                  value={RESPONSE_TYPE.replyAll}
+                  checked={emailType === RESPONSE_TYPE.replyAll}
                 />
                 <label htmlFor="reply-all-radio" style={styles.header.radioText}>
                   <i className="fas fa-reply-all" style={styles.header.responseTypeIcons} />
@@ -149,6 +152,9 @@ class EditEmail extends Component {
                   type="radio"
                   name="responseTypeRadio"
                   style={styles.header.radioPadding}
+                  onChange={this.onEmailTypeChange}
+                  value={RESPONSE_TYPE.forward}
+                  checked={emailType === RESPONSE_TYPE.forward}
                 />
                 <label htmlFor="forward-radio" style={styles.header.radioText}>
                   <i className="fas fa-share-square" style={styles.header.responseTypeIcons} />

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -95,27 +95,27 @@ class EditEmail extends Component {
   };
 
   onEmailToChange = event => {
-    const newemailTo = event.target.value;
-    this.setState({ emailTo: newemailTo });
-    this.props.onChange({ ...this.state, emailTo: newemailTo });
+    const newEmailTo = event.target.value;
+    this.setState({ emailTo: newEmailTo });
+    this.props.onChange({ ...this.state, emailTo: newEmailTo });
   };
 
   onEmailCcChange = event => {
-    const newemailCc = event.target.value;
-    this.setState({ emailCc: newemailCc });
-    this.props.onChange({ ...this.state, emailCc: newemailCc });
+    const newEmailCc = event.target.value;
+    this.setState({ emailCc: newEmailCc });
+    this.props.onChange({ ...this.state, emailCc: newEmailCc });
   };
 
   onEmailBodyChange = event => {
-    const newemailBody = event.target.value;
-    this.setState({ emailBody: newemailBody });
-    this.props.onChange({ ...this.state, emailBody: newemailBody });
+    const newEmailBody = event.target.value;
+    this.setState({ emailBody: newEmailBody });
+    this.props.onChange({ ...this.state, emailBody: newEmailBody });
   };
 
   onReasonsForActionChange = event => {
-    const newreasonsForAction = event.target.value;
-    this.setState({ reasonsForAction: newreasonsForAction });
-    this.props.onChange({ ...this.state, reasonsForAction: newreasonsForAction });
+    const newReasonsForAction = event.target.value;
+    this.setState({ reasonsForAction: newReasonsForAction });
+    this.props.onChange({ ...this.state, reasonsForAction: newReasonsForAction });
   };
 
   render() {

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -82,10 +82,10 @@ class EditEmail extends Component {
 
   state = {
     emailType: EMAIL_TYPE.reply,
-    toValue: "",
-    ccValue: "",
-    responseValue: "",
-    reasonsForActionValue: ""
+    emailTo: "",
+    emailCc: "",
+    emailBody: "",
+    reasonsForAction: ""
   };
 
   onEmailTypeChange = event => {
@@ -94,32 +94,32 @@ class EditEmail extends Component {
     this.props.onChange({ ...this.state, emailType: newEmailType });
   };
 
-  onToValueChange = event => {
-    const newToValue = event.target.value;
-    this.setState({ toValue: newToValue });
-    this.props.onChange({ ...this.state, toValue: newToValue });
+  onemailToChange = event => {
+    const newemailTo = event.target.value;
+    this.setState({ emailTo: newemailTo });
+    this.props.onChange({ ...this.state, emailTo: newemailTo });
   };
 
-  onCcValueChange = event => {
-    const newCcValue = event.target.value;
-    this.setState({ ccValue: newCcValue });
-    this.props.onChange({ ...this.state, ccValue: newCcValue });
+  onemailCcChange = event => {
+    const newemailCc = event.target.value;
+    this.setState({ emailCc: newemailCc });
+    this.props.onChange({ ...this.state, emailCc: newemailCc });
   };
 
-  onResponseValueChange = event => {
-    const newResponseValue = event.target.value;
-    this.setState({ responseValue: newResponseValue });
-    this.props.onChange({ ...this.state, responseValue: newResponseValue });
+  onemailBodyChange = event => {
+    const newemailBody = event.target.value;
+    this.setState({ emailBody: newemailBody });
+    this.props.onChange({ ...this.state, emailBody: newemailBody });
   };
 
-  onReasonsForActionValueChange = event => {
-    const newReasonsForActionValue = event.target.value;
-    this.setState({ reasonsForActionValue: newReasonsForActionValue });
-    this.props.onChange({ ...this.state, reasonsForAction: newReasonsForActionValue });
+  onreasonsForActionChange = event => {
+    const newreasonsForAction = event.target.value;
+    this.setState({ reasonsForAction: newreasonsForAction });
+    this.props.onChange({ ...this.state, reasonsForAction: newreasonsForAction });
   };
 
   render() {
-    const { emailType, toValue, ccValue, responseValue, reasonsForActionValue } = this.state;
+    const { emailType, emailTo, emailCc, emailBody, reasonsForAction } = this.state;
 
     return (
       <div style={styles.container}>
@@ -189,8 +189,8 @@ class EditEmail extends Component {
                   type="text"
                   placeholder={LOCALIZE.emibTest.inboxPage.addEmailResponse.headerFieldPlaceholder}
                   style={styles.header.textField}
-                  value={toValue}
-                  onChange={this.onToValueChange}
+                  value={emailTo}
+                  onChange={this.onemailToChange}
                 />
               </span>
             </div>
@@ -206,8 +206,8 @@ class EditEmail extends Component {
                   type="text"
                   placeholder={LOCALIZE.emibTest.inboxPage.addEmailResponse.headerFieldPlaceholder}
                   style={styles.header.textField}
-                  value={ccValue}
-                  onChange={this.onCcValueChange}
+                  value={emailCc}
+                  onChange={this.onemailCcChange}
                 />
               </span>
             </div>
@@ -221,8 +221,8 @@ class EditEmail extends Component {
                 id="your-response-text-area"
                 maxLength="500"
                 style={styles.response.textArea}
-                value={responseValue}
-                onChange={this.onResponseValueChange}
+                value={emailBody}
+                onChange={this.onemailBodyChange}
               />
             </div>
           </div>
@@ -236,8 +236,8 @@ class EditEmail extends Component {
                 id="reasons-for-action-text-area"
                 maxLength="100"
                 style={styles.reasonsForAction.textArea}
-                value={reasonsForActionValue}
-                onChange={this.onReasonsForActionValueChange}
+                value={reasonsForAction}
+                onChange={this.onreasonsForActionChange}
               />
             </div>
           </div>

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
 import "../../css/inbox.css";
 import EditActionDialog from "./EditActionDialog";
-import { ACTION_TYPE, EDIT_MODE } from "./constants";
+import { ACTION_TYPE, EDIT_MODE, emailShape } from "./constants";
 import { addEmail, addTask } from "../../modules/EmibInboxRedux";
 
 const styles = {
@@ -45,7 +45,7 @@ const styles = {
 
 class Email extends Component {
   static propTypes = {
-    email: PropTypes.object.isRequired,
+    email: emailShape,
     emailCount: PropTypes.number,
     taskCount: PropTypes.number,
     // Provided by Redux.

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -4,7 +4,7 @@ import { bindActionCreators } from "redux";
 import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
 import "../../css/inbox.css";
-import EditEmailActionDialog, { ACTION_TYPE, EDIT_MODE } from "./EditEmailActionDialog";
+import EditActionDialog, { ACTION_TYPE, EDIT_MODE } from "./EditActionDialog";
 import { addEmail, addTask } from "../../modules/EmibInboxRedux";
 
 const styles = {
@@ -139,17 +139,17 @@ class Email extends Component {
         </div>
         <hr style={styles.dataBodyDivider} />
         <div>{email.body}</div>
-        <EditEmailActionDialog
+        <EditActionDialog
           showDialog={this.state.showAddEmailDialog}
           handleClose={this.closeEmailDialog}
-          saveEmail={this.replyToEmail}
+          saveAction={this.replyToEmail}
           actionType={ACTION_TYPE.email}
           editMode={EDIT_MODE.create}
         />
-        <EditEmailActionDialog
+        <EditActionDialog
           showDialog={this.state.showAddTaskDialog}
           handleClose={this.closeTaskDialog}
-          saveEmail={this.addTaskToEmail}
+          saveAction={this.addTaskToEmail}
           actionType={ACTION_TYPE.task}
           editMode={EDIT_MODE.create}
         />

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -4,7 +4,8 @@ import { bindActionCreators } from "redux";
 import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
 import "../../css/inbox.css";
-import EditActionDialog, { ACTION_TYPE, EDIT_MODE } from "./EditActionDialog";
+import EditActionDialog from "./EditActionDialog";
+import { ACTION_TYPE, EDIT_MODE } from "./constants";
 import { addEmail, addTask } from "../../modules/EmibInboxRedux";
 
 const styles = {

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -73,14 +73,6 @@ class Email extends Component {
     this.setState({ showAddTaskDialog: false });
   };
 
-  replyToEmail = () => {
-    this.props.addEmail(this.props.email.id);
-  };
-
-  addTaskToEmail = () => {
-    this.props.addTask(this.props.email.id);
-  };
-
   render() {
     const { email, emailCount, taskCount } = this.props;
     const hasTakenAction = emailCount + taskCount > 0;
@@ -140,16 +132,18 @@ class Email extends Component {
         <hr style={styles.dataBodyDivider} />
         <div>{email.body}</div>
         <EditActionDialog
+          emailId={email.id}
           showDialog={this.state.showAddEmailDialog}
           handleClose={this.closeEmailDialog}
-          saveAction={this.replyToEmail}
+          saveAction={this.props.addEmail}
           actionType={ACTION_TYPE.email}
           editMode={EDIT_MODE.create}
         />
         <EditActionDialog
+          emailId={email.id}
           showDialog={this.state.showAddTaskDialog}
           handleClose={this.closeTaskDialog}
-          saveAction={this.addTaskToEmail}
+          saveAction={this.props.addTask}
           actionType={ACTION_TYPE.task}
           editMode={EDIT_MODE.create}
         />

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -1,12 +1,9 @@
 import React, { Component } from "react";
-import { connect } from "react-redux";
-import { bindActionCreators } from "redux";
 import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
 import "../../css/inbox.css";
 import EditActionDialog from "./EditActionDialog";
 import { ACTION_TYPE, EDIT_MODE, emailShape } from "./constants";
-import { addEmail, addTask } from "../../modules/EmibInboxRedux";
 
 const styles = {
   header: {
@@ -47,10 +44,7 @@ class Email extends Component {
   static propTypes = {
     email: emailShape,
     emailCount: PropTypes.number,
-    taskCount: PropTypes.number,
-    // Provided by Redux.
-    addEmail: PropTypes.func.isRequired,
-    addTask: PropTypes.func.isRequired
+    taskCount: PropTypes.number
   };
 
   state = {
@@ -136,7 +130,6 @@ class Email extends Component {
           emailId={email.id}
           showDialog={this.state.showAddEmailDialog}
           handleClose={this.closeEmailDialog}
-          saveAction={this.props.addEmail}
           actionType={ACTION_TYPE.email}
           editMode={EDIT_MODE.create}
         />
@@ -144,7 +137,6 @@ class Email extends Component {
           emailId={email.id}
           showDialog={this.state.showAddTaskDialog}
           handleClose={this.closeTaskDialog}
-          saveAction={this.props.addTask}
           actionType={ACTION_TYPE.task}
           editMode={EDIT_MODE.create}
         />
@@ -153,18 +145,4 @@ class Email extends Component {
   }
 }
 
-export { Email as UnconnectedEmail };
-
-const mapDispatchToProps = dispatch =>
-  bindActionCreators(
-    {
-      addEmail,
-      addTask
-    },
-    dispatch
-  );
-
-export default connect(
-  null,
-  mapDispatchToProps
-)(Email);
+export default Email;

--- a/frontend/src/components/eMIB/EmailPreview.jsx
+++ b/frontend/src/components/eMIB/EmailPreview.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
+import { emailShape } from "./constants";
 
 const styles = {
   //buttons
@@ -60,7 +61,7 @@ const styles = {
 
 class EmailPreview extends Component {
   static propTypes = {
-    email: PropTypes.object.isRequired,
+    email: emailShape,
     selectEmail: PropTypes.func.isRequired,
     isRead: PropTypes.bool.isRequired,
     isRepliedTo: PropTypes.bool.isRequired,

--- a/frontend/src/components/eMIB/Inbox.jsx
+++ b/frontend/src/components/eMIB/Inbox.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import EmailPreview from "./EmailPreview";
 import Email from "./Email";
 import "../../css/inbox.css";
-import { HEADER_HEIGHT, FOOTER_HEIGHT } from "./constants";
+import { HEADER_HEIGHT, FOOTER_HEIGHT, emailShape } from "./constants";
 import { readEmail } from "../../modules/EmibInboxRedux";
 
 const INBOX_HEIGHT = `calc(100vh - ${HEADER_HEIGHT + FOOTER_HEIGHT}px)`;
@@ -29,7 +29,7 @@ const styles = {
 class Inbox extends Component {
   static propTypes = {
     // Provided by redux
-    emails: PropTypes.array,
+    emails: PropTypes.arrayOf(emailShape),
     emailSummaries: PropTypes.array.isRequired,
     readEmail: PropTypes.func.isRequired
   };

--- a/frontend/src/components/eMIB/constants.js
+++ b/frontend/src/components/eMIB/constants.js
@@ -1,3 +1,5 @@
+import PropTypes from "prop-types";
+
 // Display
 export const HEADER_HEIGHT = 130;
 export const FOOTER_HEIGHT = 72;
@@ -18,3 +20,12 @@ export const EMAIL_TYPE = {
   replyAll: "reply all",
   forward: "forward"
 };
+
+export const emailShape = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  to: PropTypes.string,
+  from: PropTypes.string,
+  subject: PropTypes.string,
+  date: PropTypes.string,
+  body: PropTypes.string
+});

--- a/frontend/src/components/eMIB/constants.js
+++ b/frontend/src/components/eMIB/constants.js
@@ -3,6 +3,16 @@ export const HEADER_HEIGHT = 130;
 export const FOOTER_HEIGHT = 72;
 
 // Data structure
+export const ACTION_TYPE = {
+  email: "email",
+  task: "task"
+};
+
+export const EDIT_MODE = {
+  create: "create",
+  update: "update"
+};
+
 export const EMAIL_TYPE = {
   reply: "reply",
   replyAll: "reply all",

--- a/frontend/src/components/eMIB/constants.js
+++ b/frontend/src/components/eMIB/constants.js
@@ -29,3 +29,13 @@ export const emailShape = PropTypes.shape({
   date: PropTypes.string,
   body: PropTypes.string
 });
+
+export const actionShape = PropTypes.shape({
+  actionType: PropTypes.oneOf(Object.values(ACTION_TYPE)).isRequired,
+  reasonForAction: PropTypes.string,
+  task: PropTypes.string,
+  emailType: PropTypes.oneOf(Object.values(EMAIL_TYPE)),
+  emailTo: PropTypes.string,
+  emailCc: PropTypes.string,
+  emailBody: PropTypes.string
+});

--- a/frontend/src/components/eMIB/constants.js
+++ b/frontend/src/components/eMIB/constants.js
@@ -1,2 +1,10 @@
+// Display
 export const HEADER_HEIGHT = 130;
 export const FOOTER_HEIGHT = 72;
+
+// Data structure
+export const EMAIL_TYPE = {
+  reply: "reply",
+  replyAll: "reply all",
+  forward: "forward"
+};

--- a/frontend/src/components/eMIB/constants.js
+++ b/frontend/src/components/eMIB/constants.js
@@ -4,23 +4,31 @@ import PropTypes from "prop-types";
 export const HEADER_HEIGHT = 130;
 export const FOOTER_HEIGHT = 72;
 
-// Data structure
+// Data structures
+
+// Candidates can take action on an email by creating another
+// email or creating a task.
 export const ACTION_TYPE = {
   email: "email",
   task: "task"
 };
 
+// Actions can be created or edited.
 export const EDIT_MODE = {
   create: "create",
   update: "update"
 };
 
+// Possible types of emails candidates can create.
 export const EMAIL_TYPE = {
   reply: "reply",
   replyAll: "reply all",
   forward: "forward"
 };
 
+// PropType Shape Definitions
+
+// Email test content. Won't be edited by a candidate.
 export const emailShape = PropTypes.shape({
   id: PropTypes.number.isRequired,
   to: PropTypes.string,
@@ -30,6 +38,7 @@ export const emailShape = PropTypes.shape({
   body: PropTypes.string
 });
 
+// Actions a candidate can take in response to an email.
 export const actionShape = PropTypes.shape({
   actionType: PropTypes.oneOf(Object.values(ACTION_TYPE)).isRequired,
   reasonForAction: PropTypes.string,

--- a/frontend/src/modules/EmibInboxRedux.js
+++ b/frontend/src/modules/EmibInboxRedux.js
@@ -26,15 +26,15 @@ const ADD_TASK = "emibInbox/ADD_TASK";
 
 // Action Creators
 const readEmail = emailIndex => ({ type: READ_EMAIL, emailIndex });
-// emailIndex refers to the index of the original parent email.
+// emailIndex refers to the index of the original parent email and emailAction is an actionShape
 const addEmail = (emailIndex, emailAction) => ({ type: ADD_EMAIL, emailIndex, emailAction });
-// emailIndex refers to the index of the original parent email.
+// emailIndex refers to the index of the original parent email and taskAction is an actionShape
 const addTask = (emailIndex, taskAction) => ({ type: ADD_TASK, emailIndex, taskAction });
 
 // Initial State
 // emails - represents an array of emailShape objects in the currently selected language.
 // emailSummaries - represents an array of objects indicating read state of each email.
-// emailActions - represents an array of arrays, each array contains action objects, representing an ACTION_TYPE.
+// emailActions - represents an array of arrays, each array contains actionShape objects, representing an ACTION_TYPE.
 const initialState = {
   // Loads emails from a static JSON file until an API exists.
   emails: emailsJson.emailsEN,
@@ -64,7 +64,7 @@ const emibInbox = (state = initialState, action) => {
       let modifiedEmailActions = Array.from(state.emailActions);
       modifiedEmailActions[action.emailIndex].push({
         ...action.emailAction,
-        type: ACTION_TYPE.email
+        actionType: ACTION_TYPE.email
       });
       return {
         ...state,

--- a/frontend/src/modules/EmibInboxRedux.js
+++ b/frontend/src/modules/EmibInboxRedux.js
@@ -1,6 +1,7 @@
 import { emailsJson } from "./sampleEmibJson";
 import { SET_LANGUAGE } from "./LocalizeRedux";
 
+// Initializers
 export const initializeEmailSummaries = length => {
   let emailSummaries = [];
   for (let i = 0; i < length; i++) {

--- a/frontend/src/modules/EmibInboxRedux.js
+++ b/frontend/src/modules/EmibInboxRedux.js
@@ -25,9 +25,9 @@ const ADD_TASK = "emibInbox/ADD_TASK";
 // Action Creators
 const readEmail = emailIndex => ({ type: READ_EMAIL, emailIndex });
 // emailIndex refers to the index of the original parent email.
-const addEmail = emailIndex => ({ type: ADD_EMAIL, emailIndex });
+const addEmail = (emailIndex, emailAction) => ({ type: ADD_EMAIL, emailIndex, emailAction });
 // emailIndex refers to the index of the original parent email.
-const addTask = emailIndex => ({ type: ADD_TASK, emailIndex });
+const addTask = (emailIndex, taskAction) => ({ type: ADD_TASK, emailIndex, taskAction });
 
 // Initial State
 // emails - represents an array of emails in the currently selected language.
@@ -42,6 +42,9 @@ const initialState = {
 
 // Reducer
 const emibInbox = (state = initialState, action) => {
+  console.log("emib inbox");
+  console.log(action);
+  console.log(state);
   switch (action.type) {
     case SET_LANGUAGE:
       return {
@@ -58,9 +61,13 @@ const emibInbox = (state = initialState, action) => {
     case ADD_EMAIL:
       let modifiedEmailSummaries = Array.from(state.emailSummaries);
       modifiedEmailSummaries[action.emailIndex].emailCount++;
+
+      let modifiedEmailActions = Array.from(state.emailActions);
+      modifiedEmailActions[action.emailIndex].push({ ...action.emailAction, type: "email" });
       return {
         ...state,
-        emailSummaries: modifiedEmailSummaries
+        emailSummaries: modifiedEmailSummaries,
+        emailActions: modifiedEmailActions
       };
     case ADD_TASK:
       let duplicatedEmailSummaries = Array.from(state.emailSummaries);

--- a/frontend/src/modules/EmibInboxRedux.js
+++ b/frontend/src/modules/EmibInboxRedux.js
@@ -9,6 +9,14 @@ export const initializeEmailSummaries = length => {
   return emailSummaries;
 };
 
+const initializeEmailActions = length => {
+  let emailActions = [];
+  for (let i = 0; i < length; i++) {
+    emailActions.push([]);
+  }
+  return emailActions;
+};
+
 // Action Types
 const READ_EMAIL = "emibInbox/READ_EMAIL";
 const ADD_EMAIL = "emibInbox/ADD_EMAIL";
@@ -24,10 +32,12 @@ const addTask = emailIndex => ({ type: ADD_TASK, emailIndex });
 // Initial State
 // emails - represents an array of emails in the currently selected language.
 // emailSummaries - represents an array of objects indicating read state of each email.
+// emailActions - represents an array of arrays, each array contains action objects.
 const initialState = {
   // Loads emails from a static JSON file until an API exists.
   emails: emailsJson.emailsEN,
-  emailSummaries: initializeEmailSummaries(emailsJson.emailsEN.length)
+  emailSummaries: initializeEmailSummaries(emailsJson.emailsEN.length),
+  emailActions: initializeEmailActions(emailsJson.emailsEN.length)
 };
 
 // Reducer

--- a/frontend/src/modules/EmibInboxRedux.js
+++ b/frontend/src/modules/EmibInboxRedux.js
@@ -32,7 +32,7 @@ const addEmail = (emailIndex, emailAction) => ({ type: ADD_EMAIL, emailIndex, em
 const addTask = (emailIndex, taskAction) => ({ type: ADD_TASK, emailIndex, taskAction });
 
 // Initial State
-// emails - represents an array of emails in the currently selected language.
+// emails - represents an array of emailShape objects in the currently selected language.
 // emailSummaries - represents an array of objects indicating read state of each email.
 // emailActions - represents an array of arrays, each array contains action objects, representing an ACTION_TYPE.
 const initialState = {

--- a/frontend/src/modules/EmibInboxRedux.js
+++ b/frontend/src/modules/EmibInboxRedux.js
@@ -1,5 +1,6 @@
 import { emailsJson } from "./sampleEmibJson";
 import { SET_LANGUAGE } from "./LocalizeRedux";
+import { ACTION_TYPE } from "../components/eMIB/constants";
 
 // Initializers
 export const initializeEmailSummaries = length => {
@@ -33,7 +34,7 @@ const addTask = (emailIndex, taskAction) => ({ type: ADD_TASK, emailIndex, taskA
 // Initial State
 // emails - represents an array of emails in the currently selected language.
 // emailSummaries - represents an array of objects indicating read state of each email.
-// emailActions - represents an array of arrays, each array contains action objects.
+// emailActions - represents an array of arrays, each array contains action objects, representing an ACTION_TYPE.
 const initialState = {
   // Loads emails from a static JSON file until an API exists.
   emails: emailsJson.emailsEN,
@@ -43,9 +44,6 @@ const initialState = {
 
 // Reducer
 const emibInbox = (state = initialState, action) => {
-  console.log("emib inbox");
-  console.log(action);
-  console.log(state);
   switch (action.type) {
     case SET_LANGUAGE:
       return {
@@ -64,7 +62,10 @@ const emibInbox = (state = initialState, action) => {
       modifiedEmailSummaries[action.emailIndex].emailCount++;
 
       let modifiedEmailActions = Array.from(state.emailActions);
-      modifiedEmailActions[action.emailIndex].push({ ...action.emailAction, type: "email" });
+      modifiedEmailActions[action.emailIndex].push({
+        ...action.emailAction,
+        type: ACTION_TYPE.email
+      });
       return {
         ...state,
         emailSummaries: modifiedEmailSummaries,

--- a/frontend/src/tests/components/eMIB/ActionViewEmail.test.js
+++ b/frontend/src/tests/components/eMIB/ActionViewEmail.test.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
-import ActionViewEmail, { EMAIL_TYPE } from "../../../components/eMIB/ActionViewEmail";
+import ActionViewEmail from "../../../components/eMIB/ActionViewEmail";
+import { EMAIL_TYPE } from "../../../components/eMIB/constants";
 
 describe("Response types", () => {
   const reply = <i className="fas fa-reply" />;

--- a/frontend/src/tests/components/eMIB/ActionViewEmail.test.js
+++ b/frontend/src/tests/components/eMIB/ActionViewEmail.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import ResponseItem, { RESPONSE_TYPE } from "../../../components/eMIB/ResponseItem";
+import ActionViewEmail, { EMAIL_TYPE } from "../../../components/eMIB/ActionViewEmail";
 
 describe("Response types", () => {
   const reply = <i className="fas fa-reply" />;
@@ -9,8 +9,8 @@ describe("Response types", () => {
 
   it("renders reply response", () => {
     const wrapper = shallow(
-      <ResponseItem
-        responseType={RESPONSE_TYPE.reply}
+      <ActionViewEmail
+        responseType={EMAIL_TYPE.reply}
         to={"to"}
         cc={"cc"}
         response={"response"}
@@ -25,8 +25,8 @@ describe("Response types", () => {
 
   it("renders reply all response", () => {
     const wrapper = shallow(
-      <ResponseItem
-        responseType={RESPONSE_TYPE.replyAll}
+      <ActionViewEmail
+        responseType={EMAIL_TYPE.replyAll}
         to={"to"}
         cc={"cc"}
         response={"response"}
@@ -41,8 +41,8 @@ describe("Response types", () => {
 
   it("renders forward response", () => {
     const wrapper = shallow(
-      <ResponseItem
-        responseType={RESPONSE_TYPE.forward}
+      <ActionViewEmail
+        responseType={EMAIL_TYPE.forward}
         to={"to"}
         cc={"cc"}
         response={"response"}
@@ -61,8 +61,8 @@ describe("Email header", () => {
 
   it("renders email's header with cc)", () => {
     const wrapper = shallow(
-      <ResponseItem
-        responseType={RESPONSE_TYPE.reply}
+      <ActionViewEmail
+        responseType={EMAIL_TYPE.reply}
         to={"to"}
         cc={"cc"}
         response={"response"}
@@ -75,8 +75,8 @@ describe("Email header", () => {
 
   it("renders email's header without cc)", () => {
     const wrapper = shallow(
-      <ResponseItem
-        responseType={RESPONSE_TYPE.reply}
+      <ActionViewEmail
+        responseType={EMAIL_TYPE.reply}
         to={"to"}
         response={"response"}
         reasonsForAction={"reasons"}

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { shallow } from "enzyme";
-import EditEmailActionDialog, {
+import EditActionDialog, {
   EDIT_MODE,
   ACTION_TYPE
-} from "../../../components/eMIB/EditEmailActionDialog";
+} from "../../../components/eMIB/EditActionDialog";
 
 describe("email action type", () => {
   it("renders Add Email dialog", () => {
@@ -31,10 +31,10 @@ function testCore(actionType, editMode) {
 
   //shallow wrapper of the dialog
   const wrapper = shallow(
-    <EditEmailActionDialog
+    <EditActionDialog
       showDialog={true}
       handleClose={() => {}}
-      saveEmail={saveMock}
+      saveAction={saveMock}
       actionType={actionType}
       editMode={editMode}
     />

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -1,9 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
-import EditActionDialog, {
-  EDIT_MODE,
-  ACTION_TYPE
-} from "../../../components/eMIB/EditActionDialog";
+import EditActionDialog from "../../../components/eMIB/EditActionDialog";
+import { ACTION_TYPE, EDIT_MODE } from "../../../components/eMIB/constants";
 
 describe("email action type", () => {
   it("renders Add Email dialog", () => {

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -30,6 +30,7 @@ function testCore(actionType, editMode) {
   //shallow wrapper of the dialog
   const wrapper = shallow(
     <EditActionDialog
+      emailId={1}
       showDialog={true}
       handleClose={() => {}}
       saveAction={saveMock}

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import EditActionDialog from "../../../components/eMIB/EditActionDialog";
+import { UnconnectedEditActionDialog as EditActionDialog } from "../../../components/eMIB/EditActionDialog";
 import { ACTION_TYPE, EDIT_MODE } from "../../../components/eMIB/constants";
 
 describe("email action type", () => {
@@ -25,7 +25,8 @@ describe("task action type", () => {
 
 function testCore(actionType, editMode) {
   //Simulation of the save function
-  const saveMock = jest.fn();
+  const addEmail = jest.fn();
+  const addTask = jest.fn();
 
   //shallow wrapper of the dialog
   const wrapper = shallow(
@@ -33,7 +34,8 @@ function testCore(actionType, editMode) {
       emailId={1}
       showDialog={true}
       handleClose={() => {}}
-      saveAction={saveMock}
+      addEmail={addEmail}
+      addTask={addTask}
       actionType={actionType}
       editMode={editMode}
     />
@@ -55,5 +57,11 @@ function testCore(actionType, editMode) {
 
   //Check that the button click triggers the function
   wrapper.find("#unit-test-email-response-button").simulate("click");
-  expect(saveMock).toHaveBeenCalledTimes(1);
+  if (actionType === ACTION_TYPE.email) {
+    expect(addTask).toHaveBeenCalledTimes(0);
+    expect(addEmail).toHaveBeenCalledTimes(1);
+  } else if (actionType === ACTION_TYPE.task) {
+    expect(addTask).toHaveBeenCalledTimes(1);
+    expect(addEmail).toHaveBeenCalledTimes(0);
+  }
 }

--- a/frontend/src/tests/components/eMIB/Email.test.js
+++ b/frontend/src/tests/components/eMIB/Email.test.js
@@ -1,6 +1,6 @@
 import React from "react";
-import { shallow, mount } from "enzyme";
-import { UnconnectedEmail as Email } from "../../../components/eMIB/Email";
+import { shallow } from "enzyme";
+import Email from "../../../components/eMIB/Email";
 
 const emailStub = {
   id: 1,
@@ -14,27 +14,21 @@ const emailStub = {
 const hasAction = <i className="fas fa-sign-out-alt" style={{ color: "#00565E" }} />;
 
 it("default email renders with subject as an h3", () => {
-  const wrapper = shallow(
-    <Email email={emailStub} addEmail={() => {}} addTask={() => {}} emailCount={0} taskCount={0} />
-  );
+  const wrapper = shallow(<Email email={emailStub} emailCount={0} taskCount={0} />);
   const subject = <h3>Subject 1</h3>;
   expect(wrapper.contains(subject)).toEqual(true);
   expect(wrapper.contains(hasAction)).toEqual(false);
 });
 
 it("shows action when email count is non zero", () => {
-  const wrapper = shallow(
-    <Email email={emailStub} addEmail={() => {}} addTask={() => {}} emailCount={1} taskCount={0} />
-  );
+  const wrapper = shallow(<Email email={emailStub} emailCount={1} taskCount={0} />);
   const subject = <h3>Subject 1</h3>;
   expect(wrapper.contains(subject)).toEqual(true);
   expect(wrapper.contains(hasAction)).toEqual(true);
 });
 
 it("shows action when task count is non zero", () => {
-  const wrapper = shallow(
-    <Email email={emailStub} addEmail={() => {}} addTask={() => {}} emailCount={0} taskCount={2} />
-  );
+  const wrapper = shallow(<Email email={emailStub} emailCount={0} taskCount={2} />);
   const subject = <h3>Subject 1</h3>;
   expect(wrapper.contains(subject)).toEqual(true);
   expect(wrapper.contains(hasAction)).toEqual(true);

--- a/frontend/src/tests/components/eMIB/EmailPreview.test.js
+++ b/frontend/src/tests/components/eMIB/EmailPreview.test.js
@@ -3,7 +3,7 @@ import { mount } from "enzyme";
 import EmailPreview from "../../../components/eMIB/EmailPreview";
 
 const emailStub = {
-  id: "1",
+  id: 1,
   to: "To Stub",
   from: "From Stub",
   subject: "Subject Stub",

--- a/frontend/src/tests/modules/EmibInboxRedux.test.js
+++ b/frontend/src/tests/modules/EmibInboxRedux.test.js
@@ -4,6 +4,7 @@ import emibInbox, {
   addEmail,
   addTask
 } from "../../modules/EmibInboxRedux";
+import { EMAIL_TYPE, ACTION_TYPE } from "../../components/eMIB/constants";
 import { setLanguage } from "../../modules/LocalizeRedux";
 import { emailsJson } from "../../modules/sampleEmibJson";
 
@@ -53,6 +54,19 @@ describe("EmibInboxRedux", () => {
       expect(newState.emailSummaries[0].emailCount).toEqual(1);
       expect(newState.emailSummaries[0].taskCount).toEqual(0);
       expect(newState.emailSummaries[1].emailCount).toEqual(0);
+    });
+
+    it("should add an email action to the action list", () => {
+      const emailAction = {
+        emailType: EMAIL_TYPE.reply,
+        emailTo: "Sara",
+        emailCc: "Luke",
+        emailBody: "Hi Sarah!",
+        reasonsForAction: "I wanted to say hi."
+      };
+      const addAction = addEmail(0, emailAction);
+      const newState = emibInbox(stubbedInitialState, addAction);
+      expect(newState.emailActions[0]).toEqual([{ ...emailAction, actionType: ACTION_TYPE.email }]);
     });
   });
 

--- a/frontend/src/tests/modules/EmibInboxRedux.test.js
+++ b/frontend/src/tests/modules/EmibInboxRedux.test.js
@@ -12,7 +12,8 @@ describe("EmibInboxRedux", () => {
   beforeEach(() => {
     stubbedInitialState = {
       emails: emailsJson.emailsEN,
-      emailSummaries: initializeEmailSummaries(emailsJson.emailsEN.length)
+      emailSummaries: initializeEmailSummaries(emailsJson.emailsEN.length),
+      emailActions: [[], [], []]
     };
   });
 

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -334,7 +334,7 @@ let LOCALIZE = new LocalizedStrings({
         addReply: "Add email Response",
         addTask: "Create a task",
         yourActions: `You responded with {0} emails and {1} tasks`,
-        editEmailActionDialog: {
+        editActionDialog: {
           addEmail: "Add email response",
           editEmail: "Edit email response",
           addTask: "Add task",
@@ -794,7 +794,7 @@ let LOCALIZE = new LocalizedStrings({
         addReply: "FR Add email Response",
         addTask: "FR Create a task",
         yourActions: `FR You responded with {0} emails and {1} tasks`,
-        editEmailActionDialog: {
+        editActionDialog: {
           addEmail: "FR Add email response",
           editEmail: "FR Edit email response",
           addTask: "FR Add task",


### PR DESCRIPTION
# Description

No user facing changes. This preps us to show a saved email action to the user.

- Followed EmivInboxRedux tech spec for storing data
- Re-named components to be consistent 
- Defined enums and PropType shapes in eMIB/constants.js
- Modified `addEmail` to take in an `actionShape` and added a test
- Saved state of the add email form into state and then redux on save button press

The last part of "Add email" is displaying it in the Email component.

## Type of change

- New feature (non-breaking change which adds functionality)
- Code cleanliness or refactor

## Screenshot

No changes to the UI.

# Testing

Manual steps to reproduce this functionality:

1.  Navigate to eMIB Sample Test Inbox.
2.  Click on "Add email" or "Add task" and notice no breaking changes.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
~~- [ ] My changes look good on IE 10+, Firefox, and Chrome~~
