### PR TITLE
[Bug Fixes] Removed 'mark as read' as soon as we select an email functionality

### DIFF
--- a/frontend/src/components/eMIB/Inbox.jsx
+++ b/frontend/src/components/eMIB/Inbox.jsx
@@ -41,7 +41,6 @@ class Inbox extends Component {
   changeEmail = index => {
     this.props.readEmail(this.state.currentEmail);
     this.setState({ currentEmail: index });
-    this.props.readEmail(index);
   };
 
   render() {


### PR DESCRIPTION
# Description

After discussion, I simply removed the _'mark email as read'_ as soon as we select an email functionality. The emails become _'as read'_ only if you select another email or if you add action(s) on them.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

(N/A)

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB Sample Test.
2.  Complete the _pre-test_ process.
3.  Open the _Inbox_ tab.
4.  Select an email other than the first one and make sure that it still unread.
5.  Add an action (email response or task) and make sure that it becomes _'read'_.

# Checklist

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 10+, Firefox, and Chrome
