### PR TITLE
[Email] Formatting email body

### DIFF
--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -80,6 +80,7 @@ class Email extends Component {
     const emailActions = emailActionsArray[email.id];
     let emailNumber = 0;
     let taskNumber = 0;
+    const bodyArray = email.body.split("\n");
     return (
       <div style={styles.email}>
         <div style={styles.header}>
@@ -133,7 +134,11 @@ class Email extends Component {
           {LOCALIZE.emibTest.inboxPage.date}: {email.date}
         </div>
         <hr style={styles.dataBodyDivider} />
-        <div>{email.body}</div>
+        <div>
+          {bodyArray.map((paragraph, key) => (
+            <p id={key}>{paragraph}</p>
+          ))}
+        </div>
         <div>
           {emailActions.map((action, id) => {
             // populate email responses

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -80,7 +80,10 @@ class Email extends Component {
     const emailActions = emailActionsArray[email.id];
     let emailNumber = 0;
     let taskNumber = 0;
-    const bodyArray = email.body.split("\n");
+    //Split the body on new line characters
+    //This will allow them to be wrapped in <p></p> tags
+    // .filter(Boolean) drops empty elements
+    const bodyArray = email.body.split("\n").filter(Boolean);
     return (
       <div style={styles.email}>
         <div style={styles.header}>
@@ -136,7 +139,7 @@ class Email extends Component {
         <hr style={styles.dataBodyDivider} />
         <div>
           {bodyArray.map((paragraph, key) => (
-            <p id={key}>{paragraph}</p>
+            <p key={key}>{paragraph}</p>
           ))}
         </div>
         <div>

--- a/frontend/src/tests/components/eMIB/Email.test.js
+++ b/frontend/src/tests/components/eMIB/Email.test.js
@@ -96,3 +96,36 @@ describe("shows as many 'CollapsingItemContainer' as there are actions", () => {
     expect(wrapper.find(CollapsingItemContainer).length).toEqual(3);
   });
 });
+
+describe("email body renders the proper number of <p> tags in the body", () => {
+  it("renders only 1 <p> with a short body", () => {
+    testParagraphTags("I am a one line email", 1);
+  });
+
+  it("renders only 2 <p>'s with a single \n body", () => {
+    testParagraphTags("I am a one line\nI am the next", 2);
+  });
+
+  it("renders only 2 <p>'s with a body split by \n\n", () => {
+    testParagraphTags("I am a one line\n\nI am the next", 2);
+  });
+
+  it("renders only 4 <p>'s despite varying  \n's", () => {
+    testParagraphTags("Dear Joe\nHow are you?\n\n\n\n\n\n\nSincerely,\n\nBob", 4);
+  });
+
+  function testParagraphTags(body, expectedCount) {
+    const emailStub = {
+      id: 0,
+      to: "To 1",
+      from: "From 1",
+      subject: "Subject 1",
+      date: "Date 1",
+      body: body
+    };
+    const wrapper = shallow(
+      <Email email={emailStub} emailCount={0} taskCount={2} emailActionsArray={[[]]} />
+    );
+    expect(wrapper.find("p").length).toEqual(expectedCount);
+  }
+});


### PR DESCRIPTION
# Description

Added code to:
- Create array by splitting email body on \n characters
- Iterate over array, wrapping each element in <p> tags

NOTE: this looks the same if the body contains '\n', '\n\n', '\n\n\n', etc.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot
Before:
![image](https://user-images.githubusercontent.com/2746350/56035108-39ecab80-5cf7-11e9-89e4-df38de3a9186.png)
![image](https://user-images.githubusercontent.com/2746350/56035122-45d86d80-5cf7-11e9-9cd8-a82fff53e7c0.png)
![image](https://user-images.githubusercontent.com/2746350/56035134-4d981200-5cf7-11e9-9ee3-a3cca78c875d.png)

After:
![image](https://user-images.githubusercontent.com/2746350/56034904-b206a180-5cf6-11e9-8265-dd9d012f4448.png)
![image](https://user-images.githubusercontent.com/2746350/56035060-19bcec80-5cf7-11e9-8a33-ccf417179956.png)
![image](https://user-images.githubusercontent.com/2746350/56035071-22adbe00-5cf7-11e9-89b9-b053d9b3d8b8.png)

# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Go to Prototype -> Start eMIB -> Pre-test instructions -> Start Test
2.  Open the Inbox tab
3.  See that all the emails are nicely formatted

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
