### PR TITLE
[Bug Fixes] Fixing 'read email' Bugs

### DIFF
--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -7,7 +7,13 @@ import EditEmail from "./EditEmail";
 import EditTask from "./EditTask";
 import { Modal } from "react-bootstrap";
 import { ACTION_TYPE, EDIT_MODE, actionShape } from "./constants";
-import { addEmail, addTask, updateEmail, updateTask } from "../../modules/EmibInboxRedux";
+import {
+  addEmail,
+  addTask,
+  updateEmail,
+  updateTask,
+  readEmail
+} from "../../modules/EmibInboxRedux";
 
 const styles = {
   icon: {
@@ -59,6 +65,7 @@ class EditActionDialog extends Component {
     addTask: PropTypes.func.isRequired,
     updateEmail: PropTypes.func.isRequired,
     updateTask: PropTypes.func.isRequired,
+    readEmail: PropTypes.func.isRequired,
     // Only needed when updating an existing one
     action: actionShape,
     actionId: PropTypes.number
@@ -71,11 +78,13 @@ class EditActionDialog extends Component {
   handleSave = () => {
     if (this.props.actionType === ACTION_TYPE.email && this.props.editMode === EDIT_MODE.create) {
       this.props.addEmail(this.props.emailId, this.state.action);
+      this.props.readEmail(this.props.emailId);
     } else if (
       this.props.actionType === ACTION_TYPE.task &&
       this.props.editMode === EDIT_MODE.create
     ) {
       this.props.addTask(this.props.emailId, this.state.action);
+      this.props.readEmail(this.props.emailId);
     } else if (
       this.props.actionType === ACTION_TYPE.email &&
       this.props.editMode === EDIT_MODE.update
@@ -181,7 +190,8 @@ const mapDispatchToProps = dispatch =>
       addEmail,
       addTask,
       updateEmail,
-      updateTask
+      updateTask,
+      readEmail
     },
     dispatch
   );

--- a/frontend/src/components/eMIB/Inbox.jsx
+++ b/frontend/src/components/eMIB/Inbox.jsx
@@ -41,6 +41,7 @@ class Inbox extends Component {
   changeEmail = index => {
     this.props.readEmail(this.state.currentEmail);
     this.setState({ currentEmail: index });
+    this.props.readEmail(index);
   };
 
   render() {

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -29,6 +29,7 @@ function testCore(actionType, editMode) {
   const addTask = jest.fn();
   const updateEmail = jest.fn();
   const updateTask = jest.fn();
+  const readEmail = jest.fn();
 
   //shallow wrapper of the dialog
   const wrapper = shallow(
@@ -41,7 +42,7 @@ function testCore(actionType, editMode) {
       addTask={addTask}
       updateEmail={updateEmail}
       updateTask={updateTask}
-      readEmail={() => {}}
+      readEmail={readEmail}
       actionType={actionType}
       editMode={editMode}
     />
@@ -88,21 +89,25 @@ function testCore(actionType, editMode) {
     expect(addEmail).toHaveBeenCalledTimes(1);
     expect(updateEmail).toHaveBeenCalledTimes(0);
     expect(updateTask).toHaveBeenCalledTimes(0);
+    expect(readEmail).toHaveBeenCalledTimes(1);
   } else if (actionType === ACTION_TYPE.email && editMode === EDIT_MODE.update) {
     expect(addTask).toHaveBeenCalledTimes(0);
     expect(addEmail).toHaveBeenCalledTimes(0);
     expect(updateEmail).toHaveBeenCalledTimes(1);
     expect(updateTask).toHaveBeenCalledTimes(0);
+    expect(readEmail).toHaveBeenCalledTimes(0);
   } else if (actionType === ACTION_TYPE.task && editMode === EDIT_MODE.create) {
     expect(addTask).toHaveBeenCalledTimes(1);
     expect(addEmail).toHaveBeenCalledTimes(0);
     expect(updateEmail).toHaveBeenCalledTimes(0);
     expect(updateTask).toHaveBeenCalledTimes(0);
+    expect(readEmail).toHaveBeenCalledTimes(1);
   } else if (actionType === ACTION_TYPE.task && editMode === EDIT_MODE.update) {
     expect(addTask).toHaveBeenCalledTimes(0);
     expect(addEmail).toHaveBeenCalledTimes(0);
     expect(updateEmail).toHaveBeenCalledTimes(0);
     expect(updateTask).toHaveBeenCalledTimes(1);
+    expect(readEmail).toHaveBeenCalledTimes(0);
   }
 }
 

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -41,6 +41,7 @@ function testCore(actionType, editMode) {
       addTask={addTask}
       updateEmail={updateEmail}
       updateTask={updateTask}
+      readEmail={() => {}}
       actionType={actionType}
       editMode={editMode}
     />
@@ -145,6 +146,7 @@ function testMode(actionType, editMode) {
       addTask={() => {}}
       updateEmail={() => {}}
       updateTask={() => {}}
+      readEmail={() => {}}
       actionType={actionType}
       editMode={editMode}
       action={{


### PR DESCRIPTION
# Description

This PR fixes two minor bugs related to the _'read email'_ state:
- Mark emails _'as read'_ as soon as we click on them
- Mark emails _'as read'_ when we add action(s), meaning adding an email response and/or a task

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

**Bug 1**
---

**Initial states when you open the Inbox (all emails are marked as unread):*

![image](https://user-images.githubusercontent.com/23021242/56036257-648c3380-5cfa-11e9-80b3-ec9660152f44.png)

**As soon as I select another email (first email and the selected one are marked as read):**

![image](https://user-images.githubusercontent.com/23021242/56036237-50483680-5cfa-11e9-8629-91f49285e0e6.png)

**Bug 2**
---

**Initial states when you open the Inbox (all emails are marked as unread):*

![image](https://user-images.githubusercontent.com/23021242/56036257-648c3380-5cfa-11e9-80b3-ec9660152f44.png)

**Adding an action (email response or task):**

![image](https://user-images.githubusercontent.com/23021242/56036058-dca62980-5cf9-11e9-9b85-562915fb738c.png)

**Result (the first email is now marked as read):**

![image](https://user-images.githubusercontent.com/23021242/56036084-f0519000-5cf9-11e9-898c-444ce0b46f4b.png)

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB Sample Test.
2.  Complete the _pre-test_ process.
3.  Open the _Inbox_ tab.
4.  In the first email, add an action (email response or task) and make sure that the email becomes _'as read'_.
5.  Select another email and make sure it becomes _'as read'_ as soon as you select it.

# Checklist

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 10+, Firefox, and Chrome
