### PR TITLE
Fix IE JS Compatibility Bug

### DIFF
--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -35,8 +35,8 @@ class EditActionDialog extends Component {
     emailId: PropTypes.number.isRequired,
     showDialog: PropTypes.bool.isRequired,
     handleClose: PropTypes.func.isRequired,
-    actionType: PropTypes.oneOf(Object.values(ACTION_TYPE)).isRequired,
-    editMode: PropTypes.oneOf(Object.values(EDIT_MODE)).isRequired,
+    actionType: PropTypes.oneOf(Object.keys(ACTION_TYPE)).isRequired,
+    editMode: PropTypes.oneOf(Object.keys(EDIT_MODE)).isRequired,
     // Provided from Redux.
     addEmail: PropTypes.func.isRequired,
     addTask: PropTypes.func.isRequired

--- a/frontend/src/components/eMIB/constants.js
+++ b/frontend/src/components/eMIB/constants.js
@@ -40,10 +40,10 @@ export const emailShape = PropTypes.shape({
 
 // Actions a candidate can take in response to an email.
 export const actionShape = PropTypes.shape({
-  actionType: PropTypes.oneOf(Object.values(ACTION_TYPE)).isRequired,
+  actionType: PropTypes.oneOf(Object.keys(ACTION_TYPE)).isRequired,
   reasonForAction: PropTypes.string,
   task: PropTypes.string,
-  emailType: PropTypes.oneOf(Object.values(EMAIL_TYPE)),
+  emailType: PropTypes.oneOf(Object.keys(EMAIL_TYPE)),
   emailTo: PropTypes.string,
   emailCc: PropTypes.string,
   emailBody: PropTypes.string


### PR DESCRIPTION
# Description

Object.keys is compatible but not Object.values with IE: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Testing

1.  Open up the application on IE.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 10+, Firefox, and Chrome
