### PR TITLE
[Travis] Updating Travis settings to treat warnings as errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ services:
 
 language: node_js
 
+warnings_are_errors: true
+
 matrix:
   include:
     #Backend Tests

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -144,7 +144,7 @@ function testMode(actionType, editMode) {
       addEmail={() => {}}
       addTask={() => {}}
       updateEmail={() => {}}
-      updateTask={() => {}}
+      // updateTask={() => {}}
       actionType={actionType}
       editMode={editMode}
       action={{

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -144,7 +144,7 @@ function testMode(actionType, editMode) {
       addEmail={() => {}}
       addTask={() => {}}
       updateEmail={() => {}}
-      // updateTask={() => {}}
+      updateTask={() => {}}
       actionType={actionType}
       editMode={editMode}
       action={{


### PR DESCRIPTION
# Description

I updated Travis settings, so it should now fail if there are any warnings **or** errors during the build.

## Type of change

Please delete options that are not relevant.

- Code cleanliness or refactor

## Screenshot

**All tests still passed:**

Backend:
![image](https://user-images.githubusercontent.com/23021242/56128177-f2f7f380-5f4c-11e9-83d0-330a1100da86.png)

Frontend:
![image](https://user-images.githubusercontent.com/23021242/56128206-01460f80-5f4d-11e9-992b-7c2c31dcf4e4.png)


# Testing

Manual steps to reproduce this functionality:

- The only way to test that is to run tests using Travis in a new PR or one of the existing ones.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [ ] ~~My changes look good on IE 10+, Firefox, and Chrome~~
