### PR TITLE
[QA Fix 3] All h2's have no margin

### DIFF
--- a/frontend/src/components/eMIB/BackgroundInformation.jsx
+++ b/frontend/src/components/eMIB/BackgroundInformation.jsx
@@ -9,9 +9,7 @@ class BackgroundInformation extends Component {
     return (
       <div>
         <div>
-          <h2 style={instructionStyles.h2}>
-            {LOCALIZE.emibTest.background.backgroundInformation.title}
-          </h2>
+          <h2>{LOCALIZE.emibTest.background.backgroundInformation.title}</h2>
           <div>
             <p style={instructionStyles.p}>
               {LOCALIZE.emibTest.background.backgroundInformation.paragraph1}

--- a/frontend/src/components/eMIB/Evaluation.jsx
+++ b/frontend/src/components/eMIB/Evaluation.jsx
@@ -9,7 +9,7 @@ class Evaluation extends Component {
     return (
       <div>
         <div>
-          <h2 style={instructionStyles.h2}>{LOCALIZE.emibTest.howToPage.evaluation.title}</h2>
+          <h2>{LOCALIZE.emibTest.howToPage.evaluation.title}</h2>
           <div>
             <ul>
               <li>{LOCALIZE.emibTest.howToPage.evaluation.bullet1}</li>

--- a/frontend/src/components/eMIB/OrganizationalInformation.jsx
+++ b/frontend/src/components/eMIB/OrganizationalInformation.jsx
@@ -9,9 +9,7 @@ class OrganizationalInformation extends Component {
     return (
       <div>
         <div>
-          <h2 style={instructionStyles.h2}>
-            {LOCALIZE.emibTest.background.organizationalInformation.title}
-          </h2>
+          <h2>{LOCALIZE.emibTest.background.organizationalInformation.title}</h2>
           <div>
             <p style={instructionStyles.p}>
               {LOCALIZE.emibTest.background.organizationalInformation.description}

--- a/frontend/src/components/eMIB/OrganizationalStructure.jsx
+++ b/frontend/src/components/eMIB/OrganizationalStructure.jsx
@@ -57,9 +57,7 @@ class OrganizationalStructure extends Component {
           rightButtonTitle={LOCALIZE.commons.close}
         />
         <div>
-          <h2 style={instructionStyles.h2}>
-            {LOCALIZE.emibTest.background.organizationalStructure.title}
-          </h2>
+          <h2>{LOCALIZE.emibTest.background.organizationalStructure.title}</h2>
           <div>
             <p style={instructionStyles.p}>
               {LOCALIZE.emibTest.background.organizationalStructure.description}

--- a/frontend/src/components/eMIB/Overview.jsx
+++ b/frontend/src/components/eMIB/Overview.jsx
@@ -9,7 +9,7 @@ class Overview extends Component {
     return (
       <div>
         <div>
-          <h2 style={instructionStyles.h2}>{LOCALIZE.emibTest.howToPage.overview.title}</h2>
+          <h2>{LOCALIZE.emibTest.howToPage.overview.title}</h2>
           <div>
             <p style={instructionStyles.p}>{LOCALIZE.emibTest.howToPage.overview.description}</p>
           </div>

--- a/frontend/src/components/eMIB/TeamInformation.jsx
+++ b/frontend/src/components/eMIB/TeamInformation.jsx
@@ -55,7 +55,7 @@ class TeamInformation extends Component {
           rightButtonTitle={LOCALIZE.commons.close}
         />
         <div>
-          <h2 style={instructionStyles.h2}>{LOCALIZE.emibTest.background.teamInformation.title}</h2>
+          <h2>{LOCALIZE.emibTest.background.teamInformation.title}</h2>
           <div>
             <h3 style={instructionStyles.h3}>
               {LOCALIZE.emibTest.background.teamInformation.teamMembersSection.title}

--- a/frontend/src/components/eMIB/TestExamples.jsx
+++ b/frontend/src/components/eMIB/TestExamples.jsx
@@ -30,7 +30,7 @@ class TestExamples extends Component {
     return (
       <div>
         <div>
-          <h2 style={instructionStyles.h2}>{LOCALIZE.emibTest.howToPage.testExamples.title}</h2>
+          <h2>{LOCALIZE.emibTest.howToPage.testExamples.title}</h2>
           <div>
             <p style={instructionStyles.p}>{LOCALIZE.emibTest.howToPage.testExamples.para1}</p>
             <h4 style={instructionStyles.h4}>

--- a/frontend/src/components/eMIB/TestInstructions.jsx
+++ b/frontend/src/components/eMIB/TestInstructions.jsx
@@ -9,7 +9,7 @@ class TestInstructions extends Component {
     return (
       <div>
         <div>
-          <h2 style={instructionStyles.h2}>{LOCALIZE.emibTest.howToPage.testInstructions.title}</h2>
+          <h2>{LOCALIZE.emibTest.howToPage.testInstructions.title}</h2>
           <div>
             <p style={instructionStyles.p}>{LOCALIZE.emibTest.howToPage.testInstructions.para1}</p>
           </div>

--- a/frontend/src/components/eMIB/TipsOnTest.jsx
+++ b/frontend/src/components/eMIB/TipsOnTest.jsx
@@ -9,7 +9,7 @@ class TipsOnTest extends Component {
     return (
       <div>
         <div>
-          <h2 style={instructionStyles.h2}>{LOCALIZE.emibTest.howToPage.tipsOnTest.title}</h2>
+          <h2>{LOCALIZE.emibTest.howToPage.tipsOnTest.title}</h2>
           <p style={instructionStyles.p}>{LOCALIZE.emibTest.howToPage.tipsOnTest.description}</p>
           <ul>
             <li>{LOCALIZE.emibTest.howToPage.tipsOnTest.bullet1}</li>

--- a/frontend/src/components/eMIB/constants.js
+++ b/frontend/src/components/eMIB/constants.js
@@ -51,9 +51,6 @@ export const actionShape = PropTypes.shape({
 
 /* Override margins for the Instuctions and Background pages and nothing else */
 export const instructionStyles = {
-  h2: {
-    margin: 0
-  },
   h3: {
     marginTop: 32,
     marginBottom: 0

--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -32,8 +32,7 @@ h1 {
 
 h2 {
   color: #00565e;
-  margin-top: 12px;
-  margin-bottom: 12px;
+  margin: 0px;
 }
 
 h3 {


### PR DESCRIPTION
# Description

Overrode default cat h2 margins to be 0; removed h2 styling added in constants.js as this is no longer needed

## Type of change

Please delete options that are not relevant.

- Code cleanliness or refactor

## Screenshot

Only visually different page is Prototype, and that only slightly
Before:
![image](https://user-images.githubusercontent.com/2746350/56424853-f0b0d480-627f-11e9-888a-6887dbbdfd9d.png)

After:
![image](https://user-images.githubusercontent.com/2746350/56424875-fc9c9680-627f-11e9-9d1c-80300da43b6c.png)

# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Navigate through test, see all h2s have no margin

# Checklist

Applicable for all code changes.

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
- [ ] My changes generate no new compiler warnings
- [ ] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 10+, Firefox, and Chrome
