### PR TITLE
[Cancel Response Dialog] Added cancel 'edit dialog' for inbox responses

### DIFF
--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -108,10 +108,6 @@ class EditActionDialog extends Component {
     this.setState({ action: updatedAction });
   };
 
-  handleClose = () => {
-    this.setState({ showCancelConfirmationDialog: true });
-  };
-
   showCancelConfirmationDialog = () => {
     this.setState({ showCancelConfirmationDialog: true });
   };
@@ -124,98 +120,108 @@ class EditActionDialog extends Component {
     const { showDialog, handleClose, actionType, editMode } = this.props;
     return (
       <div>
-        {!this.state.showCancelConfirmationDialog && (
-          <Modal show={showDialog} onHide={this.handleClose}>
-            <div>
-              <Modal.Header style={styles.modalHeader}>
-                {
-                  <div style={styles.fullWidth}>
-                    {actionType === ACTION_TYPE.email && (
-                      <div style={styles.fullWidth}>
-                        <i style={styles.icon} className="fas fa-envelope" />
-                        <h3 style={styles.dialogHeaderText}>
-                          {editMode === EDIT_MODE.create &&
-                            LOCALIZE.emibTest.inboxPage.editActionDialog.addEmail}
-                          {editMode === EDIT_MODE.update &&
-                            LOCALIZE.emibTest.inboxPage.editActionDialog.editEmail}
-                        </h3>
-                        <button onClick={handleClose} style={styles.closeButton}>
-                          <i className="fas fa-times" />
-                        </button>
-                      </div>
-                    )}
-                    {actionType === ACTION_TYPE.task && (
-                      <div style={styles.fullWidth}>
-                        <i style={styles.icon} className="fas fa-tasks" />
-                        <h3 style={styles.dialogHeaderText}>
-                          {editMode === EDIT_MODE.create &&
-                            LOCALIZE.emibTest.inboxPage.editActionDialog.addTask}
-                          {editMode === EDIT_MODE.update &&
-                            LOCALIZE.emibTest.inboxPage.editActionDialog.editTask}
-                        </h3>
-                        <button onClick={handleClose} style={styles.closeButton}>
-                          <i className="fas fa-times" />
-                        </button>
-                      </div>
-                    )}
-                  </div>
-                }
-              </Modal.Header>
-              <Modal.Body style={styles.modalBody}>
-                {actionType === ACTION_TYPE.email && (
-                  <EditEmail
-                    onChange={this.editAction}
-                    action={editMode === EDIT_MODE.update ? this.props.action : null}
-                  />
-                )}
-                {actionType === ACTION_TYPE.task && (
-                  <EditTask
-                    emailNumber={this.props.emailId}
-                    emailSubject={this.props.emailSubject}
-                    onChange={this.editAction}
-                    action={editMode === EDIT_MODE.update ? this.props.action : null}
-                  />
-                )}
-              </Modal.Body>
-              <Modal.Footer>
-                <div>
-                  <div>
-                    <button
-                      id="unit-test-email-response-button"
-                      type="button"
-                      className="btn btn-primary"
-                      onClick={this.handleSave}
-                      disabled={!this.props.showDialog}
-                    >
-                      {LOCALIZE.emibTest.inboxPage.editActionDialog.save}
-                    </button>
-                  </div>
+        <Modal show={showDialog} onHide={this.showCancelConfirmationDialog}>
+          <div>
+            <Modal.Header style={styles.modalHeader}>
+              {
+                <div style={styles.fullWidth}>
+                  {actionType === ACTION_TYPE.email && (
+                    <div style={styles.fullWidth}>
+                      <i style={styles.icon} className="fas fa-envelope" />
+                      <h3 style={styles.dialogHeaderText}>
+                        {editMode === EDIT_MODE.create &&
+                          LOCALIZE.emibTest.inboxPage.editActionDialog.addEmail}
+                        {editMode === EDIT_MODE.update &&
+                          LOCALIZE.emibTest.inboxPage.editActionDialog.editEmail}
+                      </h3>
+                      <button
+                        onClick={this.showCancelConfirmationDialog}
+                        style={styles.closeButton}
+                      >
+                        <i className="fas fa-times" />
+                      </button>
+                    </div>
+                  )}
+                  {actionType === ACTION_TYPE.task && (
+                    <div style={styles.fullWidth}>
+                      <i style={styles.icon} className="fas fa-tasks" />
+                      <h3 style={styles.dialogHeaderText}>
+                        {editMode === EDIT_MODE.create &&
+                          LOCALIZE.emibTest.inboxPage.editActionDialog.addTask}
+                        {editMode === EDIT_MODE.update &&
+                          LOCALIZE.emibTest.inboxPage.editActionDialog.editTask}
+                      </h3>
+                      <button
+                        onClick={this.showCancelConfirmationDialog}
+                        style={styles.closeButton}
+                      >
+                        <i className="fas fa-times" />
+                      </button>
+                    </div>
+                  )}
                 </div>
-              </Modal.Footer>
-            </div>
-          </Modal>
-        )}
+              }
+            </Modal.Header>
+            <Modal.Body style={styles.modalBody}>
+              {actionType === ACTION_TYPE.email && (
+                <EditEmail
+                  onChange={this.editAction}
+                  action={editMode === EDIT_MODE.update ? this.props.action : null}
+                />
+              )}
+              {actionType === ACTION_TYPE.task && (
+                <EditTask
+                  emailNumber={this.props.emailId}
+                  emailSubject={this.props.emailSubject}
+                  onChange={this.editAction}
+                  action={editMode === EDIT_MODE.update ? this.props.action : null}
+                />
+              )}
+            </Modal.Body>
+            <Modal.Footer>
+              <div>
+                <div>
+                  <button
+                    id="unit-test-email-response-button"
+                    type="button"
+                    className="btn btn-primary"
+                    onClick={this.handleSave}
+                    disabled={!this.props.showDialog}
+                  >
+                    {LOCALIZE.emibTest.inboxPage.editActionDialog.save}
+                  </button>
+                </div>
+              </div>
+            </Modal.Footer>
+          </div>
+        </Modal>
         {this.state.showCancelConfirmationDialog && (
           <PopupBox
             show={this.state.showCancelConfirmationDialog}
             handleClose={this.closeCancelConfirmationDialog}
-            title={"TITLE"}
+            title={LOCALIZE.emibTest.inboxPage.cancelResponseConfirmation.title}
             description={
               <div>
                 <div>
                   <SystemMessage
                     messageType={MESSAGE_TYPE.error}
-                    title={"TITLE"}
-                    message={"Message here..."}
+                    title={
+                      LOCALIZE.emibTest.inboxPage.cancelResponseConfirmation.systemMessageTitle
+                    }
+                    message={
+                      LOCALIZE.emibTest.inboxPage.cancelResponseConfirmation
+                        .systemMessageDescription
+                    }
                   />
                 </div>
+                <div>{LOCALIZE.emibTest.inboxPage.cancelResponseConfirmation.description}</div>
               </div>
             }
             leftButtonType={BUTTON_TYPE.danger}
-            leftButtonTitle={"Cancel response"}
+            leftButtonTitle={LOCALIZE.commons.cancelResponse}
             leftButtonAction={handleClose}
             rightButtonType={BUTTON_TYPE.primary}
-            rightButtonTitle={"Return to response"}
+            rightButtonTitle={LOCALIZE.commons.returnToResponse}
           />
         )}
       </div>

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -6,6 +6,8 @@ import LOCALIZE from "../../text_resources";
 import EditEmail from "./EditEmail";
 import EditTask from "./EditTask";
 import { Modal } from "react-bootstrap";
+import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
+import SystemMessage, { MESSAGE_TYPE } from "../commons/SystemMessage";
 import { ACTION_TYPE, EDIT_MODE, actionShape } from "./constants";
 import {
   addEmail,
@@ -72,7 +74,8 @@ class EditActionDialog extends Component {
   };
 
   state = {
-    action: {}
+    action: {},
+    showCancelConfirmationDialog: false
   };
 
   handleSave = () => {
@@ -105,79 +108,116 @@ class EditActionDialog extends Component {
     this.setState({ action: updatedAction });
   };
 
+  handleClose = () => {
+    this.setState({ showCancelConfirmationDialog: true });
+  };
+
+  showCancelConfirmationDialog = () => {
+    this.setState({ showCancelConfirmationDialog: true });
+  };
+
+  closeCancelConfirmationDialog = () => {
+    this.setState({ showCancelConfirmationDialog: false });
+  };
+
   render() {
     const { showDialog, handleClose, actionType, editMode } = this.props;
     return (
       <div>
-        <Modal show={showDialog} onHide={handleClose}>
-          <div>
-            <Modal.Header style={styles.modalHeader}>
-              {
-                <div style={styles.fullWidth}>
-                  {actionType === ACTION_TYPE.email && (
-                    <div style={styles.fullWidth}>
-                      <i style={styles.icon} className="fas fa-envelope" />
-                      <h3 style={styles.dialogHeaderText}>
-                        {editMode === EDIT_MODE.create &&
-                          LOCALIZE.emibTest.inboxPage.editActionDialog.addEmail}
-                        {editMode === EDIT_MODE.update &&
-                          LOCALIZE.emibTest.inboxPage.editActionDialog.editEmail}
-                      </h3>
-                      <button onClick={handleClose} style={styles.closeButton}>
-                        <i className="fas fa-times" />
-                      </button>
-                    </div>
-                  )}
-                  {actionType === ACTION_TYPE.task && (
-                    <div style={styles.fullWidth}>
-                      <i style={styles.icon} className="fas fa-tasks" />
-                      <h3 style={styles.dialogHeaderText}>
-                        {editMode === EDIT_MODE.create &&
-                          LOCALIZE.emibTest.inboxPage.editActionDialog.addTask}
-                        {editMode === EDIT_MODE.update &&
-                          LOCALIZE.emibTest.inboxPage.editActionDialog.editTask}
-                      </h3>
-                      <button onClick={handleClose} style={styles.closeButton}>
-                        <i className="fas fa-times" />
-                      </button>
-                    </div>
-                  )}
+        {!this.state.showCancelConfirmationDialog && (
+          <Modal show={showDialog} onHide={this.handleClose}>
+            <div>
+              <Modal.Header style={styles.modalHeader}>
+                {
+                  <div style={styles.fullWidth}>
+                    {actionType === ACTION_TYPE.email && (
+                      <div style={styles.fullWidth}>
+                        <i style={styles.icon} className="fas fa-envelope" />
+                        <h3 style={styles.dialogHeaderText}>
+                          {editMode === EDIT_MODE.create &&
+                            LOCALIZE.emibTest.inboxPage.editActionDialog.addEmail}
+                          {editMode === EDIT_MODE.update &&
+                            LOCALIZE.emibTest.inboxPage.editActionDialog.editEmail}
+                        </h3>
+                        <button onClick={handleClose} style={styles.closeButton}>
+                          <i className="fas fa-times" />
+                        </button>
+                      </div>
+                    )}
+                    {actionType === ACTION_TYPE.task && (
+                      <div style={styles.fullWidth}>
+                        <i style={styles.icon} className="fas fa-tasks" />
+                        <h3 style={styles.dialogHeaderText}>
+                          {editMode === EDIT_MODE.create &&
+                            LOCALIZE.emibTest.inboxPage.editActionDialog.addTask}
+                          {editMode === EDIT_MODE.update &&
+                            LOCALIZE.emibTest.inboxPage.editActionDialog.editTask}
+                        </h3>
+                        <button onClick={handleClose} style={styles.closeButton}>
+                          <i className="fas fa-times" />
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                }
+              </Modal.Header>
+              <Modal.Body style={styles.modalBody}>
+                {actionType === ACTION_TYPE.email && (
+                  <EditEmail
+                    onChange={this.editAction}
+                    action={editMode === EDIT_MODE.update ? this.props.action : null}
+                  />
+                )}
+                {actionType === ACTION_TYPE.task && (
+                  <EditTask
+                    emailNumber={this.props.emailId}
+                    emailSubject={this.props.emailSubject}
+                    onChange={this.editAction}
+                    action={editMode === EDIT_MODE.update ? this.props.action : null}
+                  />
+                )}
+              </Modal.Body>
+              <Modal.Footer>
+                <div>
+                  <div>
+                    <button
+                      id="unit-test-email-response-button"
+                      type="button"
+                      className="btn btn-primary"
+                      onClick={this.handleSave}
+                      disabled={!this.props.showDialog}
+                    >
+                      {LOCALIZE.emibTest.inboxPage.editActionDialog.save}
+                    </button>
+                  </div>
                 </div>
-              }
-            </Modal.Header>
-            <Modal.Body style={styles.modalBody}>
-              {actionType === ACTION_TYPE.email && (
-                <EditEmail
-                  onChange={this.editAction}
-                  action={editMode === EDIT_MODE.update ? this.props.action : null}
-                />
-              )}
-              {actionType === ACTION_TYPE.task && (
-                <EditTask
-                  emailNumber={this.props.emailId}
-                  emailSubject={this.props.emailSubject}
-                  onChange={this.editAction}
-                  action={editMode === EDIT_MODE.update ? this.props.action : null}
-                />
-              )}
-            </Modal.Body>
-            <Modal.Footer>
+              </Modal.Footer>
+            </div>
+          </Modal>
+        )}
+        {this.state.showCancelConfirmationDialog && (
+          <PopupBox
+            show={this.state.showCancelConfirmationDialog}
+            handleClose={this.closeCancelConfirmationDialog}
+            title={"TITLE"}
+            description={
               <div>
                 <div>
-                  <button
-                    id="unit-test-email-response-button"
-                    type="button"
-                    className="btn btn-primary"
-                    onClick={this.handleSave}
-                    disabled={!this.props.showDialog}
-                  >
-                    {LOCALIZE.emibTest.inboxPage.editActionDialog.save}
-                  </button>
+                  <SystemMessage
+                    messageType={MESSAGE_TYPE.error}
+                    title={"TITLE"}
+                    message={"Message here..."}
+                  />
                 </div>
               </div>
-            </Modal.Footer>
-          </div>
-        </Modal>
+            }
+            leftButtonType={BUTTON_TYPE.danger}
+            leftButtonTitle={"Cancel response"}
+            leftButtonAction={handleClose}
+            rightButtonType={BUTTON_TYPE.primary}
+            rightButtonTitle={"Return to response"}
+          />
+        )}
       </div>
     );
   }

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -12,7 +12,7 @@ const MAX_REASON = "100";
 
 const styles = {
   container: {
-    maxHeight: "calc(100vh - 300px)",
+    maxHeight: "calc(100vh - 297px)",
     overflow: "auto",
     width: 500
   },

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -377,6 +377,14 @@ let LOCALIZE = new LocalizedStrings({
             "This reply will be removed from your test responses. You will not be able to recover your response or reasons for action.",
           description:
             'If you are certain that you want to delete your response, click the "Delete response" button.'
+        },
+        cancelResponseConfirmation: {
+          title: "Are you sure you want to cancel this response?",
+          systemMessageTitle: "Warning!",
+          systemMessageDescription:
+            "Your response will not be saved if you proceed. If you wish to save your answer, you may return to the response. All of your responses can be edited or deleted before submission.",
+          description:
+            'If you do not wish to save the response, click the "Cancel response" button.'
         }
       },
 
@@ -457,6 +465,7 @@ let LOCALIZE = new LocalizedStrings({
       submitTestButton: "Submit test",
       quitTest: "Quit Test",
       returnToTest: "Return to Test",
+      returnToResponse: "Return to response",
       passStatus: "Pass",
       failStatus: "Fail",
       enabled: "Enabled",
@@ -469,6 +478,7 @@ let LOCALIZE = new LocalizedStrings({
         openButton: "open notes"
       },
       cancel: "Cancel",
+      cancelResponse: "Cancel response",
       close: "Close"
     }
   },
@@ -857,6 +867,14 @@ let LOCALIZE = new LocalizedStrings({
             "FR This reply will be removed from your test responses. You will not be able to recover your response or reasons for action.",
           description:
             'FR If you are certain that you want to delete your response, click the "Delete response" button.'
+        },
+        cancelResponseConfirmation: {
+          title: "FR Are you sure you want to cancel this response?",
+          systemMessageTitle: "Avertissement!",
+          systemMessageDescription:
+            "FR Your response will not be saved if you proceed. If you wish to save your answer, you may return to the response. All of your responses can be edited or deleted before submission.",
+          description:
+            'FR If you do not wish to save the response, click the "Cancel response" button.'
         }
       },
 
@@ -938,6 +956,7 @@ let LOCALIZE = new LocalizedStrings({
       submitTestButton: "Envoyer le test",
       quitTest: "Quitter la séance de test",
       returnToTest: "Retourner à la séance",
+      returnToResponse: "Retourner à la réponse",
       passStatus: "Réussi",
       failStatus: "Échoue",
       enabled: "Activé",
@@ -950,6 +969,7 @@ let LOCALIZE = new LocalizedStrings({
         openButton: "ouvrir notes"
       },
       cancel: "Annuler",
+      cancelResponse: "Annuler la réponse",
       close: "Fermer"
     }
   }


### PR DESCRIPTION
# Description

I implemented new cancel confirmation messages for the following situations:
- While creating a new email response or a new task and you hit the close button or click next to the response dialog
- While editing an new email response or a task and you hit the close button or click next to the response dialog

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**New Email Response or Task**
---
**When you click one of the following places:**

![image](https://user-images.githubusercontent.com/23021242/56293026-4f4a4700-60f6-11e9-8070-106e70adfa27.png)

**It shows the following:**

![image](https://user-images.githubusercontent.com/23021242/56293079-6be67f00-60f6-11e9-88d1-28dba45ef9f0.png)

**If you click 'Return to response:'**

![image](https://user-images.githubusercontent.com/23021242/56293339-e2837c80-60f6-11e9-815a-f2caaef7a013.png)

**If you click 'Cancel response:'**

![image](https://user-images.githubusercontent.com/23021242/56293374-f16a2f00-60f6-11e9-93c0-c0f2f921c29b.png)

**Edit Email Response or Task**
---

**Exactly the same behavior:**

![image](https://user-images.githubusercontent.com/23021242/56293600-5aea3d80-60f7-11e9-8314-ac4bdfc93d2a.png)

![image](https://user-images.githubusercontent.com/23021242/56293026-4f4a4700-60f6-11e9-8070-106e70adfa27.png)

![image](https://user-images.githubusercontent.com/23021242/56293079-6be67f00-60f6-11e9-88d1-28dba45ef9f0.png)

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB Sample Test.
2.  Complete the _pre-test_ process.
3.  Open the _Inbox_ tab.
4.  Create a new email response or a new task.
5.  Close the dialog and make sure you see the cancel confirmation message.
6.  Also make sure that the buttons do what they are supposed to do.
7.  Save an email response or a task.
8.  Edit it and make sure it does exactly the same thing as steps 5 and 6.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
