### PR TITLE
[Refactoring] Replaced all 'reasonForAction' with 'reasonsForAction'

### DIFF
--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -104,7 +104,7 @@ class ActionViewEmail extends Component {
             <p className="font-weight-bold">
               {LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}
             </p>
-            <p>{action.reasonForAction}</p>
+            <p>{action.reasonsForAction}</p>
           </div>
         </div>
         <hr style={styles.hr} />

--- a/frontend/src/components/eMIB/ActionViewTask.jsx
+++ b/frontend/src/components/eMIB/ActionViewTask.jsx
@@ -43,7 +43,7 @@ class ActionViewTask extends Component {
           <p className="font-weight-bold">
             {LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}
           </p>
-          <p>{action.reasonForAction}</p>
+          <p>{action.reasonsForAction}</p>
         </div>
         <hr style={styles.hr} />
         <div aria-label={LOCALIZE.ariaLabel.taskOptions}>

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -85,7 +85,7 @@ class EditEmail extends Component {
     emailTo: "",
     emailCc: "",
     emailBody: "",
-    reasonForAction: ""
+    reasonsForAction: ""
   };
 
   onEmailTypeChange = event => {
@@ -113,9 +113,9 @@ class EditEmail extends Component {
   };
 
   onReasonsForActionChange = event => {
-    const newReasonForAction = event.target.value;
-    this.setState({ reasonForAction: newReasonForAction });
-    this.props.onChange({ ...this.state, reasonForAction: newReasonForAction });
+    const newreasonsForAction = event.target.value;
+    this.setState({ reasonsForAction: newreasonsForAction });
+    this.props.onChange({ ...this.state, reasonsForAction: newreasonsForAction });
   };
 
   render() {

--- a/frontend/src/components/eMIB/constants.js
+++ b/frontend/src/components/eMIB/constants.js
@@ -41,7 +41,7 @@ export const emailShape = PropTypes.shape({
 // Actions a candidate can take in response to an email.
 export const actionShape = PropTypes.shape({
   actionType: PropTypes.oneOf(Object.keys(ACTION_TYPE)).isRequired,
-  reasonForAction: PropTypes.string,
+  reasonsForAction: PropTypes.string,
   task: PropTypes.string,
   emailType: PropTypes.oneOf(Object.keys(EMAIL_TYPE)),
   emailTo: PropTypes.string,

--- a/frontend/src/tests/components/eMIB/ActionViewEmail.test.js
+++ b/frontend/src/tests/components/eMIB/ActionViewEmail.test.js
@@ -52,7 +52,7 @@ describe("Email header", () => {
 function genWrapper(responseType, cc) {
   const actionStub = {
     actionType: ACTION_TYPE.email,
-    reasonForAction: "reasons",
+    reasonsForAction: "reasons",
     emailType: responseType,
     emailTo: "to",
     emailCc: cc,

--- a/frontend/src/tests/components/eMIB/ActionViewTask.test.js
+++ b/frontend/src/tests/components/eMIB/ActionViewTask.test.js
@@ -7,7 +7,7 @@ import { ACTION_TYPE } from "../../../components/eMIB/constants";
 const actionStub = {
   actionType: ACTION_TYPE.task,
   task: "Liste of my tasks here...",
-  reasonForAction: "Reasons for action here..."
+  reasonsForAction: "Reasons for action here..."
 };
 
 describe("renders component's content", () => {


### PR DESCRIPTION
# Description

I simply replaced all 'reasonForAction' with 'reasonsForAction' (with an s).

## Type of change

- Code cleanliness or refactor

## Screenshot

**(No Visual Changes)**

# Testing

Manual steps to reproduce this functionality:

- Make sure that the app is still the same as before

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [ ] ~~My changes look good on IE 10+, Firefox, and Chrome~~
