### PR TITLE
[EditActionDialog] Design pairing fixes

### DIFF
--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -80,11 +80,6 @@ class EditActionDialog extends Component {
 
   render() {
     const { showDialog, handleClose, actionType, editMode } = this.props;
-    const closeButton = (
-      <button onClick={handleClose} style={styles.closeButton}>
-        <i class="fas fa-times" />
-      </button>
-    );
     return (
       <div>
         <Modal show={showDialog} onHide={handleClose}>
@@ -101,7 +96,9 @@ class EditActionDialog extends Component {
                         {editMode === EDIT_MODE.update &&
                           LOCALIZE.emibTest.inboxPage.editActionDialog.editEmail}
                       </h3>
-                      {closeButton}
+                      <button onClick={handleClose} style={styles.closeButton}>
+                        <i class="fas fa-times" />
+                      </button>
                     </div>
                   )}
                   {actionType === ACTION_TYPE.task && (
@@ -113,7 +110,9 @@ class EditActionDialog extends Component {
                         {editMode === EDIT_MODE.update &&
                           LOCALIZE.emibTest.inboxPage.editActionDialog.editTask}
                       </h3>
-                      {closeButton}
+                      <button onClick={handleClose} style={styles.closeButton}>
+                        <i class="fas fa-times" />
+                      </button>
                     </div>
                   )}
                 </div>

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -26,7 +26,12 @@ const styles = {
     color: "white",
     fontSize: 16,
     fontWeight: 600,
-    borderRadius: "10px 10px 0px 0px"
+    borderRadius: "10px 10px 0px 0px",
+    padding: 0
+  },
+  closeButton: {
+    backgroundColor: "transparent",
+    float: "right"
   }
 };
 
@@ -64,6 +69,11 @@ class EditActionDialog extends Component {
 
   render() {
     const { showDialog, handleClose, actionType, editMode } = this.props;
+    const closeButton = (
+      <button onClick={handleClose} style={styles.closeButton}>
+        X
+      </button>
+    );
     return (
       <div>
         <Modal show={showDialog} onHide={handleClose}>
@@ -80,6 +90,7 @@ class EditActionDialog extends Component {
                         {editMode === EDIT_MODE.update &&
                           LOCALIZE.emibTest.inboxPage.editActionDialog.editEmail}
                       </h3>
+                      {closeButton}
                     </div>
                   )}
                   {actionType === ACTION_TYPE.task && (
@@ -91,6 +102,7 @@ class EditActionDialog extends Component {
                         {editMode === EDIT_MODE.update &&
                           LOCALIZE.emibTest.inboxPage.editActionDialog.editTask}
                       </h3>
+                      {closeButton}
                     </div>
                   )}
                 </div>

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -33,6 +33,10 @@ const styles = {
   closeButton: {
     backgroundColor: "transparent",
     float: "right"
+  },
+  modalBody: {
+    paddingTop: 0,
+    paddingBottom: 0
   }
 };
 
@@ -109,7 +113,7 @@ class EditActionDialog extends Component {
                 </div>
               }
             </Modal.Header>
-            <Modal.Body>
+            <Modal.Body style={styles.modalBody}>
               {actionType === ACTION_TYPE.email && <EditEmail onChange={this.editAction} />}
               {actionType === ACTION_TYPE.task && (
                 <EditTask emailId={this.props.emailId + 1} emailSubject={this.props.emailSubject} />

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -32,7 +32,9 @@ const styles = {
   },
   closeButton: {
     backgroundColor: "transparent",
-    float: "right"
+    float: "right",
+    color: "white",
+    border: 0
   },
   modalBody: {
     paddingTop: 0,

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -27,7 +27,8 @@ const styles = {
     fontSize: 16,
     fontWeight: 600,
     borderRadius: "10px 10px 0px 0px",
-    padding: 0
+    paddingTop: 0,
+    paddingBottom: 0
   },
   closeButton: {
     backgroundColor: "transparent",

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -78,7 +78,7 @@ class EditActionDialog extends Component {
     const { showDialog, handleClose, actionType, editMode } = this.props;
     const closeButton = (
       <button onClick={handleClose} style={styles.closeButton}>
-        X
+        <i class="fas fa-times" />
       </button>
     );
     return (

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -34,7 +34,8 @@ const styles = {
     backgroundColor: "transparent",
     float: "right",
     color: "white",
-    border: 0
+    border: 0,
+    marginTop: 11
   },
   modalBody: {
     paddingTop: 0,

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -39,6 +39,9 @@ const styles = {
   modalBody: {
     paddingTop: 0,
     paddingBottom: 0
+  },
+  fullWidth: {
+    width: "100%"
   }
 };
 
@@ -87,9 +90,9 @@ class EditActionDialog extends Component {
           <div>
             <Modal.Header style={styles.modalHeader}>
               {
-                <div style={styles.title}>
+                <div style={styles.fullWidth}>
                   {actionType === ACTION_TYPE.email && (
-                    <div>
+                    <div style={styles.fullWidth}>
                       <i style={styles.icon} className="fas fa-envelope" />
                       <h3 style={styles.dialogHeaderText}>
                         {editMode === EDIT_MODE.create &&
@@ -101,7 +104,7 @@ class EditActionDialog extends Component {
                     </div>
                   )}
                   {actionType === ACTION_TYPE.task && (
-                    <div>
+                    <div style={styles.fullWidth}>
                       <i style={styles.icon} className="fas fa-tasks" />
                       <h3 style={styles.dialogHeaderText}>
                         {editMode === EDIT_MODE.create &&

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -30,7 +30,8 @@ const styles = {
       marginBottom: 16
     },
     radioText: {
-      textDecoration: "underline"
+      textDecoration: "underline",
+      cursor: "pointer"
     },
     textFieldBoxPadding: {
       padding: "0 6px"

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -51,13 +51,13 @@ function testCore(actionType, editMode) {
     expect(
       wrapper
         .find("i")
-        .last()
+        .first()
         .hasClass(emailIcon)
     ).toEqual(true);
     expect(
       wrapper
         .find("i")
-        .last()
+        .first()
         .hasClass(taskIcon)
     ).toEqual(false);
   }
@@ -65,13 +65,13 @@ function testCore(actionType, editMode) {
     expect(
       wrapper
         .find("i")
-        .last()
+        .first()
         .hasClass(emailIcon)
     ).toEqual(false);
     expect(
       wrapper
         .find("i")
-        .last()
+        .first()
         .hasClass(taskIcon)
     ).toEqual(true);
   }

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -48,12 +48,32 @@ function testCore(actionType, editMode) {
 
   // Check if it is an email or a task
   if (actionType === ACTION_TYPE.email) {
-    expect(wrapper.find("i").hasClass(emailIcon)).toEqual(true);
-    expect(wrapper.find("i").hasClass(taskIcon)).toEqual(false);
+    expect(
+      wrapper
+        .find("i")
+        .last()
+        .hasClass(emailIcon)
+    ).toEqual(true);
+    expect(
+      wrapper
+        .find("i")
+        .last()
+        .hasClass(taskIcon)
+    ).toEqual(false);
   }
   if (actionType === ACTION_TYPE.task) {
-    expect(wrapper.find("i").hasClass(emailIcon)).toEqual(false);
-    expect(wrapper.find("i").hasClass(taskIcon)).toEqual(true);
+    expect(
+      wrapper
+        .find("i")
+        .last()
+        .hasClass(emailIcon)
+    ).toEqual(false);
+    expect(
+      wrapper
+        .find("i")
+        .last()
+        .hasClass(taskIcon)
+    ).toEqual(true);
   }
 
   //Check that the button click triggers the function


### PR DESCRIPTION
# Description

Several styling changes from design pairing with Joey, including:
- Removing unnecessary padding and margins
- Increasing width of the modal header
- Adding a close button
- Adding a pointer cursor over the Edit Email Radio buttons

## Type of change

Please delete options that are not relevant.

- Code cleanliness or refactor

## Screenshot

Before:
![image](https://user-images.githubusercontent.com/2746350/55822883-830de700-5ace-11e9-9d98-3b3f936ed51c.png)
![image](https://user-images.githubusercontent.com/2746350/55822897-8e611280-5ace-11e9-8f94-9d6bf84da165.png)
![image](https://user-images.githubusercontent.com/2746350/55822919-98831100-5ace-11e9-8d59-33f608681e58.png)


After:
![image](https://user-images.githubusercontent.com/2746350/55822757-4b9f3a80-5ace-11e9-9f45-82400ff17647.png)
![image](https://user-images.githubusercontent.com/2746350/55822785-58bc2980-5ace-11e9-9dcb-137e96d8cce4.png)
![image](https://user-images.githubusercontent.com/2746350/55822805-640f5500-5ace-11e9-901d-faf21945a04b.png)


# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Enter the test
2.  Open the Inbox Tab
3.  Look at the differences in the dialog when adding/modifying an email/task

# Checklist

Applicable for all code changes.

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
