### PR TITLE
[WIP Delete Task] Delete task functionality

### DIFF
--- a/frontend/src/components/eMIB/ActionViewTask.jsx
+++ b/frontend/src/components/eMIB/ActionViewTask.jsx
@@ -4,6 +4,9 @@ import "../../css/collapsing-item.css";
 import LOCALIZE from "../../text_resources";
 import EditActionDialog from "./EditActionDialog";
 import { ACTION_TYPE, EDIT_MODE, actionShape } from "./constants";
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
+import { deleteTask } from "../../modules/EmibInboxRedux";
 
 const styles = {
   taskStyle: {
@@ -22,7 +25,9 @@ class ActionViewTask extends Component {
     action: actionShape,
     emailSubject: PropTypes.string,
     actionId: PropTypes.number.isRequired,
-    emailId: PropTypes.number.isRequired
+    emailId: PropTypes.number.isRequired,
+    // Props from Redux
+    deleteTask: PropTypes.func
   };
 
   state = {
@@ -59,7 +64,11 @@ class ActionViewTask extends Component {
           >
             {LOCALIZE.emibTest.inboxPage.emailCommons.editButton}
           </button>
-          <button className="btn btn-danger">
+          <button
+            id="unit-test-view-task-delete-button"
+            className="btn btn-danger"
+            onClick={() => this.props.deleteTask(this.props.emailId, this.props.actionId)}
+          >
             {LOCALIZE.emibTest.inboxPage.emailCommons.deleteButton}
           </button>
         </div>
@@ -79,4 +88,16 @@ class ActionViewTask extends Component {
     );
   }
 }
-export default ActionViewTask;
+
+export { ActionViewTask as UnconnectedActionViewTask };
+const mapDispatchToProps = dispatch =>
+  bindActionCreators(
+    {
+      deleteTask
+    },
+    dispatch
+  );
+export default connect(
+  null,
+  mapDispatchToProps
+)(ActionViewTask);

--- a/frontend/src/modules/EmibInboxRedux.js
+++ b/frontend/src/modules/EmibInboxRedux.js
@@ -26,6 +26,7 @@ const ADD_TASK = "emibInbox/ADD_TASK";
 const UPDATE_EMAIL = "emibInbox/UPDATE_EMAIL";
 const UPDATE_TASK = "emibInbox/UPDATE_TASK";
 const DELETE_EMAIL = "emibInbox/DELETE_EMAIL";
+const DELETE_TASK = "emibInbox/DELETE_TASK";
 
 // Action Creators
 const readEmail = emailIndex => ({ type: READ_EMAIL, emailIndex });
@@ -50,6 +51,12 @@ const updateTask = (emailIndex, responseId, taskAction) => ({
 // emailIndex refers to the index of the original parent email and responseId is the id of the response that is being deleted
 const deleteEmail = (emailIndex, responseId) => ({
   type: DELETE_EMAIL,
+  emailIndex,
+  responseId
+});
+// emailIndex refers to the index of the original parent email and responseId is the id of the response that is being deleted
+const deleteTask = (emailIndex, responseId) => ({
+  type: DELETE_TASK,
   emailIndex,
   responseId
 });
@@ -139,6 +146,17 @@ const emibInbox = (state = initialState, action) => {
         emailSummaries: purgedEmailSummaries,
         emailActions: purgedEmailActions
       };
+    case DELETE_TASK:
+      let purifiedEmailSummaries = Array.from(state.emailSummaries);
+      purifiedEmailSummaries[action.emailIndex].taskCount--;
+
+      let purifiedEmailActions = Array.from(state.emailActions);
+      purifiedEmailActions[action.emailIndex].splice(action.responseId, 1);
+      return {
+        ...state,
+        emailSummaries: purifiedEmailSummaries,
+        emailActions: purifiedEmailActions
+      };
     default:
       return state;
   }
@@ -158,5 +176,6 @@ export {
   updateEmail,
   updateTask,
   deleteEmail,
+  deleteTask,
   selectEmailActions
 };

--- a/frontend/src/tests/components/eMIB/ActionViewTask.test.js
+++ b/frontend/src/tests/components/eMIB/ActionViewTask.test.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import LOCALIZE from "../../../text_resources";
-import ActionViewTask from "../../../components/eMIB/ActionViewTask";
+import { UnconnectedActionViewTask } from "../../../components/eMIB/ActionViewTask";
 import { ACTION_TYPE } from "../../../components/eMIB/constants";
 
 const actionStub = {
@@ -11,7 +10,15 @@ const actionStub = {
 };
 
 describe("renders component's content", () => {
-  const wrapper = shallow(<ActionViewTask action={actionStub} actionId={0} emailId={1} />);
+  const deleteMock = jest.fn();
+  const wrapper = shallow(
+    <UnconnectedActionViewTask
+      action={actionStub}
+      actionId={0}
+      emailId={1}
+      deleteTask={deleteMock}
+    />
+  );
 
   it("task content", () => {
     const taskContent = <p>{"Liste of my tasks here..."}</p>;
@@ -21,5 +28,10 @@ describe("renders component's content", () => {
   it("reasons for action content", () => {
     const reasonsForActionContent = <p>{"Reasons for action here..."}</p>;
     expect(wrapper.containsMatchingElement(reasonsForActionContent)).toEqual(true);
+  });
+
+  it("delete button is triggered properly", () => {
+    wrapper.find("#unit-test-view-task-delete-button").simulate("click");
+    expect(deleteMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/tests/modules/EmibInboxRedux.test.js
+++ b/frontend/src/tests/modules/EmibInboxRedux.test.js
@@ -5,6 +5,7 @@ import emibInbox, {
   addTask,
   updateEmail,
   deleteEmail,
+  deleteTask,
   updateTask
 } from "../../modules/EmibInboxRedux";
 import { EMAIL_TYPE, ACTION_TYPE } from "../../components/eMIB/constants";
@@ -227,7 +228,7 @@ describe("EmibInboxRedux", () => {
       ]);
     });
 
-    it("should update 3 task actions one by one", () => {
+    it("should update 3 task actions one by one then delete them all one by one", () => {
       const task1 = {
         task: "Task 1",
         reasonsForAction: "Reason 1"
@@ -295,6 +296,23 @@ describe("EmibInboxRedux", () => {
         { ...task2Update, actionType: ACTION_TYPE.email },
         { ...task3Update, actionType: ACTION_TYPE.email }
       ]);
+      //delete second task
+      const deleteAction1 = deleteTask(0, 1);
+      const newState7 = emibInbox(newState6, deleteAction1);
+      expect(newState7.emailActions[0]).toEqual([
+        { ...task1Update, actionType: ACTION_TYPE.email },
+        { ...task3Update, actionType: ACTION_TYPE.email }
+      ]);
+      //delete first task
+      const deleteAction2 = deleteTask(0, 0);
+      const newState8 = emibInbox(newState7, deleteAction2);
+      expect(newState8.emailActions[0]).toEqual([
+        { ...task3Update, actionType: ACTION_TYPE.email }
+      ]);
+      //delete first task again (originally the third)
+      const deleteAction3 = deleteTask(0, 0);
+      const newState9 = emibInbox(newState8, deleteAction3);
+      expect(newState9.emailActions[0]).toEqual([]);
     });
   });
 


### PR DESCRIPTION
# Description

Added functionality allowing deletion of task responses; very similar to PR #197

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**After adding 3 emails:**
1x

**1st email:**
1x

**2nd email:**
1x
**3rd email:**
1x

**Delete email 2:**
1x

**After deleting 2nd email:**
3x

**Delete email 1:**
1x

**After deleting 1st email:**
2x

**Delete new 1st email (originally 3rd email):**
1x

**After deleting all emails:**
1x

# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Prototype -> Start eMIB -> Instructions Page 5 -> Start Test -> Inbox Tab
2.  Add Task Responses
3.  Delete Task Responses

# Checklist

Applicable for all code changes.

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
- [ ] My changes generate no new compiler warnings
- [ ] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 10+, Firefox, and Chrome
