### PR TITLE
[Edit Task] Added Edit Task Functionality

### DIFF
--- a/frontend/src/components/eMIB/ActionViewTask.jsx
+++ b/frontend/src/components/eMIB/ActionViewTask.jsx
@@ -1,7 +1,9 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 import "../../css/collapsing-item.css";
 import LOCALIZE from "../../text_resources";
-import { actionShape } from "./constants";
+import EditActionDialog from "./EditActionDialog";
+import { ACTION_TYPE, EDIT_MODE, actionShape } from "./constants";
 
 const styles = {
   taskStyle: {
@@ -17,7 +19,22 @@ const styles = {
 
 class ActionViewTask extends Component {
   static propTypes = {
-    action: actionShape
+    action: actionShape,
+    emailSubject: PropTypes.string,
+    actionId: PropTypes.number.isRequired,
+    emailId: PropTypes.number.isRequired
+  };
+
+  state = {
+    showTaskDialog: false
+  };
+
+  showTaskDialog = () => {
+    this.setState({ showTaskDialog: true });
+  };
+
+  closeTaskDialog = () => {
+    this.setState({ showTaskDialog: false });
   };
 
   render() {
@@ -35,12 +52,28 @@ class ActionViewTask extends Component {
         </div>
         <hr style={styles.hr} />
         <div aria-label={LOCALIZE.ariaLabel.taskOptions}>
-          <button className="btn btn-primary" style={styles.editButton}>
+          <button
+            className="btn btn-primary"
+            style={styles.editButton}
+            onClick={this.showTaskDialog}
+          >
             {LOCALIZE.emibTest.inboxPage.emailCommons.editButton}
           </button>
           <button className="btn btn-danger">
             {LOCALIZE.emibTest.inboxPage.emailCommons.deleteButton}
           </button>
+        </div>
+        <div>
+          <EditActionDialog
+            emailId={this.props.emailId}
+            emailSubject={this.props.emailSubject}
+            showDialog={this.state.showTaskDialog}
+            handleClose={this.closeTaskDialog}
+            actionType={ACTION_TYPE.task}
+            editMode={EDIT_MODE.update}
+            action={action}
+            actionId={this.props.actionId}
+          />
         </div>
       </div>
     );

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -7,7 +7,7 @@ import EditEmail from "./EditEmail";
 import EditTask from "./EditTask";
 import { Modal } from "react-bootstrap";
 import { ACTION_TYPE, EDIT_MODE, actionShape } from "./constants";
-import { addEmail, addTask, updateEmail } from "../../modules/EmibInboxRedux";
+import { addEmail, addTask, updateEmail, updateTask } from "../../modules/EmibInboxRedux";
 
 const styles = {
   icon: {
@@ -58,6 +58,7 @@ class EditActionDialog extends Component {
     addEmail: PropTypes.func.isRequired,
     addTask: PropTypes.func.isRequired,
     updateEmail: PropTypes.func.isRequired,
+    updateTask: PropTypes.func.isRequired,
     // Only needed when updating an existing one
     action: actionShape,
     actionId: PropTypes.number
@@ -84,8 +85,7 @@ class EditActionDialog extends Component {
       this.props.actionType === ACTION_TYPE.task &&
       this.props.editMode === EDIT_MODE.update
     ) {
-      //TODO jcherry add this one it is defined
-      //this.props.updateTask(this.props.emailId, this.state.action);
+      this.props.updateTask(this.props.emailId, this.props.actionId, this.state.action);
     }
     this.setState({ action: {} });
     this.props.handleClose();
@@ -148,6 +148,7 @@ class EditActionDialog extends Component {
                   emailNumber={this.props.emailId}
                   emailSubject={this.props.emailSubject}
                   onChange={this.editAction}
+                  action={editMode === EDIT_MODE.update ? this.props.action : null}
                 />
               )}
             </Modal.Body>
@@ -179,7 +180,8 @@ const mapDispatchToProps = dispatch =>
     {
       addEmail,
       addTask,
-      updateEmail
+      updateEmail,
+      updateTask
     },
     dispatch
   );

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
+import { actionShape } from "./constants";
 
 const styles = {
   container: {
@@ -64,14 +65,15 @@ const styles = {
 
 class EditTask extends Component {
   state = {
-    task: "",
-    reasonsForAction: ""
+    task: !this.props.action ? "" : this.props.action.task,
+    reasonsForAction: !this.props.action ? "" : this.props.action.reasonsForAction
   };
 
   static propTypes = {
     emailNumber: PropTypes.number.isRequired,
     emailSubject: PropTypes.string.isRequired,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    action: actionShape
   };
 
   onTaskContentChange = event => {

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -142,9 +142,7 @@ class Email extends Component {
                   iconType={ICON_TYPE.email}
                   // TODO: we need to put a dynamic title generator here instead of hard coding this title
                   title={"Email Response #XX"}
-                  body={
-                    <ActionViewEmail action={action} actionId={id} emailId={this.props.email.id} />
-                  }
+                  body={<ActionViewEmail action={action} actionId={id} emailId={email.id} />}
                 />
               );
             } else if (emailActions[id].actionType === ACTION_TYPE.task) {
@@ -154,7 +152,14 @@ class Email extends Component {
                   iconType={ICON_TYPE.task}
                   // TODO: we need to put a dynamic title generator here instead of hard coding this title
                   title={"Task #XX"}
-                  body={<ActionViewTask action={action} emailId={this.props.email.id} />}
+                  body={
+                    <ActionViewTask
+                      action={action}
+                      actionId={id}
+                      emailId={email.id}
+                      emailSubject={email.subject}
+                    />
+                  }
                 />
               );
             }

--- a/frontend/src/modules/EmibInboxRedux.js
+++ b/frontend/src/modules/EmibInboxRedux.js
@@ -111,7 +111,16 @@ const emibInbox = (state = initialState, action) => {
         ...state,
         emailActions: updatedEmailActions
       };
-    //TODO jcherry handle calls UPDATE_TASK when this is added
+    case UPDATE_TASK:
+      let emailActionsUpdated = Array.from(state.emailActions);
+      emailActionsUpdated[action.emailIndex][action.responseId] = {
+        ...action.taskAction,
+        actionType: ACTION_TYPE.task
+      };
+      return {
+        ...state,
+        emailActions: emailActionsUpdated
+      };
     default:
       return state;
   }

--- a/frontend/src/tests/components/eMIB/ActionViewTask.test.js
+++ b/frontend/src/tests/components/eMIB/ActionViewTask.test.js
@@ -11,7 +11,7 @@ const actionStub = {
 };
 
 describe("renders component's content", () => {
-  const wrapper = shallow(<ActionViewTask action={actionStub} />);
+  const wrapper = shallow(<ActionViewTask action={actionStub} actionId={0} emailId={1} />);
 
   it("task content", () => {
     const taskContent = <p>{"Liste of my tasks here..."}</p>;

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -188,6 +188,17 @@ function testMode(actionType, editMode) {
     expect(wrapper.find("#reply-all-radio").props().checked).toEqual(isReplyAllChecked);
     expect(wrapper.find("#forward-radio").props().checked).toEqual(isForwardChecked);
   } else if (actionType === ACTION_TYPE.task) {
-    //TODO jcherry populate this when task editing has been added
+    //set default values when in "create" mode
+    let valTask = "";
+    let valReasonsForAction = "";
+    if (editMode == EDIT_MODE.update) {
+      // change defaults when in 'update' mode
+      valTask = task;
+      valReasonsForAction = reasonsForAction;
+    }
+    expect(wrapper.find("#your-tasks-text-area").props().value).toEqual(valTask);
+    expect(wrapper.find("#reasons-for-action-text-area").props().value).toEqual(
+      valReasonsForAction
+    );
   }
 }

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -28,7 +28,7 @@ function testCore(actionType, editMode) {
   const addEmail = jest.fn();
   const addTask = jest.fn();
   const updateEmail = jest.fn();
-  //TODO jcherry add jest fn and checks for updateTask when it is implemented
+  const updateTask = jest.fn();
 
   //shallow wrapper of the dialog
   const wrapper = shallow(
@@ -40,6 +40,7 @@ function testCore(actionType, editMode) {
       addEmail={addEmail}
       addTask={addTask}
       updateEmail={updateEmail}
+      updateTask={updateTask}
       actionType={actionType}
       editMode={editMode}
     />
@@ -85,10 +86,12 @@ function testCore(actionType, editMode) {
     expect(addTask).toHaveBeenCalledTimes(0);
     expect(addEmail).toHaveBeenCalledTimes(1);
     expect(updateEmail).toHaveBeenCalledTimes(0);
+    expect(updateTask).toHaveBeenCalledTimes(0);
   } else if (actionType === ACTION_TYPE.email && editMode === EDIT_MODE.update) {
     expect(addTask).toHaveBeenCalledTimes(0);
     expect(addEmail).toHaveBeenCalledTimes(0);
     expect(updateEmail).toHaveBeenCalledTimes(1);
+    expect(updateTask).toHaveBeenCalledTimes(0);
   } else if (actionType === ACTION_TYPE.task && editMode === EDIT_MODE.create) {
     expect(addTask).toHaveBeenCalledTimes(1);
     expect(addEmail).toHaveBeenCalledTimes(0);
@@ -97,6 +100,7 @@ function testCore(actionType, editMode) {
     expect(addTask).toHaveBeenCalledTimes(0);
     expect(addEmail).toHaveBeenCalledTimes(0);
     expect(updateEmail).toHaveBeenCalledTimes(0);
+    expect(updateTask).toHaveBeenCalledTimes(1);
   }
 }
 
@@ -139,6 +143,7 @@ function testMode(actionType, editMode) {
       addEmail={() => {}}
       addTask={() => {}}
       updateEmail={() => {}}
+      updateTask={() => {}}
       actionType={actionType}
       editMode={editMode}
       action={{

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -96,6 +96,7 @@ function testCore(actionType, editMode) {
     expect(addTask).toHaveBeenCalledTimes(1);
     expect(addEmail).toHaveBeenCalledTimes(0);
     expect(updateEmail).toHaveBeenCalledTimes(0);
+    expect(updateTask).toHaveBeenCalledTimes(0);
   } else if (actionType === ACTION_TYPE.task && editMode === EDIT_MODE.update) {
     expect(addTask).toHaveBeenCalledTimes(0);
     expect(addEmail).toHaveBeenCalledTimes(0);

--- a/frontend/src/tests/modules/EmibInboxRedux.test.js
+++ b/frontend/src/tests/modules/EmibInboxRedux.test.js
@@ -72,8 +72,6 @@ describe("EmibInboxRedux", () => {
     });
   });
 
-  //TODO jcherry add tests for UPDATE_TASK when implemented
-
   describe("update email action works as expected", () => {
     it("should update an email action in the action list", () => {
       const emailAction = {
@@ -191,13 +189,114 @@ describe("EmibInboxRedux", () => {
     });
   });
 
+  describe("update task action works as expected", () => {
+    it("should update a task action in the action list", () => {
+      const taskAction = {
+        task: "Here are my tasks.",
+        reasonsForAction: "I wanted to say hi."
+      };
+      const taskActionUpdate = {
+        task: "Here are my tasks. 2",
+        reasonsForAction: "I wanted to say hi. 2"
+      };
+      const addAction = addTask(0, taskAction);
+      const newState1 = emibInbox(stubbedInitialState, addAction);
+      expect(newState1.emailActions[0]).toEqual([{ ...taskAction, actionType: ACTION_TYPE.task }]);
+      const updateAction = updateTask(0, 0, taskActionUpdate);
+      const newState2 = emibInbox(newState1, updateAction);
+      expect(newState2.emailActions[0]).toEqual([
+        { ...taskActionUpdate, actionType: ACTION_TYPE.task }
+      ]);
+    });
+
+    it("should update 3 task actions one by one", () => {
+      const task1 = {
+        task: "Task 1",
+        reasonsForAction: "Reason 1"
+      };
+      const task2 = {
+        task: "Task 2",
+        reasonsForAction: "Reason 2"
+      };
+      const task3 = {
+        task: "Task 3",
+        reasonsForAction: "Reason 3"
+      };
+      const task1Update = {
+        task: "Task 1 Update",
+        reasonsForAction: "Reason 1 Update"
+      };
+      const task2Update = {
+        task: "Task 2 Update",
+        reasonsForAction: "Reason 2 Update"
+      };
+      const task3Update = {
+        task: "Task 3 Update",
+        reasonsForAction: "Reason 3 Update"
+      };
+      // Add first task
+      const addAction1 = addEmail(0, task1);
+      const newState1 = emibInbox(stubbedInitialState, addAction1);
+      expect(newState1.emailActions[0]).toEqual([{ ...task1, actionType: ACTION_TYPE.email }]);
+      // Add second task
+      const addAction2 = addEmail(0, task2);
+      const newState2 = emibInbox(newState1, addAction2);
+      expect(newState2.emailActions[0]).toEqual([
+        { ...task1, actionType: ACTION_TYPE.email },
+        { ...task2, actionType: ACTION_TYPE.email }
+      ]);
+      // Add third task
+      const addAction3 = addEmail(0, task3);
+      const newState3 = emibInbox(newState2, addAction3);
+      expect(newState3.emailActions[0]).toEqual([
+        { ...task1, actionType: ACTION_TYPE.email },
+        { ...task2, actionType: ACTION_TYPE.email },
+        { ...task3, actionType: ACTION_TYPE.email }
+      ]);
+      //Update first task
+      const updateAction1 = updateEmail(0, 0, task1Update);
+      const newState4 = emibInbox(newState3, updateAction1);
+      expect(newState4.emailActions[0]).toEqual([
+        { ...task1Update, actionType: ACTION_TYPE.email },
+        { ...task2, actionType: ACTION_TYPE.email },
+        { ...task3, actionType: ACTION_TYPE.email }
+      ]);
+      //Update second task
+      const updateAction2 = updateEmail(0, 1, task2Update);
+      const newState5 = emibInbox(newState4, updateAction2);
+      expect(newState5.emailActions[0]).toEqual([
+        { ...task1Update, actionType: ACTION_TYPE.email },
+        { ...task2Update, actionType: ACTION_TYPE.email },
+        { ...task3, actionType: ACTION_TYPE.email }
+      ]);
+      //update third task
+      const updateAction3 = updateEmail(0, 2, task3Update);
+      const newState6 = emibInbox(newState5, updateAction3);
+      expect(newState6.emailActions[0]).toEqual([
+        { ...task1Update, actionType: ACTION_TYPE.email },
+        { ...task2Update, actionType: ACTION_TYPE.email },
+        { ...task3Update, actionType: ACTION_TYPE.email }
+      ]);
+    });
+  });
+
   describe("add task action", () => {
-    it("should update email 0 count state", () => {
+    it("should update task 0 count state", () => {
       const addAction = addTask(0);
       const newState = emibInbox(stubbedInitialState, addAction);
       expect(newState.emailSummaries[0].taskCount).toEqual(1);
       expect(newState.emailSummaries[0].emailCount).toEqual(0);
       expect(newState.emailSummaries[1].taskCount).toEqual(0);
+    });
+
+    it("should add a task action to the action list", () => {
+      const taskAction = {
+        task: "Here are my tasks.",
+        reasonsForAction: "I wanted to say hi."
+      };
+      const addAction = addTask(0, taskAction);
+      const newState = emibInbox(stubbedInitialState, addAction);
+      expect(newState.emailActions[0]).toEqual([{ ...taskAction, actionType: ACTION_TYPE.task }]);
     });
   });
 });


### PR DESCRIPTION
# Description

I implemented the 'Edit Task' functionality the same way @MichaelCherry did in PR https://github.com/code-for-canada/project-thundercat/pull/192.

## Type of change

- New feature (non-breaking change which adds functionality)
- Code cleanliness or refactor

## Screenshot

**Create a Task (1):**

![image](https://user-images.githubusercontent.com/23021242/55962153-5aa4fa80-5c3e-11e9-91d5-448eb48377d4.png)

**Create a Task (2):**

![image](https://user-images.githubusercontent.com/23021242/55962210-6f818e00-5c3e-11e9-850b-434fc11ca2af.png)

**Update Task (1):**

![image](https://user-images.githubusercontent.com/23021242/55962262-87591200-5c3e-11e9-8590-856a8da2706a.png)

**Update Task (2):**

![image](https://user-images.githubusercontent.com/23021242/55962315-9dff6900-5c3e-11e9-8e8a-23e8aabbed41.png)

**Task Updated:**

![image](https://user-images.githubusercontent.com/23021242/55962354-ace61b80-5c3e-11e9-81ac-c850fe4384e7.png)

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB Sample Test.
2.  Complete the _pre-test_ process.
3.  Open _Inbox_ tab.
4.  Create a new Task.
5.  Edit this new Task and make sure everything is working fine and looking good.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
