### PR TITLE
[Inbox] Display email from redux

### DIFF
--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -31,7 +31,7 @@ class ActionViewEmail extends Component {
     to: PropTypes.string.isRequired,
     cc: PropTypes.string,
     response: PropTypes.string.isRequired,
-    reasonsForAction: PropTypes.string.isRequired
+    reasonsForAction: PropTypes.string
   };
 
   render() {

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -52,6 +52,7 @@ class EditActionDialog extends Component {
     } else if (this.props.actionType === ACTION_TYPE.task) {
       this.props.addTask(this.props.emailId, this.state.action);
     }
+    this.setState({ action: {} });
     this.props.handleClose();
   };
 

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -85,7 +85,7 @@ class EditEmail extends Component {
     emailTo: "",
     emailCc: "",
     emailBody: "",
-    reasonsForAction: ""
+    reasonForAction: ""
   };
 
   onEmailTypeChange = event => {
@@ -113,9 +113,9 @@ class EditEmail extends Component {
   };
 
   onreasonsForActionChange = event => {
-    const newreasonsForAction = event.target.value;
-    this.setState({ reasonsForAction: newreasonsForAction });
-    this.props.onChange({ ...this.state, reasonsForAction: newreasonsForAction });
+    const newReasonForAction = event.target.value;
+    this.setState({ reasonForAction: newReasonForAction });
+    this.props.onChange({ ...this.state, reasonForAction: newReasonForAction });
   };
 
   render() {

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -138,6 +138,7 @@ class Email extends Component {
               <CollapsingItemContainer
                 key={id}
                 icon={ICON_TYPE.email}
+                // TODO: we need to put a dynamic title generator here instead of hard coding this title
                 title={"Email response"}
                 body={
                   <ActionViewEmail

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -1,9 +1,13 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { connect } from "react-redux";
 import LOCALIZE from "../../text_resources";
 import "../../css/inbox.css";
 import EditActionDialog from "./EditActionDialog";
 import { ACTION_TYPE, EDIT_MODE, emailShape } from "./constants";
+import { selectEmailActions } from "../../modules/EmibInboxRedux";
+import ActionViewEmail from "./ActionViewEmail";
+import CollapsingItemContainer, { ICON_TYPE } from "./CollapsingItemContainer";
 
 const styles = {
   header: {
@@ -44,7 +48,9 @@ class Email extends Component {
   static propTypes = {
     email: emailShape,
     emailCount: PropTypes.number,
-    taskCount: PropTypes.number
+    taskCount: PropTypes.number,
+    // Provided by Redux
+    emailActions: PropTypes.array
   };
 
   state = {
@@ -69,7 +75,7 @@ class Email extends Component {
   };
 
   render() {
-    const { email, emailCount, taskCount } = this.props;
+    const { email, emailCount, taskCount, emailActions } = this.props;
     const hasTakenAction = emailCount + taskCount > 0;
 
     return (
@@ -126,6 +132,26 @@ class Email extends Component {
         </div>
         <hr style={styles.dataBodyDivider} />
         <div>{email.body}</div>
+        <div>
+          {emailActions.map((email, id) => {
+            return (
+              <CollapsingItemContainer
+                key={id}
+                icon={ICON_TYPE.email}
+                title={"Email response"}
+                body={
+                  <ActionViewEmail
+                    responseType={email.emailType}
+                    to={email.emailTo}
+                    cc={email.emailCc}
+                    response={email.emailBody}
+                    reasonsForAction={email.reasonForAction}
+                  />
+                }
+              />
+            );
+          })}
+        </div>
         <EditActionDialog
           emailId={email.id}
           showDialog={this.state.showAddEmailDialog}
@@ -145,4 +171,15 @@ class Email extends Component {
   }
 }
 
-export default Email;
+export { Email as UnconnectedEmail };
+
+const mapStateToProps = (state, ownProps) => {
+  return {
+    emailActions: selectEmailActions(state.emibInbox.emailActions, ownProps.email.id)
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  null
+)(Email);

--- a/frontend/src/modules/EmibInboxRedux.js
+++ b/frontend/src/modules/EmibInboxRedux.js
@@ -83,5 +83,10 @@ const emibInbox = (state = initialState, action) => {
   }
 };
 
+// Selector functions
+const selectEmailActions = (actionState, emailId) => {
+  return actionState[emailId];
+};
+
 export default emibInbox;
-export { initialState, readEmail, addEmail, addTask };
+export { initialState, readEmail, addEmail, addTask, selectEmailActions };

--- a/frontend/src/tests/components/eMIB/Email.test.js
+++ b/frontend/src/tests/components/eMIB/Email.test.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
-import Email from "../../../components/eMIB/Email";
+import { UnconnectedEmail as Email } from "../../../components/eMIB/Email";
+import CollapsingItemContainer from "../../../components/eMIB/CollapsingItemContainer";
 
 const emailStub = {
   id: 1,
@@ -14,22 +15,40 @@ const emailStub = {
 const hasAction = <i className="fas fa-sign-out-alt" style={{ color: "#00565E" }} />;
 
 it("default email renders with subject as an h3", () => {
-  const wrapper = shallow(<Email email={emailStub} emailCount={0} taskCount={0} />);
+  const wrapper = shallow(
+    <Email email={emailStub} emailCount={0} taskCount={0} emailActions={[]} />
+  );
   const subject = <h3>Subject 1</h3>;
   expect(wrapper.contains(subject)).toEqual(true);
   expect(wrapper.contains(hasAction)).toEqual(false);
 });
 
 it("shows action when email count is non zero", () => {
-  const wrapper = shallow(<Email email={emailStub} emailCount={1} taskCount={0} />);
+  const wrapper = shallow(
+    <Email email={emailStub} emailCount={1} taskCount={0} emailActions={[]} />
+  );
   const subject = <h3>Subject 1</h3>;
   expect(wrapper.contains(subject)).toEqual(true);
   expect(wrapper.contains(hasAction)).toEqual(true);
 });
 
 it("shows action when task count is non zero", () => {
-  const wrapper = shallow(<Email email={emailStub} emailCount={0} taskCount={2} />);
+  const wrapper = shallow(
+    <Email email={emailStub} emailCount={0} taskCount={2} emailActions={[]} />
+  );
   const subject = <h3>Subject 1</h3>;
   expect(wrapper.contains(subject)).toEqual(true);
   expect(wrapper.contains(hasAction)).toEqual(true);
+});
+
+it("shows as many CollapsingItemContainer as there are actions", () => {
+  const wrapper = shallow(
+    <Email
+      email={emailStub}
+      emailCount={0}
+      taskCount={2}
+      emailActions={[{ emailType: "reply", emailTo: "you", emailBody: "hi" }]}
+    />
+  );
+  expect(wrapper.find(CollapsingItemContainer).length).toEqual(1);
 });

--- a/frontend/src/tests/components/eMIB/Email.test.js
+++ b/frontend/src/tests/components/eMIB/Email.test.js
@@ -2,6 +2,7 @@ import React from "react";
 import { shallow } from "enzyme";
 import { UnconnectedEmail as Email } from "../../../components/eMIB/Email";
 import CollapsingItemContainer from "../../../components/eMIB/CollapsingItemContainer";
+import { EMAIL_TYPE } from "../../../components/eMIB/constants";
 
 const emailStub = {
   id: 1,
@@ -41,14 +42,31 @@ it("shows action when task count is non zero", () => {
   expect(wrapper.contains(hasAction)).toEqual(true);
 });
 
-it("shows as many CollapsingItemContainer as there are actions", () => {
-  const wrapper = shallow(
-    <Email
-      email={emailStub}
-      emailCount={0}
-      taskCount={2}
-      emailActions={[{ emailType: "reply", emailTo: "you", emailBody: "hi" }]}
-    />
-  );
-  expect(wrapper.find(CollapsingItemContainer).length).toEqual(1);
+describe("shows as many 'CollapsingItemContainer' as there are actions", () => {
+  it("shows 1 'CollapsingItemContainer'", () => {
+    const wrapper = shallow(
+      <Email
+        email={emailStub}
+        emailCount={0}
+        taskCount={2}
+        emailActions={[{ emailType: EMAIL_TYPE.reply, emailTo: "you", emailBody: "hi" }]}
+      />
+    );
+    expect(wrapper.find(CollapsingItemContainer).length).toEqual(1);
+  });
+  it("shows 3 'CollapsingItemContainer'", () => {
+    const wrapper = shallow(
+      <Email
+        email={emailStub}
+        emailCount={2}
+        taskCount={2}
+        emailActions={[
+          { emailType: EMAIL_TYPE.reply, emailTo: "you1", emailBody: "hi1" },
+          { emailType: EMAIL_TYPE.replyAll, emailTo: "you2", emailBody: "hi2" },
+          { emailType: EMAIL_TYPE.forward, emailTo: "you3", emailBody: "hi3" }
+        ]}
+      />
+    );
+    expect(wrapper.find(CollapsingItemContainer).length).toEqual(3);
+  });
 });


### PR DESCRIPTION
# Description

Displays email based on the actions in redux.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

<img width="884" alt="Screen Shot 2019-04-05 at 6 54 17 PM" src="https://user-images.githubusercontent.com/4640747/55660447-5eff8c80-57d4-11e9-8dfc-56b5adb61595.png">
<img width="1399" alt="Screen Shot 2019-04-05 at 6 54 40 PM" src="https://user-images.githubusercontent.com/4640747/55660451-63c44080-57d4-11e9-8681-9665e822299a.png">
<img width="1389" alt="Screen Shot 2019-04-05 at 6 54 55 PM" src="https://user-images.githubusercontent.com/4640747/55660455-67f05e00-57d4-11e9-9781-0eb4be327574.png">


# Testing

Manual steps to reproduce this functionality:

1.  Go to the inbox on the sample test.
2. Try adding an email

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 10+, Firefox, and Chrome
