### PR TITLE
Update content of submit dialog

### DIFF
--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -380,9 +380,9 @@ let LOCALIZE = new LocalizedStrings({
         submitTestPopupBox: {
           title: "Confirm test submission?",
           warning: {
-            title: "Warning! All draft items will not be saved.",
+            title: "Warning! The notepad will not be saved.",
             message:
-              "All draft emails and any notes in the notepad will not be submitted with the test for scoring. Review draft emails and the notepad before submitting the test."
+              "Anything written in the notepad will not be submitted with the test for scoring. Ensure that you have reviewed all of your responses before submitting the test as you will not be able to go back to make changes."
           },
           description:
             "If you are ready to send your test in for scoring, click the “Submit test” button. You will be exited out of this test session and provided further instructions."
@@ -841,9 +841,9 @@ let LOCALIZE = new LocalizedStrings({
         submitTestPopupBox: {
           title: "Confirmer l’envoi du test?",
           warning: {
-            title: "Avertissement : aucun brouillon ne sera sauvegardé.",
+            title: "Avertissement : your notebook will not be saved.",
             message:
-              "Les ébauches de courriels et le contenu du bloc-notes ne seront pas envoyés avec le test pour la notation. Passez en revue les ébauches de courriels et le bloc-notes avant d’envoyer le test."
+              "FR Anything written in the notepad will not be submitted with the test for scoring. Ensure that you have reviewed all of your responses before submitting the test as you will not be able to go back to make changes."
           },
           description:
             "Si vous êtes prêt(e) à envoyer votre test pour la notation, cliquez sur le bouton « Envoyer le test ». La séance de test sera fermée et vous recevrez d’autres instructions."


### PR DESCRIPTION
# Description

There are no more drafts, so replacing the content with something that makes more sense.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot
<img width="737" alt="Screen Shot 2019-04-08 at 4 50 48 PM" src="https://user-images.githubusercontent.com/4640747/55756036-a24d3b80-5a1e-11e9-8541-68deb4c91b1c.png">


# Testing

Manual steps to reproduce this functionality:

1.  Go to sample test and click submit.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 10+, Firefox, and Chrome
