### PR TITLE
[Email Reply/Edit] Reply button formatting

### DIFF
--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -34,8 +34,7 @@ const styles = {
       cursor: "pointer"
     },
     radioPadding: {
-      marginBottom: 16,
-      visibility: "hidden"
+      marginBottom: 16
     },
     radioTextUnselected: {
       fontWeight: "normal",
@@ -146,7 +145,7 @@ class EditEmail extends Component {
             <p className="font-weight-bold" style={styles.header.title}>
               {LOCALIZE.emibTest.inboxPage.addEmailResponse.selectResponseType}
             </p>
-            <div style={styles.header.radioButtonZone}>
+            <div style={styles.header.radioButtonZone} className="radio-button-hover">
               <span style={styles.header.responseTypeRadio}>
                 <input
                   id="reply-radio"
@@ -156,6 +155,7 @@ class EditEmail extends Component {
                   onChange={this.onEmailTypeChange}
                   value={EMAIL_TYPE.reply}
                   checked={replyChecked}
+                  className="visually-hidden"
                 />
                 <label
                   htmlFor="reply-radio"
@@ -186,6 +186,7 @@ class EditEmail extends Component {
                   onChange={this.onEmailTypeChange}
                   value={EMAIL_TYPE.replyAll}
                   checked={replyAllChecked}
+                  className="visually-hidden"
                 />
                 <label
                   htmlFor="reply-all-radio"
@@ -216,6 +217,7 @@ class EditEmail extends Component {
                   onChange={this.onEmailTypeChange}
                   value={EMAIL_TYPE.forward}
                   checked={forwardChecked}
+                  className="visually-hidden"
                 />
                 <label
                   htmlFor="forward-radio"

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -147,7 +147,7 @@ class EditEmail extends Component {
               {LOCALIZE.emibTest.inboxPage.addEmailResponse.selectResponseType}
             </p>
             <div style={styles.header.radioButtonZone}>
-              <div style={styles.header.responseTypeRadio}>
+              <span style={styles.header.responseTypeRadio}>
                 <input
                   id="reply-radio"
                   type="radio"
@@ -176,8 +176,8 @@ class EditEmail extends Component {
                   />
                   {LOCALIZE.emibTest.inboxPage.emailCommons.reply}
                 </label>
-              </div>
-              <div style={styles.header.responseTypeRadio}>
+              </span>
+              <span style={styles.header.responseTypeRadio}>
                 <input
                   id="reply-all-radio"
                   type="radio"
@@ -206,8 +206,8 @@ class EditEmail extends Component {
                   />
                   {LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
                 </label>
-              </div>
-              <div style={styles.header.responseTypeRadio}>
+              </span>
+              <span style={styles.header.responseTypeRadio}>
                 <input
                   id="forward-radio"
                   type="radio"
@@ -236,7 +236,7 @@ class EditEmail extends Component {
                   />
                   {LOCALIZE.emibTest.inboxPage.emailCommons.forward}
                 </label>
-              </div>
+              </span>
             </div>
           </div>
           <div>

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -36,7 +36,12 @@ const styles = {
     radioPadding: {
       marginBottom: 16
     },
-    radioText: {
+    radioTextUnselected: {
+      fontWeight: "normal",
+      cursor: "pointer"
+    },
+    radioTextSelected: {
+      fontWeight: "bold",
       textDecoration: "underline",
       cursor: "pointer"
     },
@@ -151,7 +156,14 @@ class EditEmail extends Component {
                   value={EMAIL_TYPE.reply}
                   checked={replyChecked}
                 />
-                <label htmlFor="reply-radio" style={styles.header.radioText}>
+                <label
+                  htmlFor="reply-radio"
+                  style={
+                    replyChecked
+                      ? styles.header.radioTextSelected
+                      : styles.header.radioTextUnselected
+                  }
+                >
                   <i
                     className="fas fa-reply"
                     style={{
@@ -175,7 +187,14 @@ class EditEmail extends Component {
                   value={EMAIL_TYPE.replyAll}
                   checked={replyAllChecked}
                 />
-                <label htmlFor="reply-all-radio" style={styles.header.radioText}>
+                <label
+                  htmlFor="reply-all-radio"
+                  style={
+                    replyAllChecked
+                      ? styles.header.radioTextSelected
+                      : styles.header.radioTextUnselected
+                  }
+                >
                   <i
                     className="fas fa-reply-all"
                     style={{
@@ -199,7 +218,14 @@ class EditEmail extends Component {
                   value={EMAIL_TYPE.forward}
                   checked={forwardChecked}
                 />
-                <label htmlFor="forward-radio" style={styles.header.radioText}>
+                <label
+                  htmlFor="forward-radio"
+                  style={
+                    forwardChecked
+                      ? styles.header.radioTextSelected
+                      : styles.header.radioTextUnselected
+                  }
+                >
                   <i
                     className="fas fa-share-square"
                     style={{

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -11,12 +11,19 @@ const styles = {
   },
   header: {
     responseTypeIcons: {
-      color: "#00565E",
       margin: "0 8px",
       padding: 3,
       border: "1px solid #00565E",
       borderRadius: 4,
       cursor: "pointer"
+    },
+    responseTypeIconsSelected: {
+      backgroundColor: "#00565E",
+      color: "white"
+    },
+    responseTypeIconsUnelected: {
+      backgroundColor: "white",
+      color: "00565E"
     },
     radioButtonZone: {
       marginBottom: 12
@@ -145,7 +152,15 @@ class EditEmail extends Component {
                   checked={replyChecked}
                 />
                 <label htmlFor="reply-radio" style={styles.header.radioText}>
-                  <i className="fas fa-reply" style={styles.header.responseTypeIcons} />
+                  <i
+                    className="fas fa-reply"
+                    style={{
+                      ...styles.header.responseTypeIcons,
+                      ...(replyChecked
+                        ? styles.header.responseTypeIconsSelected
+                        : styles.header.responseTypeIconsUnselected)
+                    }}
+                  />
                   {LOCALIZE.emibTest.inboxPage.emailCommons.reply}
                 </label>
               </div>
@@ -161,7 +176,15 @@ class EditEmail extends Component {
                   checked={replyAllChecked}
                 />
                 <label htmlFor="reply-all-radio" style={styles.header.radioText}>
-                  <i className="fas fa-reply-all" style={styles.header.responseTypeIcons} />
+                  <i
+                    className="fas fa-reply-all"
+                    style={{
+                      ...styles.header.responseTypeIcons,
+                      ...(replyAllChecked
+                        ? styles.header.responseTypeIconsSelected
+                        : styles.header.responseTypeIconsUnselected)
+                    }}
+                  />
                   {LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
                 </label>
               </div>
@@ -177,7 +200,15 @@ class EditEmail extends Component {
                   checked={forwardChecked}
                 />
                 <label htmlFor="forward-radio" style={styles.header.radioText}>
-                  <i className="fas fa-share-square" style={styles.header.responseTypeIcons} />
+                  <i
+                    className="fas fa-share-square"
+                    style={{
+                      ...styles.header.responseTypeIcons,
+                      ...(forwardChecked
+                        ? styles.header.responseTypeIconsSelected
+                        : styles.header.responseTypeIconsUnselected)
+                    }}
+                  />
                   {LOCALIZE.emibTest.inboxPage.emailCommons.forward}
                 </label>
               </div>

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -34,7 +34,9 @@ const styles = {
       cursor: "pointer"
     },
     radioPadding: {
-      marginBottom: 16
+      marginBottom: 16,
+      visibility: "hidden",
+      marginLeft: -20
     },
     radioTextUnselected: {
       fontWeight: "normal",

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -158,7 +158,6 @@ class EditEmail extends Component {
                     value={EMAIL_TYPE.reply}
                     checked={replyChecked}
                     className="visually-hidden"
-                    aria-label={LOCALIZE.emibTest.inboxPage.emailCommons.reply}
                   />
                   <label
                     htmlFor="reply-radio"
@@ -188,7 +187,6 @@ class EditEmail extends Component {
                     value={EMAIL_TYPE.replyAll}
                     checked={replyAllChecked}
                     className="visually-hidden"
-                    aria-label={LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
                   />
                   <label
                     htmlFor="reply-all-radio"
@@ -218,7 +216,6 @@ class EditEmail extends Component {
                     value={EMAIL_TYPE.forward}
                     checked={forwardChecked}
                     className="visually-hidden"
-                    aria-label={LOCALIZE.emibTest.inboxPage.emailCommons.forward}
                   />
                   <label
                     htmlFor="forward-radio"

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -50,6 +50,11 @@ const styles = {
       borderRadius: 4,
       width: "calc(100% - 40px)"
     },
+    title: {
+      fontSize: 16,
+      marginBottom: 12,
+      marginTop: 12
+    },
     titleStyle: {
       float: "left",
       width: 28,
@@ -138,98 +143,103 @@ class EditEmail extends Component {
       <div style={styles.container}>
         <form>
           <div>
-            <p className="font-weight-bold" style={styles.header.title}>
-              {LOCALIZE.emibTest.inboxPage.addEmailResponse.selectResponseType}
-            </p>
-            <div style={styles.header.radioButtonZone} className="radio-button-hover">
-              <span style={styles.header.responseTypeRadio}>
-                <input
-                  id="reply-radio"
-                  type="radio"
-                  name="responseTypeRadio"
-                  style={styles.header.radioPadding}
-                  onChange={this.onEmailTypeChange}
-                  value={EMAIL_TYPE.reply}
-                  checked={replyChecked}
-                  className="visually-hidden"
-                />
-                <label
-                  htmlFor="reply-radio"
-                  style={
-                    replyChecked
-                      ? styles.header.radioTextSelected
-                      : styles.header.radioTextUnselected
-                  }
-                >
-                  <i
-                    className="fas fa-reply"
-                    style={{
-                      ...styles.header.responseTypeIcons,
-                      ...(replyChecked ? styles.header.responseTypeIconsSelected : {})
-                    }}
+            <fieldset>
+              <legend className="font-weight-bold" style={styles.header.title}>
+                {LOCALIZE.emibTest.inboxPage.addEmailResponse.selectResponseType}
+              </legend>
+              <div style={styles.header.radioButtonZone} className="radio-button-hover">
+                <span style={styles.header.responseTypeRadio}>
+                  <input
+                    id="reply-radio"
+                    type="radio"
+                    name="responseTypeRadio"
+                    style={styles.header.radioPadding}
+                    onChange={this.onEmailTypeChange}
+                    value={EMAIL_TYPE.reply}
+                    checked={replyChecked}
+                    className="visually-hidden"
+                    aria-label={LOCALIZE.emibTest.inboxPage.emailCommons.reply}
                   />
-                  {LOCALIZE.emibTest.inboxPage.emailCommons.reply}
-                </label>
-              </span>
-              <span style={styles.header.responseTypeRadio}>
-                <input
-                  id="reply-all-radio"
-                  type="radio"
-                  name="responseTypeRadio"
-                  style={styles.header.radioPadding}
-                  onChange={this.onEmailTypeChange}
-                  value={EMAIL_TYPE.replyAll}
-                  checked={replyAllChecked}
-                  className="visually-hidden"
-                />
-                <label
-                  htmlFor="reply-all-radio"
-                  style={
-                    replyAllChecked
-                      ? styles.header.radioTextSelected
-                      : styles.header.radioTextUnselected
-                  }
-                >
-                  <i
-                    className="fas fa-reply-all"
-                    style={{
-                      ...styles.header.responseTypeIcons,
-                      ...(replyAllChecked ? styles.header.responseTypeIconsSelected : {})
-                    }}
+                  <label
+                    htmlFor="reply-radio"
+                    style={
+                      replyChecked
+                        ? styles.header.radioTextSelected
+                        : styles.header.radioTextUnselected
+                    }
+                  >
+                    <i
+                      className="fas fa-reply"
+                      style={{
+                        ...styles.header.responseTypeIcons,
+                        ...(replyChecked ? styles.header.responseTypeIconsSelected : {})
+                      }}
+                    />
+                    {LOCALIZE.emibTest.inboxPage.emailCommons.reply}
+                  </label>
+                </span>
+                <span style={styles.header.responseTypeRadio}>
+                  <input
+                    id="reply-all-radio"
+                    type="radio"
+                    name="responseTypeRadio"
+                    style={styles.header.radioPadding}
+                    onChange={this.onEmailTypeChange}
+                    value={EMAIL_TYPE.replyAll}
+                    checked={replyAllChecked}
+                    className="visually-hidden"
+                    aria-label={LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
                   />
-                  {LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
-                </label>
-              </span>
-              <span style={styles.header.responseTypeRadio}>
-                <input
-                  id="forward-radio"
-                  type="radio"
-                  name="responseTypeRadio"
-                  style={styles.header.radioPadding}
-                  onChange={this.onEmailTypeChange}
-                  value={EMAIL_TYPE.forward}
-                  checked={forwardChecked}
-                  className="visually-hidden"
-                />
-                <label
-                  htmlFor="forward-radio"
-                  style={
-                    forwardChecked
-                      ? styles.header.radioTextSelected
-                      : styles.header.radioTextUnselected
-                  }
-                >
-                  <i
-                    className="fas fa-share-square"
-                    style={{
-                      ...styles.header.responseTypeIcons,
-                      ...(forwardChecked ? styles.header.responseTypeIconsSelected : {})
-                    }}
+                  <label
+                    htmlFor="reply-all-radio"
+                    style={
+                      replyAllChecked
+                        ? styles.header.radioTextSelected
+                        : styles.header.radioTextUnselected
+                    }
+                  >
+                    <i
+                      className="fas fa-reply-all"
+                      style={{
+                        ...styles.header.responseTypeIcons,
+                        ...(replyAllChecked ? styles.header.responseTypeIconsSelected : {})
+                      }}
+                    />
+                    {LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
+                  </label>
+                </span>
+                <span style={styles.header.responseTypeRadio}>
+                  <input
+                    id="forward-radio"
+                    type="radio"
+                    name="responseTypeRadio"
+                    style={styles.header.radioPadding}
+                    onChange={this.onEmailTypeChange}
+                    value={EMAIL_TYPE.forward}
+                    checked={forwardChecked}
+                    className="visually-hidden"
+                    aria-label={LOCALIZE.emibTest.inboxPage.emailCommons.forward}
                   />
-                  {LOCALIZE.emibTest.inboxPage.emailCommons.forward}
-                </label>
-              </span>
-            </div>
+                  <label
+                    htmlFor="forward-radio"
+                    style={
+                      forwardChecked
+                        ? styles.header.radioTextSelected
+                        : styles.header.radioTextUnselected
+                    }
+                  >
+                    <i
+                      className="fas fa-share-square"
+                      style={{
+                        ...styles.header.responseTypeIcons,
+                        ...(forwardChecked ? styles.header.responseTypeIconsSelected : {})
+                      }}
+                    />
+                    {LOCALIZE.emibTest.inboxPage.emailCommons.forward}
+                  </label>
+                </span>
+              </div>
+            </fieldset>
           </div>
           <div>
             <div className="font-weight-bold form-group">

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -21,10 +21,6 @@ const styles = {
       backgroundColor: "#00565E",
       color: "white"
     },
-    responseTypeIconsUnelected: {
-      backgroundColor: "white",
-      color: "00565E"
-    },
     radioButtonZone: {
       marginBottom: 12
     },
@@ -169,9 +165,7 @@ class EditEmail extends Component {
                     className="fas fa-reply"
                     style={{
                       ...styles.header.responseTypeIcons,
-                      ...(replyChecked
-                        ? styles.header.responseTypeIconsSelected
-                        : styles.header.responseTypeIconsUnselected)
+                      ...(replyChecked ? styles.header.responseTypeIconsSelected : {})
                     }}
                   />
                   {LOCALIZE.emibTest.inboxPage.emailCommons.reply}
@@ -200,9 +194,7 @@ class EditEmail extends Component {
                     className="fas fa-reply-all"
                     style={{
                       ...styles.header.responseTypeIcons,
-                      ...(replyAllChecked
-                        ? styles.header.responseTypeIconsSelected
-                        : styles.header.responseTypeIconsUnselected)
+                      ...(replyAllChecked ? styles.header.responseTypeIconsSelected : {})
                     }}
                   />
                   {LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
@@ -231,9 +223,7 @@ class EditEmail extends Component {
                     className="fas fa-share-square"
                     style={{
                       ...styles.header.responseTypeIcons,
-                      ...(forwardChecked
-                        ? styles.header.responseTypeIconsSelected
-                        : styles.header.responseTypeIconsUnselected)
+                      ...(forwardChecked ? styles.header.responseTypeIconsSelected : {})
                     }}
                   />
                   {LOCALIZE.emibTest.inboxPage.emailCommons.forward}

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -35,8 +35,7 @@ const styles = {
     },
     radioPadding: {
       marginBottom: 16,
-      visibility: "hidden",
-      marginLeft: -20
+      visibility: "hidden"
     },
     radioTextUnselected: {
       fontWeight: "normal",
@@ -178,7 +177,6 @@ class EditEmail extends Component {
                   {LOCALIZE.emibTest.inboxPage.emailCommons.reply}
                 </label>
               </div>
-              <br />
               <div style={styles.header.responseTypeRadio}>
                 <input
                   id="reply-all-radio"
@@ -209,7 +207,6 @@ class EditEmail extends Component {
                   {LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
                 </label>
               </div>
-              <br />
               <div style={styles.header.responseTypeRadio}>
                 <input
                   id="forward-radio"

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -122,6 +122,9 @@ class EditEmail extends Component {
 
   render() {
     const { emailType, emailTo, emailCc, emailBody, reasonsForAction } = this.state;
+    const replyChecked = emailType === EMAIL_TYPE.reply;
+    const replyAllChecked = emailType === EMAIL_TYPE.replyAll;
+    const forwardChecked = emailType === EMAIL_TYPE.forward;
 
     return (
       <div style={styles.container}>
@@ -139,7 +142,7 @@ class EditEmail extends Component {
                   style={styles.header.radioPadding}
                   onChange={this.onEmailTypeChange}
                   value={EMAIL_TYPE.reply}
-                  checked={emailType === EMAIL_TYPE.reply}
+                  checked={replyChecked}
                 />
                 <label htmlFor="reply-radio" style={styles.header.radioText}>
                   <i className="fas fa-reply" style={styles.header.responseTypeIcons} />
@@ -155,7 +158,7 @@ class EditEmail extends Component {
                   style={styles.header.radioPadding}
                   onChange={this.onEmailTypeChange}
                   value={EMAIL_TYPE.replyAll}
-                  checked={emailType === EMAIL_TYPE.replyAll}
+                  checked={replyAllChecked}
                 />
                 <label htmlFor="reply-all-radio" style={styles.header.radioText}>
                   <i className="fas fa-reply-all" style={styles.header.responseTypeIcons} />
@@ -171,7 +174,7 @@ class EditEmail extends Component {
                   style={styles.header.radioPadding}
                   onChange={this.onEmailTypeChange}
                   value={EMAIL_TYPE.forward}
-                  checked={emailType === EMAIL_TYPE.forward}
+                  checked={forwardChecked}
                 />
                 <label htmlFor="forward-radio" style={styles.header.radioText}>
                   <i className="fas fa-share-square" style={styles.header.responseTypeIcons} />

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -129,10 +129,10 @@ class EditEmail extends Component {
   };
 
   render() {
-    const { emailType, emailTo, emailCc, emailBody, reasonsForAction } = this.state;
-    const replyChecked = emailType === EMAIL_TYPE.reply;
-    const replyAllChecked = emailType === EMAIL_TYPE.replyAll;
-    const forwardChecked = emailType === EMAIL_TYPE.forward;
+    const { emailTo, emailCc, emailBody, reasonsForAction } = this.state;
+    const replyChecked = this.state.emailType === EMAIL_TYPE.reply;
+    const replyAllChecked = this.state.emailType === EMAIL_TYPE.replyAll;
+    const forwardChecked = this.state.emailType === EMAIL_TYPE.forward;
 
     return (
       <div style={styles.container}>

--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -209,3 +209,11 @@ Progess Steps
   clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
   clip: rect(1px, 1px, 1px, 1px);
 }
+
+.radio-button-hover {
+  border: 1px solid transparent;
+}
+
+.radio-button-hover:focus-within {
+  border: 1px solid #00565e;
+}

--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -198,3 +198,14 @@ Progess Steps
   min-width: 500px !important;
   max-width: 750px !important;
 }
+
+/* visually hidden, but stil accessible */
+.visually-hidden {
+  /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+  clip: rect(1px, 1px, 1px, 1px);
+}

--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -202,7 +202,7 @@ Progess Steps
 /* visually hidden, but stil accessible */
 .visually-hidden {
   /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
-  position: absolute !important;
+  position: absolute;
   height: 1px;
   width: 1px;
   overflow: hidden;


### PR DESCRIPTION
# Description

Changed formatting of the reply buttons to more closely match the style shown in the design docs.

NOTE1: IE does not recognize ":focus-within", (but most other browsers support it) so it does not get the outline when one of the radio buttons has focus:
![image](https://user-images.githubusercontent.com/2746350/56150338-b04e0f80-5f7c-11e9-80af-a954d3b25958.png)


NOTE2: There is a minor glitch where there is no email type if you submit a response without making changes. This already exists on master and is not introduced by this PR. See https://trello.com/c/BLrOPCJC/48-bug-fix-reply-not-defaulting

## Type of change

- Code cleanliness or refactor

## Screenshot

### Before:
#### Reply:
![image](https://user-images.githubusercontent.com/2746350/56143447-8db4fa00-5f6e-11e9-82c5-fbb32ee8eaed.png)

#### Reply all:
![image](https://user-images.githubusercontent.com/2746350/56143456-94437180-5f6e-11e9-9256-db231736eedc.png)

#### Forward:
![image](https://user-images.githubusercontent.com/2746350/56143476-9c9bac80-5f6e-11e9-9791-312574cdce92.png)

### After
#### Without focus:
![image](https://user-images.githubusercontent.com/2746350/56150151-2ef67d00-5f7c-11e9-9ce1-21ab5d569d3c.png)

#### Reply, with focus:
![image](https://user-images.githubusercontent.com/2746350/56150163-403f8980-5f7c-11e9-84a2-77bc7054b591.png)

#### Reply all, with focus:
![image](https://user-images.githubusercontent.com/2746350/56150178-4897c480-5f7c-11e9-8312-c6c3840621ba.png)

#### Forward, with focus:
![image](https://user-images.githubusercontent.com/2746350/56150187-52212c80-5f7c-11e9-8219-c5e881dff786.png)

# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Start the eMIB test (Start eMIB -> Pre-test -> Start Test)
2.  Switch to the Inbox tab
3.  "Add email response"
4..  Verify that the buttons look as expected and change as expected

# Checklist

Applicable for all code changes.

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
