### PR TITLE
[Add Task] Added Tooltips in 'Add Task' form (new version)

### DIFF
--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -156,6 +156,7 @@ class EditTask extends Component {
               >
                 <i
                   id="task-tooltip"
+                  aria-label={LOCALIZE.ariaLabel.taskTooltip}
                   tabIndex="0"
                   className="fas fa-question-circle"
                   style={styles.tasks.icon}
@@ -196,6 +197,7 @@ class EditTask extends Component {
               >
                 <i
                   id="reasons-for-action-tooltip"
+                  aria-label={LOCALIZE.ariaLabel.reasonsForActionTooltip}
                   tabIndex="0"
                   className="fas fa-question-circle"
                   style={styles.reasonsForAction.icon}

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -27,7 +27,8 @@ const styles = {
     icon: {
       color: "#00565E",
       marginTop: "4px",
-      width: 15
+      width: 15,
+      cursor: "pointer"
     },
     tooltipContainer: {
       marginLeft: 6,
@@ -55,7 +56,8 @@ const styles = {
     },
     icon: {
       color: "#00565E",
-      marginTop: "4px"
+      marginTop: "4px",
+      cursor: "pointer"
     },
     tooltipContainer: {
       marginLeft: 6,

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -1,7 +1,9 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { OverlayTrigger, Popover } from "react-bootstrap";
 import LOCALIZE from "../../text_resources";
 import { actionShape } from "./constants";
+import "../../css/inbox.css";
 
 const styles = {
   container: {
@@ -24,14 +26,18 @@ const styles = {
     },
     icon: {
       color: "#00565E",
-      marginTop: "4px"
+      marginTop: "4px",
+      width: 15
     },
-    tooltip: {
-      float: "right",
-      border: "1px solid #00565E",
+    tooltipContainer: {
+      marginLeft: 6,
+      padding: 6,
+      maxWidth: 500,
+      borderColor: "#00565E"
+    },
+    tooltipContent: {
       color: "#00565E",
-      width: "75%",
-      margin: "6px 6px 12px 0"
+      margin: 0
     },
     textArea: {
       padding: "6px 12px",
@@ -61,8 +67,6 @@ const styles = {
     }
   }
 };
-
-//TODO: Add tooltip functionality for both task and reasons for action icons
 
 class EditTask extends Component {
   state = {
@@ -111,7 +115,29 @@ class EditTask extends Component {
               <label htmlFor="your-tasks-text-area" style={styles.tasks.title}>
                 {LOCALIZE.emibTest.inboxPage.addEmailTask.task}
               </label>
-              <i className="fas fa-question-circle" style={styles.tasks.icon} />
+              <OverlayTrigger
+                trigger="focus"
+                placement="right"
+                overlay={
+                  <Popover id="task-tooltip" style={styles.tasks.tooltipContainer}>
+                    <div>
+                      <p style={styles.tasks.tooltipContent}>
+                        {LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart1}
+                      </p>
+                      <p style={styles.tasks.tooltipContent}>
+                        {LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart1}
+                      </p>
+                    </div>
+                  </Popover>
+                }
+              >
+                <i
+                  id="task-tooltip"
+                  tabIndex="0"
+                  className="fas fa-question-circle"
+                  style={styles.tasks.icon}
+                />
+              </OverlayTrigger>
               <textarea
                 id="your-tasks-text-area"
                 maxLength="100"

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -32,7 +32,7 @@ const styles = {
     tooltipContainer: {
       marginLeft: 6,
       padding: 6,
-      maxWidth: 500,
+      maxWidth: 550,
       borderColor: "#00565E"
     },
     tooltipContent: {
@@ -56,6 +56,16 @@ const styles = {
     icon: {
       color: "#00565E",
       marginTop: "4px"
+    },
+    tooltipContainer: {
+      marginLeft: 6,
+      padding: 6,
+      maxWidth: 360,
+      borderColor: "#00565E"
+    },
+    tooltipContent: {
+      color: "#00565E",
+      margin: 0
     },
     textArea: {
       padding: "6px 12px",
@@ -125,7 +135,7 @@ class EditTask extends Component {
                         {LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart1}
                       </p>
                       <p style={styles.tasks.tooltipContent}>
-                        {LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart1}
+                        {LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart2}
                       </p>
                     </div>
                   </Popover>
@@ -152,7 +162,29 @@ class EditTask extends Component {
               <label htmlFor="reasons-for-action-text-area" style={styles.reasonsForAction.title}>
                 {LOCALIZE.emibTest.inboxPage.addEmailTask.reasonsForAction}
               </label>
-              <i className="fas fa-question-circle" style={styles.reasonsForAction.icon} />
+              <OverlayTrigger
+                trigger="focus"
+                placement="right"
+                overlay={
+                  <Popover
+                    id="reasons-for-action-tooltip"
+                    style={styles.reasonsForAction.tooltipContainer}
+                  >
+                    <div>
+                      <p style={styles.reasonsForAction.tooltipContent}>
+                        {LOCALIZE.emibTest.inboxPage.taskContent.reasonsForActionTooltip}
+                      </p>
+                    </div>
+                  </Popover>
+                }
+              >
+                <i
+                  id="reasons-for-action-tooltip"
+                  tabIndex="0"
+                  className="fas fa-question-circle"
+                  style={styles.reasonsForAction.icon}
+                />
+              </OverlayTrigger>
               <textarea
                 id="reasons-for-action-text-area"
                 maxLength="100"

--- a/frontend/src/css/inbox.css
+++ b/frontend/src/css/inbox.css
@@ -1,5 +1,5 @@
 /*
-inbx.css is used for the Inbox.jsx, EmailPreview.jsx, and Email.jsx
+inbx.css is used for the Inbox.jsx, EmailPreview.jsx, EditTask.jsx and Email.jsx
 styles that cannot be added inside a const
 */
 
@@ -18,4 +18,9 @@ styles that cannot be added inside a const
 .inbox-grid-content-cell {
   -ms-grid-column: 2;
   grid-column: 2;
+}
+
+/* removes the arrow from the tooltip container since this is not part of the design */
+.popover .arrow {
+  display: none;
 }

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -441,7 +441,9 @@ let LOCALIZE = new LocalizedStrings({
       reasonsForActionDetails: "reasons for action details",
       taskDetails: "task details",
       emailOptions: "email options",
-      taskOptions: "task options"
+      taskOptions: "task options",
+      taskTooltip: "task tooltip",
+      reasonsForActionTooltip: "reasons for action tooltip"
     },
 
     //Commons
@@ -926,7 +928,9 @@ let LOCALIZE = new LocalizedStrings({
       reasonsForActionDetails: "motifs de l'action",
       taskDetails: "détails sur la ou les tâches",
       emailOptions: "options de messagerie",
-      taskOptions: "options de tâche"
+      taskOptions: "options de tâche",
+      taskTooltip: "infobulle de tâche",
+      reasonsForActionTooltip: "infobulle des motifs de l'action"
     },
 
     //Commons

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -368,7 +368,11 @@ let LOCALIZE = new LocalizedStrings({
         },
         taskContent: {
           task: "Your task(s):",
-          reasonsForAction: "Your reasons for action:"
+          taskTooltipPart1: "An action you intend to take to address a situation in the emails.",
+          taskTooltipPart2: "Example: Planning a meeting, asking a colleague for information.",
+          reasonsForAction: "Your reasons for action:",
+          reasonsForActionTooltip:
+            "Here, you can explain why you took a specific action in response to a situation if you feel you need to provide additional information"
         },
         deleteResponseConfirmation: {
           title: "Are you sure you want to delete this response?",
@@ -848,7 +852,11 @@ let LOCALIZE = new LocalizedStrings({
         },
         taskContent: {
           task: "FR Your task(s):",
-          reasonsForAction: "FR Your reasons for action:"
+          taskTooltipPart1: "FR An action you intend to take to address a situation in the emails.",
+          taskTooltipPart2: "FR Example: Planning a meeting, asking a colleague for information.",
+          reasonsForAction: "FR Your reasons for action:",
+          reasonsForActionTooltip:
+            "FR Here, you can explain why you took a specific action in response to a situation if you feel you need to provide additional information"
         },
         deleteResponseConfirmation: {
           title: "FR Are you sure you want to delete this response?",


### PR DESCRIPTION
# Description

The tooltip icons were already in the **Add Task** form, but they were static, so I added the tooltips content using _react-OverlayTrigger_ and _react-Popover_ libraries.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**Task Tooltip (EN):**

![image](https://user-images.githubusercontent.com/23021242/56284080-777b7b00-60e1-11e9-933f-f980021ead28.png)

**Task Tooltip (FR):**

![image](https://user-images.githubusercontent.com/23021242/56284136-9b3ec100-60e1-11e9-8deb-8d410a6cdc44.png)

**Reasons For Action Tooltip (EN):**

![image](https://user-images.githubusercontent.com/23021242/56284115-911cc280-60e1-11e9-89b3-a95296550ec9.png)

**Reasons For Action Tooltip (FR):**

![image](https://user-images.githubusercontent.com/23021242/56284149-a4c82900-60e1-11e9-9645-62d44c04bb02.png)

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB Sample Test.
2.  Complete the pre-test process.
3.  Open the Inbox tab.
4.  Click on Create a task.
5.  Make sure you are able to see the tooltips when navigating using the keyboard and when clicking on the icons.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
