### PR TITLE
[Bug Fix] Duplicate email bug

### DIFF
--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -72,12 +72,11 @@ class EditActionDialog extends Component {
   };
 
   state = {
-    action: {},
-    isSaving: false
+    action: {}
   };
 
   handleSave = () => {
-    this.setState({ isSaving: true });
+    this.props.handleClose();
     if (this.props.actionType === ACTION_TYPE.email && this.props.editMode === EDIT_MODE.create) {
       this.props.addEmail(this.props.emailId, this.state.action);
       this.props.readEmail(this.props.emailId);
@@ -99,7 +98,6 @@ class EditActionDialog extends Component {
       this.props.updateTask(this.props.emailId, this.props.actionId, this.state.action);
     }
     this.setState({ action: {} });
-    this.props.handleClose();
   };
 
   // updatedAction is the PropType shape actionShape and represents a single action a candidate takes on an email
@@ -171,7 +169,7 @@ class EditActionDialog extends Component {
                     type="button"
                     className="btn btn-primary"
                     onClick={this.handleSave}
-                    disabled={this.state.isSaving}
+                    disabled={!this.props.showDialog}
                   >
                     {LOCALIZE.emibTest.inboxPage.editActionDialog.save}
                   </button>

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -72,11 +72,12 @@ class EditActionDialog extends Component {
   };
 
   state = {
-    action: {}
+    action: {},
+    saveDisabled: false
   };
 
   handleSave = () => {
-    this.refs.emailResponseButton.setAttribute("disabled", "disabled");
+    this.setState({ saveDisabled: true });
     if (this.props.actionType === ACTION_TYPE.email && this.props.editMode === EDIT_MODE.create) {
       this.props.addEmail(this.props.emailId, this.state.action);
       this.props.readEmail(this.props.emailId);
@@ -166,11 +167,11 @@ class EditActionDialog extends Component {
               <div>
                 <div>
                   <button
-                    ref="emailResponseButton"
                     id="unit-test-email-response-button"
                     type="button"
                     className="btn btn-primary"
                     onClick={this.handleSave}
+                    disabled={this.state.saveDisabled}
                   >
                     {LOCALIZE.emibTest.inboxPage.editActionDialog.save}
                   </button>

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -76,6 +76,7 @@ class EditActionDialog extends Component {
   };
 
   handleSave = () => {
+    this.refs.emailResponseButton.setAttribute("disabled", "disabled");
     if (this.props.actionType === ACTION_TYPE.email && this.props.editMode === EDIT_MODE.create) {
       this.props.addEmail(this.props.emailId, this.state.action);
       this.props.readEmail(this.props.emailId);
@@ -165,6 +166,7 @@ class EditActionDialog extends Component {
               <div>
                 <div>
                   <button
+                    ref="emailResponseButton"
                     id="unit-test-email-response-button"
                     type="button"
                     className="btn btn-primary"

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -73,11 +73,11 @@ class EditActionDialog extends Component {
 
   state = {
     action: {},
-    saveDisabled: false
+    isSaving: false
   };
 
   handleSave = () => {
-    this.setState({ saveDisabled: true });
+    this.setState({ isSaving: true });
     if (this.props.actionType === ACTION_TYPE.email && this.props.editMode === EDIT_MODE.create) {
       this.props.addEmail(this.props.emailId, this.state.action);
       this.props.readEmail(this.props.emailId);
@@ -171,7 +171,7 @@ class EditActionDialog extends Component {
                     type="button"
                     className="btn btn-primary"
                     onClick={this.handleSave}
-                    disabled={this.state.saveDisabled}
+                    disabled={this.state.isSaving}
                   >
                     {LOCALIZE.emibTest.inboxPage.editActionDialog.save}
                   </button>

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -229,10 +229,10 @@ it("check that email duplication bug is no longer an issue", () => {
       editMode={EDIT_MODE.create}
     />
   );
-  expect(wrapper.find("#unit-test-email-response-button").prop("disabled")).toEqual(false);
   wrapper.find("#unit-test-email-response-button").simulate("click");
-  expect(wrapper.find("#unit-test-email-response-button").prop("disabled")).toEqual(true);
-  wrapper.find("#unit-test-email-response-button").simulate("click");
-  wrapper.find("#unit-test-email-response-button").simulate("click");
+  // In the test, calling handleClose does not change the showDialog vale
+  // However, in the actual UI, it does; so if this has been called,
+  // The the button is disabled in the UI
+  expect(handleClose).toHaveBeenCalledTimes(1);
   expect(addEmail).toHaveBeenCalledTimes(1);
 });

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -210,3 +210,29 @@ function testMode(actionType, editMode) {
     );
   }
 }
+
+it("check that email duplication bug is no longer an issue", () => {
+  const addEmail = jest.fn();
+  const handleClose = jest.fn();
+  const wrapper = mount(
+    <EditActionDialog
+      emailId={1}
+      emailSubject={"hello team"}
+      showDialog={true}
+      handleClose={handleClose}
+      addEmail={addEmail}
+      addTask={() => {}}
+      updateEmail={() => {}}
+      updateTask={() => {}}
+      readEmail={() => {}}
+      actionType={ACTION_TYPE.email}
+      editMode={EDIT_MODE.create}
+    />
+  );
+  expect(wrapper.find("#unit-test-email-response-button").prop("disabled")).toEqual(false);
+  wrapper.find("#unit-test-email-response-button").simulate("click");
+  expect(wrapper.find("#unit-test-email-response-button").prop("disabled")).toEqual(true);
+  wrapper.find("#unit-test-email-response-button").simulate("click");
+  wrapper.find("#unit-test-email-response-button").simulate("click");
+  expect(addEmail).toHaveBeenCalledTimes(1);
+});

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -211,7 +211,7 @@ function testMode(actionType, editMode) {
   }
 }
 
-it("check that email duplication bug is no longer an issue", () => {
+it("clicking on the button only adds the email once", () => {
   const addEmail = jest.fn();
   const handleClose = jest.fn();
   const wrapper = mount(

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -230,7 +230,7 @@ it("clicking on the button only adds the email once", () => {
     />
   );
   wrapper.find("#unit-test-email-response-button").simulate("click");
-  // In the test, calling handleClose does not change the showDialog vale
+  // In the test, calling handleClose does not change the showDialog value
   // However, in the actual UI, it does; so if this has been called,
   // The the button is disabled in the UI
   expect(handleClose).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
# Description

"Submit response" is now disabled immediately after clicking it so that users cannot accidentally duplicate emails if double clicking.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

Please provide if applicable (browser for `frontend` or any visual way to show a `backend` change).

# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Go to Prototype -> Start eMIB -> Pre-test Instructions -> Start Test"
2.  Add an email or task
3.  Fill out the form
4.  Click "Submit response" rapidly multiple times
5.  See that only one response was submitted
6.  Repeat for editing

# Checklist

Applicable for all code changes.

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
