### PR TITLE
[Add/Edit Email] Fixing Display Bugs

### DIFF
--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -24,14 +24,22 @@ const styles = {
       textDecoration: "underline"
     }
   },
-  toAndCcStyle: {
-    float: "left",
-    width: 32,
-    height: 32,
-    margin: "2px 0 0 0"
-  },
-  headerMargin: {
-    margin: "9px 0 12px 0"
+  header: {
+    zone: {
+      minHeight: 95
+    },
+    elementHeight: {
+      minHeight: 24
+    },
+    toAndCcTitle: {
+      float: "left",
+      width: 32,
+      height: 32,
+      margin: "2px 0 0 0"
+    },
+    toFieldMargin: {
+      margin: "9px 0 12px 0"
+    }
   },
   hr: {
     margin: "16px 0 16px 0"
@@ -47,13 +55,12 @@ class ActionViewEmail extends Component {
     emailId: PropTypes.number.isRequired
   };
 
-  // TODO: Fix display bug when CC field is empty
   render() {
     const action = this.props.action;
     return (
       <div aria-label={LOCALIZE.ariaLabel.responseDetails}>
-        <div tabIndex="0">
-          <div>
+        <div style={styles.header.zone} tabIndex="0">
+          <div style={styles.header.elementHeight}>
             <h6 style={styles.responseType.description}>
               {LOCALIZE.emibTest.inboxPage.emailResponse.description}
             </h6>
@@ -82,12 +89,16 @@ class ActionViewEmail extends Component {
               </>
             )}
           </div>
-          <div style={styles.headerMargin}>
-            <h6 style={styles.toAndCcStyle}>{LOCALIZE.emibTest.inboxPage.emailCommons.to}</h6>
+          <div style={{ ...styles.header.toFieldMargin, ...styles.header.elementHeight }}>
+            <h6 style={styles.header.toAndCcTitle}>
+              {LOCALIZE.emibTest.inboxPage.emailCommons.to}
+            </h6>
             <span>{action.emailTo}</span>
           </div>
-          <div>
-            <h6 style={styles.toAndCcStyle}>{LOCALIZE.emibTest.inboxPage.emailCommons.cc}</h6>
+          <div style={styles.header.elementHeight}>
+            <h6 style={styles.header.toAndCcTitle}>
+              {LOCALIZE.emibTest.inboxPage.emailCommons.cc}
+            </h6>
             <span>{action.emailCc}</span>
           </div>
         </div>

--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -47,6 +47,7 @@ class ActionViewEmail extends Component {
     emailId: PropTypes.number.isRequired
   };
 
+  // TODO: Fix display bug when CC field is empty
   render() {
     const action = this.props.action;
     return (


### PR DESCRIPTION
# Description

There was some display bugs in the email response view when the **To** and/or **Cc** fields were empty. This bug is now fixed.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

**Before:**

![image](https://user-images.githubusercontent.com/23021242/55884084-71334f00-5b75-11e9-8498-b0769c729dbb.png)

**After (empty cc field):**

![image](https://user-images.githubusercontent.com/23021242/55885956-db99be80-5b78-11e9-9fd7-ee8ae162be0e.png)

**After (empty to and cc fields):**

![image](https://user-images.githubusercontent.com/23021242/55886000-f2d8ac00-5b78-11e9-8f73-27881f29c810.png)

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB Sample Test.
2.  Complete the _pre-test_ process.
3.  Open the _Inbox_ tab.
4.  Add email responses with empty '_to_' and/or '_cc_' fields and make sure that the response views still look good.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 10+, Firefox, and Chrome
