### PR TITLE
[Delete Response Confirmation] Added delete confirmation popup for email response and task

### DIFF
--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -7,7 +7,7 @@ import { ACTION_TYPE, EDIT_MODE, EMAIL_TYPE, actionShape } from "./constants";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { deleteEmail } from "../../modules/EmibInboxRedux";
-import PopupBox, { BUTTON_TYPE, BUTTON_STATE } from "../commons/PopupBox";
+import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
 import SystemMessage, { MESSAGE_TYPE } from "../commons/SystemMessage";
 
 const styles = {
@@ -160,25 +160,22 @@ class ActionViewEmail extends Component {
           <PopupBox
             show={this.state.showDeleteConfirmationDialog}
             handleClose={this.closeDeleteConfirmationDialog}
-            title={LOCALIZE.emibTest.inboxPage.emailResponse.deleteConfirmation.title}
+            title={LOCALIZE.emibTest.inboxPage.deleteResponseConfirmation.title}
             description={
               <div>
                 <div>
                   <SystemMessage
                     messageType={MESSAGE_TYPE.error}
                     title={
-                      LOCALIZE.emibTest.inboxPage.emailResponse.deleteConfirmation
-                        .systemMessageTitle
+                      LOCALIZE.emibTest.inboxPage.deleteResponseConfirmation.systemMessageTitle
                     }
                     message={
-                      LOCALIZE.emibTest.inboxPage.emailResponse.deleteConfirmation
+                      LOCALIZE.emibTest.inboxPage.deleteResponseConfirmation
                         .systemMessageDescription
                     }
                   />
                 </div>
-                <div>
-                  {LOCALIZE.emibTest.inboxPage.emailResponse.deleteConfirmation.description}
-                </div>
+                <div>{LOCALIZE.emibTest.inboxPage.deleteResponseConfirmation.description}</div>
               </div>
             }
             leftButtonType={BUTTON_TYPE.danger}

--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -7,6 +7,8 @@ import { ACTION_TYPE, EDIT_MODE, EMAIL_TYPE, actionShape } from "./constants";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { deleteEmail } from "../../modules/EmibInboxRedux";
+import PopupBox, { BUTTON_TYPE, BUTTON_STATE } from "../commons/PopupBox";
+import SystemMessage, { MESSAGE_TYPE } from "../commons/SystemMessage";
 
 const styles = {
   responseType: {
@@ -62,7 +64,8 @@ class ActionViewEmail extends Component {
   };
 
   state = {
-    showEmailDialog: false
+    showEmailDialog: false,
+    showDeleteConfirmationDialog: false
   };
 
   showEmailDialog = () => {
@@ -71,6 +74,14 @@ class ActionViewEmail extends Component {
 
   closeEmailDialog = () => {
     this.setState({ showEmailDialog: false });
+  };
+
+  showDeleteConfirmationDialog = () => {
+    this.setState({ showDeleteConfirmationDialog: true });
+  };
+
+  closeDeleteConfirmationDialog = () => {
+    this.setState({ showDeleteConfirmationDialog: false });
   };
 
   render() {
@@ -142,10 +153,32 @@ class ActionViewEmail extends Component {
           <button
             id="unit-test-view-email-delete-button"
             className="btn btn-danger"
-            onClick={() => this.props.deleteEmail(this.props.emailId, this.props.actionId)}
+            onClick={this.showDeleteConfirmationDialog}
           >
             {LOCALIZE.emibTest.inboxPage.emailCommons.deleteButton}
           </button>
+          <PopupBox
+            show={this.state.showDeleteConfirmationDialog}
+            handleClose={this.closeDeleteConfirmationDialog}
+            title={"Title Here"}
+            description={
+              <div>
+                <div>
+                  <SystemMessage
+                    messageType={MESSAGE_TYPE.error}
+                    title={"Warning"}
+                    message={"Message Here..."}
+                  />
+                </div>
+                <div>{"Description here..."}</div>
+              </div>
+            }
+            leftButtonType={BUTTON_TYPE.danger}
+            leftButtonTitle={"Delete Response"}
+            leftButtonAction={() => this.props.deleteEmail(this.props.emailId, this.props.actionId)}
+            rightButtonType={BUTTON_TYPE.secondary}
+            rightButtonTitle={"Return to Test"}
+          />
         </div>
         <EditActionDialog
           emailId={this.props.emailId}

--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -160,24 +160,32 @@ class ActionViewEmail extends Component {
           <PopupBox
             show={this.state.showDeleteConfirmationDialog}
             handleClose={this.closeDeleteConfirmationDialog}
-            title={"Title Here"}
+            title={LOCALIZE.emibTest.inboxPage.emailResponse.deleteConfirmation.title}
             description={
               <div>
                 <div>
                   <SystemMessage
                     messageType={MESSAGE_TYPE.error}
-                    title={"Warning"}
-                    message={"Message Here..."}
+                    title={
+                      LOCALIZE.emibTest.inboxPage.emailResponse.deleteConfirmation
+                        .systemMessageTitle
+                    }
+                    message={
+                      LOCALIZE.emibTest.inboxPage.emailResponse.deleteConfirmation
+                        .systemMessageDescription
+                    }
                   />
                 </div>
-                <div>{"Description here..."}</div>
+                <div>
+                  {LOCALIZE.emibTest.inboxPage.emailResponse.deleteConfirmation.description}
+                </div>
               </div>
             }
             leftButtonType={BUTTON_TYPE.danger}
-            leftButtonTitle={"Delete Response"}
+            leftButtonTitle={LOCALIZE.emibTest.inboxPage.emailCommons.deleteButton}
             leftButtonAction={() => this.props.deleteEmail(this.props.emailId, this.props.actionId)}
-            rightButtonType={BUTTON_TYPE.secondary}
-            rightButtonTitle={"Return to Test"}
+            rightButtonType={BUTTON_TYPE.primary}
+            rightButtonTitle={LOCALIZE.commons.returnToTest}
           />
         </div>
         <EditActionDialog

--- a/frontend/src/components/eMIB/ActionViewTask.jsx
+++ b/frontend/src/components/eMIB/ActionViewTask.jsx
@@ -7,6 +7,8 @@ import { ACTION_TYPE, EDIT_MODE, actionShape } from "./constants";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { deleteTask } from "../../modules/EmibInboxRedux";
+import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
+import SystemMessage, { MESSAGE_TYPE } from "../commons/SystemMessage";
 
 const styles = {
   taskStyle: {
@@ -31,7 +33,8 @@ class ActionViewTask extends Component {
   };
 
   state = {
-    showTaskDialog: false
+    showTaskDialog: false,
+    showDeleteConfirmationDialog: false
   };
 
   showTaskDialog = () => {
@@ -40,6 +43,14 @@ class ActionViewTask extends Component {
 
   closeTaskDialog = () => {
     this.setState({ showTaskDialog: false });
+  };
+
+  showDeleteConfirmationDialog = () => {
+    this.setState({ showDeleteConfirmationDialog: true });
+  };
+
+  closeDeleteConfirmationDialog = () => {
+    this.setState({ showDeleteConfirmationDialog: false });
   };
 
   render() {
@@ -67,10 +78,37 @@ class ActionViewTask extends Component {
           <button
             id="unit-test-view-task-delete-button"
             className="btn btn-danger"
-            onClick={() => this.props.deleteTask(this.props.emailId, this.props.actionId)}
+            onClick={this.showDeleteConfirmationDialog}
           >
             {LOCALIZE.emibTest.inboxPage.emailCommons.deleteButton}
           </button>
+          <PopupBox
+            show={this.state.showDeleteConfirmationDialog}
+            handleClose={this.closeDeleteConfirmationDialog}
+            title={LOCALIZE.emibTest.inboxPage.deleteResponseConfirmation.title}
+            description={
+              <div>
+                <div>
+                  <SystemMessage
+                    messageType={MESSAGE_TYPE.error}
+                    title={
+                      LOCALIZE.emibTest.inboxPage.deleteResponseConfirmation.systemMessageTitle
+                    }
+                    message={
+                      LOCALIZE.emibTest.inboxPage.deleteResponseConfirmation
+                        .systemMessageDescription
+                    }
+                  />
+                </div>
+                <div>{LOCALIZE.emibTest.inboxPage.deleteResponseConfirmation.description}</div>
+              </div>
+            }
+            leftButtonType={BUTTON_TYPE.danger}
+            leftButtonTitle={LOCALIZE.emibTest.inboxPage.emailCommons.deleteButton}
+            leftButtonAction={() => this.props.deleteTask(this.props.emailId, this.props.actionId)}
+            rightButtonType={BUTTON_TYPE.primary}
+            rightButtonTitle={LOCALIZE.commons.returnToTest}
+          />
         </div>
         <div>
           <EditActionDialog

--- a/frontend/src/tests/components/eMIB/ActionViewEmail.test.js
+++ b/frontend/src/tests/components/eMIB/ActionViewEmail.test.js
@@ -49,13 +49,6 @@ describe("Email header", () => {
   });
 });
 
-it("check that delete button calls deleteEmail prop", () => {
-  const deleteMock = jest.fn();
-  const wrapper = genWrapper(EMAIL_TYPE.reply, null, deleteMock);
-  wrapper.find("#unit-test-view-email-delete-button").simulate("click");
-  expect(deleteMock).toHaveBeenCalledTimes(1);
-});
-
 function genWrapper(responseType, cc) {
   genWrapper(responseType, cc, () => {});
 }

--- a/frontend/src/tests/components/eMIB/ActionViewTask.test.js
+++ b/frontend/src/tests/components/eMIB/ActionViewTask.test.js
@@ -29,9 +29,4 @@ describe("renders component's content", () => {
     const reasonsForActionContent = <p>{"Reasons for action here..."}</p>;
     expect(wrapper.containsMatchingElement(reasonsForActionContent)).toEqual(true);
   });
-
-  it("delete button is triggered properly", () => {
-    wrapper.find("#unit-test-view-task-delete-button").simulate("click");
-    expect(deleteMock).toHaveBeenCalledTimes(1);
-  });
 });

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -359,15 +359,7 @@ let LOCALIZE = new LocalizedStrings({
         emailResponse: {
           description: "For this response, you've chosen to:",
           response: "Your response:",
-          reasonsForAction: "Your reasons for action:",
-          deleteConfirmation: {
-            title: "Are you sure you want to delete this response?",
-            systemMessageTitle: "Warning!",
-            systemMessageDescription:
-              "This reply will be removed from your test responses. You will not be able to recover your response or reasons for action.",
-            description:
-              'If you are certain that you want to delete your response, click the "Delete response" button.'
-          }
+          reasonsForAction: "Your reasons for action:"
         },
         addEmailTask: {
           header: "Email ID #{0}: {1}",
@@ -377,6 +369,14 @@ let LOCALIZE = new LocalizedStrings({
         taskContent: {
           task: "Your task(s):",
           reasonsForAction: "Your reasons for action:"
+        },
+        deleteResponseConfirmation: {
+          title: "Are you sure you want to delete this response?",
+          systemMessageTitle: "Warning!",
+          systemMessageDescription:
+            "This reply will be removed from your test responses. You will not be able to recover your response or reasons for action.",
+          description:
+            'If you are certain that you want to delete your response, click the "Delete response" button.'
         }
       },
 
@@ -839,15 +839,7 @@ let LOCALIZE = new LocalizedStrings({
         emailResponse: {
           description: "FR For this response, you've chosen to:",
           response: "FR Your response:",
-          reasonsForAction: "FR Your reasons for action:",
-          deleteConfirmation: {
-            title: "FR Are you sure you want to delete this response?",
-            systemMessageTitle: "Avertissement!",
-            systemMessageDescription:
-              "FR This reply will be removed from your test responses. You will not be able to recover your response or reasons for action.",
-            description:
-              'FR If you are certain that you want to delete your response, click the "Delete response" button.'
-          }
+          reasonsForAction: "FR Your reasons for action:"
         },
         addEmailTask: {
           header: "FR Email ID #{0}: {1}",
@@ -857,6 +849,14 @@ let LOCALIZE = new LocalizedStrings({
         taskContent: {
           task: "FR Your task(s):",
           reasonsForAction: "FR Your reasons for action:"
+        },
+        deleteResponseConfirmation: {
+          title: "FR Are you sure you want to delete this response?",
+          systemMessageTitle: "Avertissement!",
+          systemMessageDescription:
+            "FR This reply will be removed from your test responses. You will not be able to recover your response or reasons for action.",
+          description:
+            'FR If you are certain that you want to delete your response, click the "Delete response" button.'
         }
       },
 

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -359,7 +359,15 @@ let LOCALIZE = new LocalizedStrings({
         emailResponse: {
           description: "For this response, you've chosen to:",
           response: "Your response:",
-          reasonsForAction: "Your reasons for action:"
+          reasonsForAction: "Your reasons for action:",
+          deleteConfirmation: {
+            title: "Are you sure you want to delete this response?",
+            systemMessageTitle: "Warning!",
+            systemMessageDescription:
+              "This reply will be removed from your test responses. You will not be able to recover your response or reasons for action.",
+            description:
+              'If you are certain that you want to delete your response, click the "Delete response" button.'
+          }
         },
         addEmailTask: {
           header: "Email ID #{0}: {1}",
@@ -831,7 +839,15 @@ let LOCALIZE = new LocalizedStrings({
         emailResponse: {
           description: "FR For this response, you've chosen to:",
           response: "FR Your response:",
-          reasonsForAction: "FR Your reasons for action:"
+          reasonsForAction: "FR Your reasons for action:",
+          deleteConfirmation: {
+            title: "FR Are you sure you want to delete this response?",
+            systemMessageTitle: "Avertissement!",
+            systemMessageDescription:
+              "FR This reply will be removed from your test responses. You will not be able to recover your response or reasons for action.",
+            description:
+              'FR If you are certain that you want to delete your response, click the "Delete response" button.'
+          }
         },
         addEmailTask: {
           header: "FR Email ID #{0}: {1}",


### PR DESCRIPTION
# Description

I used the _PopupBox.jsx_ and _SystemMessage.jsx_ components to create a delete confirmation dialog when you want to delete an email response and / or a task.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**Email Response Delete Confirmation:**

![image](https://user-images.githubusercontent.com/23021242/56207209-2eadbe80-601c-11e9-9c0c-891eeeb6e91d.png)

![image](https://user-images.githubusercontent.com/23021242/56207239-3cfbda80-601c-11e9-9d3b-767a679444ba.png)

**Task Delete Confirmation:**

![image](https://user-images.githubusercontent.com/23021242/56207276-543ac800-601c-11e9-9e4f-c9592051fd52.png)

![image](https://user-images.githubusercontent.com/23021242/56207290-5c930300-601c-11e9-86d5-478d292ddf81.png)

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB Sample Test.
2.  Complete the _pre-test_ process.
3.  Open the _Inbox_ tab.
4.  Add an email response and a task.
5.  Try to delete both of them and make sure that the popup dialog is looking good and working well, meaning that it does what it is supposed to do.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 10+, Firefox, and Chrome
