### PR TITLE
[Add/Edit Email] Simplified aria-labels and roles

### DIFF
--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -35,77 +35,59 @@ class ActionViewEmail extends Component {
   render() {
     const action = this.props.action;
     return (
-      <div>
-        <div
-          aria-label={LOCALIZE.ariaLabel.emailHeader}
-          tabIndex="0"
-          aria-describedby="email-header-desc"
-        >
-          <div id="email-header-desc" role="dialog">
-            <p className="font-weight-bold">
-              {LOCALIZE.emibTest.inboxPage.emailResponse.description}
-              {action.emailType === EMAIL_TYPE.reply && (
-                <>
-                  <i className="fas fa-reply" style={styles.responseTypeIcon} />
-                  <span style={styles.responseType}>
-                    {LOCALIZE.emibTest.inboxPage.emailCommons.reply}
-                  </span>
-                </>
-              )}
-              {action.emailType === EMAIL_TYPE.replyAll && (
-                <>
-                  <i className="fas fa-reply-all" style={styles.responseTypeIcon} />
-                  <span style={styles.responseType}>
-                    {LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
-                  </span>
-                </>
-              )}
-              {action.emailType === EMAIL_TYPE.forward && (
-                <>
-                  <i className="fas fa-share-square" style={styles.responseTypeIcon} />
-                  <span style={styles.responseType}>
-                    {LOCALIZE.emibTest.inboxPage.emailCommons.forward}
-                  </span>
-                </>
-              )}
-            </p>
-            <p>
-              <span className="font-weight-bold">
-                {LOCALIZE.emibTest.inboxPage.emailCommons.to}&nbsp;
-              </span>
-              <span>{action.emailTo}</span>
-            </p>
-            <p>
-              <span className="font-weight-bold">
-                {LOCALIZE.emibTest.inboxPage.emailCommons.cc}&nbsp;
-              </span>
-              <span>{action.emailCc}</span>
-            </p>
-          </div>
+      <div aria-label={LOCALIZE.ariaLabel.responseDetails}>
+        <div tabIndex="0">
+          <p className="font-weight-bold">
+            {LOCALIZE.emibTest.inboxPage.emailResponse.description}
+            {action.emailType === EMAIL_TYPE.reply && (
+              <>
+                <i className="fas fa-reply" style={styles.responseTypeIcon} />
+                <span style={styles.responseType}>
+                  {LOCALIZE.emibTest.inboxPage.emailCommons.reply}
+                </span>
+              </>
+            )}
+            {action.emailType === EMAIL_TYPE.replyAll && (
+              <>
+                <i className="fas fa-reply-all" style={styles.responseTypeIcon} />
+                <span style={styles.responseType}>
+                  {LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
+                </span>
+              </>
+            )}
+            {action.emailType === EMAIL_TYPE.forward && (
+              <>
+                <i className="fas fa-share-square" style={styles.responseTypeIcon} />
+                <span style={styles.responseType}>
+                  {LOCALIZE.emibTest.inboxPage.emailCommons.forward}
+                </span>
+              </>
+            )}
+          </p>
+          <p>
+            <span className="font-weight-bold">
+              {LOCALIZE.emibTest.inboxPage.emailCommons.to}&nbsp;
+            </span>
+            <span>{action.emailTo}</span>
+          </p>
+          <p>
+            <span className="font-weight-bold">
+              {LOCALIZE.emibTest.inboxPage.emailCommons.cc}&nbsp;
+            </span>
+            <span>{action.emailCc}</span>
+          </p>
         </div>
         <hr style={styles.hr} />
-        <div
-          aria-label={LOCALIZE.ariaLabel.responseDetails}
-          tabIndex="0"
-          aria-describedby="email-response"
-        >
-          <div id="email-response" role="dialog">
-            <p className="font-weight-bold">{LOCALIZE.emibTest.inboxPage.emailResponse.response}</p>
-            <p>{action.emailBody}</p>
-          </div>
+        <div tabIndex="0">
+          <p className="font-weight-bold">{LOCALIZE.emibTest.inboxPage.emailResponse.response}</p>
+          <p>{action.emailBody}</p>
         </div>
         <hr style={styles.hr} />
-        <div
-          aria-label={LOCALIZE.ariaLabel.reasonsForActionDetails}
-          tabIndex="0"
-          aria-describedby="email-reasons-for-action"
-        >
-          <div id="email-reasons-for-action" role="dialog">
-            <p className="font-weight-bold">
-              {LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}
-            </p>
-            <p>{action.reasonForAction}</p>
-          </div>
+        <div tabIndex="0">
+          <p className="font-weight-bold">
+            {LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}
+          </p>
+          <p>{action.reasonForAction}</p>
         </div>
         <hr style={styles.hr} />
         <div aria-label={LOCALIZE.ariaLabel.emailOptions}>

--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -98,7 +98,7 @@ class ActionViewEmail extends Component {
         <hr style={styles.hr} />
         <div tabIndex="0">
           <h6>{LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}</h6>
-          <p>{action.reasonForAction}</p>
+          <p>{action.reasonsForAction}</p>
         </div>
         <hr style={styles.hr} />
         <div aria-label={LOCALIZE.ariaLabel.emailOptions}>

--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -92,14 +92,12 @@ class ActionViewEmail extends Component {
         </div>
         <hr style={styles.hr} />
         <div tabIndex="0">
-          <h6 className="font-weight-bold">{LOCALIZE.emibTest.inboxPage.emailResponse.response}</h6>
+          <h6>{LOCALIZE.emibTest.inboxPage.emailResponse.response}</h6>
           <p>{action.emailBody}</p>
         </div>
         <hr style={styles.hr} />
         <div tabIndex="0">
-          <h6 className="font-weight-bold">
-            {LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}
-          </h6>
+          <h6>{LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}</h6>
           <p>{action.reasonForAction}</p>
         </div>
         <hr style={styles.hr} />

--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -6,17 +6,33 @@ import { EMAIL_TYPE } from "./constants";
 import { actionShape } from "./constants";
 
 const styles = {
-  responseTypeIcon: {
-    color: "white",
-    margin: "0 8px",
-    padding: 3,
-    backgroundColor: "#00565E",
-    border: "3px solid #009FAE",
-    borderRadius: 4
-  },
   responseType: {
-    color: "#00565E",
-    textDecoration: "underline"
+    description: {
+      float: "left",
+      margin: "4px 0 0 0"
+    },
+    icon: {
+      color: "white",
+      margin: "0 8px",
+      padding: 3,
+      backgroundColor: "#00565E",
+      border: "3px solid #009FAE",
+      borderRadius: 4
+    },
+    attribute: {
+      color: "#00565E",
+      textDecoration: "underline"
+    }
+  },
+  toAndCcStyle: {
+    float: "left",
+    width: 32,
+    height: 32,
+    lineHeight: "22px",
+    margin: 0
+  },
+  headerMargin: {
+    margin: "9px 0 12px 0"
   },
   hr: {
     margin: "16px 0 16px 0"
@@ -37,56 +53,54 @@ class ActionViewEmail extends Component {
     return (
       <div aria-label={LOCALIZE.ariaLabel.responseDetails}>
         <div tabIndex="0">
-          <p className="font-weight-bold">
-            {LOCALIZE.emibTest.inboxPage.emailResponse.description}
+          <div>
+            <h6 style={styles.responseType.description}>
+              {LOCALIZE.emibTest.inboxPage.emailResponse.description}
+            </h6>
             {action.emailType === EMAIL_TYPE.reply && (
               <>
-                <i className="fas fa-reply" style={styles.responseTypeIcon} />
-                <span style={styles.responseType}>
+                <i className="fas fa-reply" style={styles.responseType.icon} />
+                <span style={styles.responseType.attribute}>
                   {LOCALIZE.emibTest.inboxPage.emailCommons.reply}
                 </span>
               </>
             )}
             {action.emailType === EMAIL_TYPE.replyAll && (
               <>
-                <i className="fas fa-reply-all" style={styles.responseTypeIcon} />
-                <span style={styles.responseType}>
+                <i className="fas fa-reply-all" style={styles.icon} />
+                <span style={styles.responseType.attribute}>
                   {LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
                 </span>
               </>
             )}
             {action.emailType === EMAIL_TYPE.forward && (
               <>
-                <i className="fas fa-share-square" style={styles.responseTypeIcon} />
-                <span style={styles.responseType}>
+                <i className="fas fa-share-square" style={styles.icon} />
+                <span style={styles.responseType.attribute}>
                   {LOCALIZE.emibTest.inboxPage.emailCommons.forward}
                 </span>
               </>
             )}
-          </p>
-          <p>
-            <span className="font-weight-bold">
-              {LOCALIZE.emibTest.inboxPage.emailCommons.to}&nbsp;
-            </span>
+          </div>
+          <div style={styles.headerMargin}>
+            <h6 style={styles.toAndCcStyle}>{LOCALIZE.emibTest.inboxPage.emailCommons.to}</h6>
             <span>{action.emailTo}</span>
-          </p>
-          <p>
-            <span className="font-weight-bold">
-              {LOCALIZE.emibTest.inboxPage.emailCommons.cc}&nbsp;
-            </span>
+          </div>
+          <div>
+            <h6 style={styles.toAndCcStyle}>{LOCALIZE.emibTest.inboxPage.emailCommons.cc}</h6>
             <span>{action.emailCc}</span>
-          </p>
+          </div>
         </div>
         <hr style={styles.hr} />
         <div tabIndex="0">
-          <p className="font-weight-bold">{LOCALIZE.emibTest.inboxPage.emailResponse.response}</p>
+          <h6 className="font-weight-bold">{LOCALIZE.emibTest.inboxPage.emailResponse.response}</h6>
           <p>{action.emailBody}</p>
         </div>
         <hr style={styles.hr} />
         <div tabIndex="0">
-          <p className="font-weight-bold">
+          <h6 className="font-weight-bold">
             {LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}
-          </p>
+          </h6>
           <p>{action.reasonForAction}</p>
         </div>
         <hr style={styles.hr} />

--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -28,8 +28,7 @@ const styles = {
     float: "left",
     width: 32,
     height: 32,
-    lineHeight: "22px",
-    margin: 0
+    margin: "2px 0 0 0"
   },
   headerMargin: {
     margin: "9px 0 12px 0"
@@ -67,7 +66,7 @@ class ActionViewEmail extends Component {
             )}
             {action.emailType === EMAIL_TYPE.replyAll && (
               <>
-                <i className="fas fa-reply-all" style={styles.icon} />
+                <i className="fas fa-reply-all" style={styles.responseType.icon} />
                 <span style={styles.responseType.attribute}>
                   {LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
                 </span>
@@ -75,7 +74,7 @@ class ActionViewEmail extends Component {
             )}
             {action.emailType === EMAIL_TYPE.forward && (
               <>
-                <i className="fas fa-share-square" style={styles.icon} />
+                <i className="fas fa-share-square" style={styles.responseType.icon} />
                 <span style={styles.responseType.attribute}>
                   {LOCALIZE.emibTest.inboxPage.emailCommons.forward}
                 </span>

--- a/frontend/src/components/eMIB/ActionViewTask.jsx
+++ b/frontend/src/components/eMIB/ActionViewTask.jsx
@@ -4,6 +4,9 @@ import LOCALIZE from "../../text_resources";
 import { actionShape } from "./constants";
 
 const styles = {
+  taskStyle: {
+    marginTop: 18
+  },
   hr: {
     margin: "16px 0 16px 0"
   },
@@ -22,14 +25,12 @@ class ActionViewTask extends Component {
     return (
       <div aria-label={LOCALIZE.ariaLabel.taskDetails}>
         <div tabIndex="0">
-          <p className="font-weight-bold">{LOCALIZE.emibTest.inboxPage.taskContent.task}</p>
+          <h6 style={styles.taskStyle}>{LOCALIZE.emibTest.inboxPage.taskContent.task}</h6>
           <p>{action.task}</p>
         </div>
         <hr style={styles.hr} />
         <div tabIndex="0">
-          <p className="font-weight-bold">
-            {LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}
-          </p>
+          <h6>{LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}</h6>
           <p>{action.reasonForAction}</p>
         </div>
         <hr style={styles.hr} />

--- a/frontend/src/components/eMIB/ActionViewTask.jsx
+++ b/frontend/src/components/eMIB/ActionViewTask.jsx
@@ -31,7 +31,7 @@ class ActionViewTask extends Component {
         <hr style={styles.hr} />
         <div tabIndex="0">
           <h6>{LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}</h6>
-          <p>{action.reasonForAction}</p>
+          <p>{action.reasonsForAction}</p>
         </div>
         <hr style={styles.hr} />
         <div aria-label={LOCALIZE.ariaLabel.taskOptions}>

--- a/frontend/src/components/eMIB/ActionViewTask.jsx
+++ b/frontend/src/components/eMIB/ActionViewTask.jsx
@@ -4,18 +4,6 @@ import LOCALIZE from "../../text_resources";
 import { actionShape } from "./constants";
 
 const styles = {
-  responseTypeIcon: {
-    color: "white",
-    margin: "0 8px",
-    padding: 3,
-    backgroundColor: "#00565E",
-    border: "3px solid #009FAE",
-    borderRadius: 4
-  },
-  responseType: {
-    color: "#00565E",
-    textDecoration: "underline"
-  },
   hr: {
     margin: "16px 0 16px 0"
   },

--- a/frontend/src/components/eMIB/ActionViewTask.jsx
+++ b/frontend/src/components/eMIB/ActionViewTask.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 import "../../css/collapsing-item.css";
 import LOCALIZE from "../../text_resources";
 import { actionShape } from "./constants";


### PR DESCRIPTION
# Description

I simplified the aria-labels and roles structure in _ActionViewEmail.jsx_ and in _ActionViewTask.jsx_ components:
- Removed all dialog roles
- refactored aria-labels
- replaced all the field's titles (was <p> tags) with header tags

## Type of change

- Code cleanliness or refactor

## Screenshot

**(No Visual Changes)**

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB Sample Test.
2.  Complete the _pre-test_ process.
3.  Open the _Inbox_ tab.
4.  Add an _Email response_.
5.  Save you email response.
6.  Turn on the narrator settings.
7. Take a look at the your response by using the collapsing item at the bottom.
8. Use the keyboard to navigate in the response view item.
9.  Make sure that the narrator reads all the information inside this response item.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] ~~My changes look good on IE 10+, Firefox, and Chrome~~
