### PR TITLE
[QA Fix 5] Remove Hyperlink form Evaluation

### DIFF
--- a/frontend/src/components/eMIB/Evaluation.jsx
+++ b/frontend/src/components/eMIB/Evaluation.jsx
@@ -15,10 +15,7 @@ class Evaluation extends Component {
               <li>{LOCALIZE.emibTest.howToPage.evaluation.bullet1}</li>
               <li>
                 {LOCALIZE.emibTest.howToPage.evaluation.bullet2}
-                <a href="#keyLeadershipCompetencies">
-                  {LOCALIZE.emibTest.howToPage.evaluation.bullet2Link}
-                </a>
-                .
+                {LOCALIZE.emibTest.howToPage.evaluation.bullet2Link}.
               </li>
               <li>{LOCALIZE.emibTest.howToPage.evaluation.bullet3}</li>
               <li>{LOCALIZE.emibTest.howToPage.evaluation.bullet4}</li>


### PR DESCRIPTION
# Description

Removing hyperlink from the evaluation page

## Type of change

Please delete options that are not relevant.

- Code cleanliness or refactor

## Screenshot

### Before-Test
Before:
![image](https://user-images.githubusercontent.com/2746350/56428127-48edd380-628c-11e9-8617-9b21dd29f616.png)

After:
![image](https://user-images.githubusercontent.com/2746350/56428067-147a1780-628c-11e9-83bc-b488b6e761d3.png)

### In-Test
Before:
![image](https://user-images.githubusercontent.com/2746350/56428151-5e62fd80-628c-11e9-9e57-d9645f6077f6.png)

After:
![image](https://user-images.githubusercontent.com/2746350/56428097-2f4c8c00-628c-11e9-9996-99934e89b68d.png)

# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Go to Evaluation before test and in test
2. See that hyperlink is no longe there

# Checklist

Applicable for all code changes.

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
