### PR TITLE
[Bug Fixes] Fixing Email Preview Gap and Keyboard Navigation

### DIFF
--- a/frontend/src/components/eMIB/EmailPreview.jsx
+++ b/frontend/src/components/eMIB/EmailPreview.jsx
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
 import { emailShape } from "./constants";
+import "../../css/inbox.css";
 
 const styles = {
   //buttons
@@ -9,8 +10,9 @@ const styles = {
     width: 202,
     textAlign: "left",
     padding: 8,
-    borderRight: "1px solid #00565E",
-    borderBottom: "1px solid #00565E",
+    borderWidth: "0 1px 1px 0",
+    borderStyle: "solid",
+    borderColor: "#00565E",
     cursor: "pointer",
     fontSize: 14
   },
@@ -111,7 +113,11 @@ class EmailPreview extends Component {
         aria-current={this.props.isSelected ? "page" : ""}
         role="menuitem"
       >
-        <div style={buttonStyle} onClick={() => this.props.selectEmail(email.id)}>
+        <button
+          className="email-preview-button"
+          style={buttonStyle}
+          onClick={() => this.props.selectEmail(email.id)}
+        >
           <div id={this.props.isRead ? "read-email-preview" : "unread-email-preview"}>
             {this.props.isRead ? (
               <i className="far fa-envelope-open" style={imageStyle} />
@@ -127,7 +133,7 @@ class EmailPreview extends Component {
           </div>
           <div style={subject}>{email.subject}</div>
           <div style={styles.truncated}>{email.from}</div>
-        </div>
+        </button>
       </li>
     );
   }

--- a/frontend/src/components/eMIB/EmailPreview.jsx
+++ b/frontend/src/components/eMIB/EmailPreview.jsx
@@ -114,7 +114,7 @@ class EmailPreview extends Component {
         role="menuitem"
       >
         <button
-          className="email-preview-button"
+          className={this.props.isSelected ? "" : "email-preview-button"}
           style={buttonStyle}
           onClick={() => this.props.selectEmail(email.id)}
         >

--- a/frontend/src/components/eMIB/EmibTabs.jsx
+++ b/frontend/src/components/eMIB/EmibTabs.jsx
@@ -23,7 +23,7 @@ const styles = {
   tabNavigation: {
     height: TAB_HEIGHT,
     backgroundColor: "white",
-    borderWidth: "1px 1px 0 1px",
+    borderWidth: "0 1px",
     borderStyle: "solid",
     borderColor: "#00565e",
     borderTopColor: "white"

--- a/frontend/src/css/inbox.css
+++ b/frontend/src/css/inbox.css
@@ -21,9 +21,9 @@ styles that cannot be added inside a const
 }
 
 .email-preview-button:focus {
-  border: 2px solid #009fae !important;
+  background-color: #c6ecef !important;
 }
 
 .email-preview-button:hover {
-  border: 2px solid #009fae !important;
+  background-color: #c6ecef !important;
 }

--- a/frontend/src/css/inbox.css
+++ b/frontend/src/css/inbox.css
@@ -20,6 +20,10 @@ styles that cannot be added inside a const
   grid-column: 2;
 }
 
+/* 
+Need to use !important here to override the background color that is defined inside 'emailPreview.jsx' component. 
+Cannot define this style in the component itself because of the use of 'focus' and 'hover'.
+*/
 .email-preview-button:focus {
   background-color: #c6ecef !important;
 }

--- a/frontend/src/css/inbox.css
+++ b/frontend/src/css/inbox.css
@@ -19,3 +19,11 @@ styles that cannot be added inside a const
   -ms-grid-column: 2;
   grid-column: 2;
 }
+
+.email-preview-button:focus {
+  border: 2px solid #009fae !important;
+}
+
+.email-preview-button:hover {
+  border: 2px solid #009fae !important;
+}


### PR DESCRIPTION
# Description

This changes in this PR are fixing the following bugs:
- Gap at the top of the email preview list
- Email preview keyboard navigation

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

**Gap Bug**
---

**Before:**

![image](https://user-images.githubusercontent.com/23021242/55979997-779ef500-5c61-11e9-97c3-9bb47f24089d.png)

**After:**

![image](https://user-images.githubusercontent.com/23021242/55980052-9a310e00-5c61-11e9-86d7-8d41759382a6.png)

**Keyboard Navigation Bug**
---

**Mouse Over and Keyboard Focus:**

![image](https://user-images.githubusercontent.com/23021242/56231275-13f33e00-604c-11e9-93c3-5ed754bc264c.png)

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB Sample Test.
2.  Complete the _pre-test_ process.
3.  Open the _Inbox_ tab.
4.  Make sure the the gap bug is fixed.
5.  Also, make sure that you are able to navigate in the email preview list using the keyboard and everything look good (mouse over and focus).

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
