### PR TITLE
[Inbox] Adding visible text counter to EditEmail/Task dialog

### DIFF
--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -78,9 +78,7 @@ const styles = {
   },
   textCounter: {
     width: "100%",
-    textAlign: "right",
-    marginTop: -40,
-    paddingRight: 20
+    textAlign: "right"
   },
   hr: {
     margin: "12px 0 6px 0"

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -3,6 +3,10 @@ import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
 import { EMAIL_TYPE, actionShape } from "./constants";
 
+// These two consts limit the number of characters
+// that can be entered into two text areas
+// and are used to display <x>/<MAX>
+// under the text areas
 const MAX_RESPONSE = "500";
 const MAX_REASON = "100";
 

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -78,7 +78,9 @@ const styles = {
   },
   textCounter: {
     width: "100%",
-    textAlign: "right"
+    textAlign: "right",
+    marginTop: -40,
+    paddingRight: 20
   },
   hr: {
     margin: "12px 0 6px 0"

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -76,6 +76,10 @@ const styles = {
       resize: "none"
     }
   },
+  textCounter: {
+    width: "100%",
+    textAlign: "right"
+  },
   hr: {
     margin: "12px 0 6px 0"
   },
@@ -287,9 +291,9 @@ class EditEmail extends Component {
                 value={emailBody}
                 onChange={this.onEmailBodyChange}
               />
-            </div>
-            <div>
-              {this.state.emailBody.length}/{MAX_RESPONSE}
+              <div style={styles.textCounter}>
+                {this.state.emailBody.length}/{MAX_RESPONSE}
+              </div>
             </div>
           </div>
           <hr style={styles.hr} />
@@ -305,9 +309,9 @@ class EditEmail extends Component {
                 value={reasonsForAction}
                 onChange={this.onReasonsForActionChange}
               />
-            </div>
-            <div>
-              {this.state.reasonsForAction.length}/{MAX_REASON}
+              <div style={styles.textCounter}>
+                {this.state.reasonsForAction.length}/{MAX_REASON}
+              </div>
             </div>
           </div>
         </form>

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -3,6 +3,9 @@ import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
 import { EMAIL_TYPE, actionShape } from "./constants";
 
+const MAX_RESPONSE = "500";
+const MAX_REASON = "100";
+
 const styles = {
   container: {
     maxHeight: "calc(100vh - 300px)",
@@ -279,11 +282,14 @@ class EditEmail extends Component {
               </label>
               <textarea
                 id="your-response-text-area"
-                maxLength="500"
+                maxLength={MAX_RESPONSE}
                 style={styles.response.textArea}
                 value={emailBody}
                 onChange={this.onEmailBodyChange}
               />
+            </div>
+            <div>
+              {this.state.emailBody.length}/{MAX_RESPONSE}
             </div>
           </div>
           <hr style={styles.hr} />
@@ -294,11 +300,14 @@ class EditEmail extends Component {
               </label>
               <textarea
                 id="reasons-for-action-text-area"
-                maxLength="100"
+                maxLength={MAX_REASON}
                 style={styles.reasonsForAction.textArea}
                 value={reasonsForAction}
                 onChange={this.onReasonsForActionChange}
               />
+            </div>
+            <div>
+              {this.state.reasonsForAction.length}/{MAX_REASON}
             </div>
           </div>
         </form>

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -3,6 +3,9 @@ import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
 import { actionShape } from "./constants";
 
+const MAX_TASK = "100";
+const MAX_REASON = "100";
+
 const styles = {
   container: {
     maxHeight: "calc(100vh - 300px)",
@@ -114,11 +117,14 @@ class EditTask extends Component {
               <i className="fas fa-question-circle" style={styles.tasks.icon} />
               <textarea
                 id="your-tasks-text-area"
-                maxLength="100"
+                maxLength={MAX_TASK}
                 style={styles.tasks.textArea}
                 value={task}
                 onChange={this.onTaskContentChange}
               />
+            </div>
+            <div>
+              {this.state.task.length}/{MAX_TASK}
             </div>
           </div>
           <div>
@@ -129,11 +135,14 @@ class EditTask extends Component {
               <i className="fas fa-question-circle" style={styles.reasonsForAction.icon} />
               <textarea
                 id="reasons-for-action-text-area"
-                maxLength="100"
+                maxLength={MAX_REASON}
                 style={styles.reasonsForAction.textArea}
                 value={reasonsForAction}
                 onChange={this.onReasonsForActionChange}
               />
+            </div>
+            <div>
+              {this.state.reasonsForAction.length}/{MAX_REASON}
             </div>
           </div>
         </form>

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -3,6 +3,10 @@ import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
 import { actionShape } from "./constants";
 
+// These two consts limit the number of characters
+// that can be entered into two text areas
+// and are used to display <x>/<MAX>
+// under the text areas
 const MAX_TASK = "100";
 const MAX_REASON = "100";
 

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -16,6 +16,10 @@ const styles = {
     color: "#00565E",
     paddingTop: 12
   },
+  textCounter: {
+    width: "100%",
+    textAlign: "right"
+  },
   hr: {
     margin: "6px 0",
     borderColor: "#00565E"
@@ -122,9 +126,9 @@ class EditTask extends Component {
                 value={task}
                 onChange={this.onTaskContentChange}
               />
-            </div>
-            <div>
-              {this.state.task.length}/{MAX_TASK}
+              <div style={styles.textCounter}>
+                {this.state.task.length}/{MAX_TASK}
+              </div>
             </div>
           </div>
           <div>
@@ -140,9 +144,9 @@ class EditTask extends Component {
                 value={reasonsForAction}
                 onChange={this.onReasonsForActionChange}
               />
-            </div>
-            <div>
-              {this.state.reasonsForAction.length}/{MAX_REASON}
+              <div style={styles.textCounter}>
+                {this.state.reasonsForAction.length}/{MAX_REASON}
+              </div>
             </div>
           </div>
         </form>


### PR DESCRIPTION
# Description

Added a visible character counter to the bottom of the four text areas in EditEmail and EditTask

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

Add Email Response:
![image](https://user-images.githubusercontent.com/2746350/56231231-f7ef9c80-604b-11e9-97b9-f98df90555e2.png)
![image](https://user-images.githubusercontent.com/2746350/56231251-08077c00-604c-11e9-8051-c31e200c92ee.png)

Add Task:
![image](https://user-images.githubusercontent.com/2746350/56231285-19508880-604c-11e9-882f-b410100011e7.png)
![image](https://user-images.githubusercontent.com/2746350/56231305-23728700-604c-11e9-80e3-6c8505244f9e.png)

# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Start eMIB/Start Test
2.  Open the Inbox tab
3.  Add an email
4.  Type in the Response and Reasons textareas
5.  See character count change
6. Repeat for Add Task

# Checklist

Applicable for all code changes.

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
