### PR TITLE
[Inbox] Add original email to the action dialog

### DIFF
--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -58,7 +58,6 @@ class ActionViewEmail extends Component {
   static propTypes = {
     action: actionShape,
     actionId: PropTypes.number.isRequired,
-    emailId: PropTypes.number.isRequired,
     email: emailShape,
     // Props from Redux
     deleteEmail: PropTypes.func
@@ -181,13 +180,14 @@ class ActionViewEmail extends Component {
             }
             leftButtonType={BUTTON_TYPE.danger}
             leftButtonTitle={LOCALIZE.emibTest.inboxPage.emailCommons.deleteButton}
-            leftButtonAction={() => this.props.deleteEmail(this.props.emailId, this.props.actionId)}
+            leftButtonAction={() =>
+              this.props.deleteEmail(this.props.email.id, this.props.actionId)
+            }
             rightButtonType={BUTTON_TYPE.primary}
             rightButtonTitle={LOCALIZE.commons.returnToTest}
           />
         </div>
         <EditActionDialog
-          emailId={this.props.emailId}
           email={this.props.email}
           showDialog={this.state.showEmailDialog}
           handleClose={this.closeEmailDialog}

--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import "../../css/collapsing-item.css";
 import LOCALIZE from "../../text_resources";
 import EditActionDialog from "./EditActionDialog";
-import { ACTION_TYPE, EDIT_MODE, EMAIL_TYPE, actionShape } from "./constants";
+import { ACTION_TYPE, EDIT_MODE, EMAIL_TYPE, actionShape, emailShape } from "./constants";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { deleteEmail } from "../../modules/EmibInboxRedux";
@@ -59,6 +59,7 @@ class ActionViewEmail extends Component {
     action: actionShape,
     actionId: PropTypes.number.isRequired,
     emailId: PropTypes.number.isRequired,
+    email: emailShape,
     // Props from Redux
     deleteEmail: PropTypes.func
   };
@@ -187,6 +188,7 @@ class ActionViewEmail extends Component {
         </div>
         <EditActionDialog
           emailId={this.props.emailId}
+          email={this.props.email}
           showDialog={this.state.showEmailDialog}
           handleClose={this.closeEmailDialog}
           actionType={ACTION_TYPE.email}

--- a/frontend/src/components/eMIB/ActionViewTask.jsx
+++ b/frontend/src/components/eMIB/ActionViewTask.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import "../../css/collapsing-item.css";
 import LOCALIZE from "../../text_resources";
 import EditActionDialog from "./EditActionDialog";
-import { ACTION_TYPE, EDIT_MODE, actionShape } from "./constants";
+import { ACTION_TYPE, EDIT_MODE, actionShape, emailShape } from "./constants";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { deleteTask } from "../../modules/EmibInboxRedux";
@@ -28,6 +28,7 @@ class ActionViewTask extends Component {
     emailSubject: PropTypes.string,
     actionId: PropTypes.number.isRequired,
     emailId: PropTypes.number.isRequired,
+    email: emailShape,
     // Props from Redux
     deleteTask: PropTypes.func
   };
@@ -113,6 +114,7 @@ class ActionViewTask extends Component {
         <div>
           <EditActionDialog
             emailId={this.props.emailId}
+            email={this.props.email}
             emailSubject={this.props.emailSubject}
             showDialog={this.state.showTaskDialog}
             handleClose={this.closeTaskDialog}

--- a/frontend/src/components/eMIB/ActionViewTask.jsx
+++ b/frontend/src/components/eMIB/ActionViewTask.jsx
@@ -25,9 +25,8 @@ const styles = {
 class ActionViewTask extends Component {
   static propTypes = {
     action: actionShape,
-    emailSubject: PropTypes.string,
     actionId: PropTypes.number.isRequired,
-    email: emailShape,
+    email: emailShape.isRequired,
     // Props from Redux
     deleteTask: PropTypes.func
   };

--- a/frontend/src/components/eMIB/ActionViewTask.jsx
+++ b/frontend/src/components/eMIB/ActionViewTask.jsx
@@ -27,7 +27,6 @@ class ActionViewTask extends Component {
     action: actionShape,
     emailSubject: PropTypes.string,
     actionId: PropTypes.number.isRequired,
-    emailId: PropTypes.number.isRequired,
     email: emailShape,
     // Props from Redux
     deleteTask: PropTypes.func
@@ -106,16 +105,14 @@ class ActionViewTask extends Component {
             }
             leftButtonType={BUTTON_TYPE.danger}
             leftButtonTitle={LOCALIZE.emibTest.inboxPage.emailCommons.deleteButton}
-            leftButtonAction={() => this.props.deleteTask(this.props.emailId, this.props.actionId)}
+            leftButtonAction={() => this.props.deleteTask(this.props.email.id, this.props.actionId)}
             rightButtonType={BUTTON_TYPE.primary}
             rightButtonTitle={LOCALIZE.commons.returnToTest}
           />
         </div>
         <div>
           <EditActionDialog
-            emailId={this.props.emailId}
             email={this.props.email}
-            emailSubject={this.props.emailSubject}
             showDialog={this.state.showTaskDialog}
             handleClose={this.closeTaskDialog}
             actionType={ACTION_TYPE.task}

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -8,7 +8,8 @@ import EditTask from "./EditTask";
 import { Modal } from "react-bootstrap";
 import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
 import SystemMessage, { MESSAGE_TYPE } from "../commons/SystemMessage";
-import { ACTION_TYPE, EDIT_MODE, actionShape } from "./constants";
+import { ACTION_TYPE, EDIT_MODE, actionShape, emailShape } from "./constants";
+import EmailContent from "./EmailContent";
 import {
   addEmail,
   addTask,
@@ -18,6 +19,12 @@ import {
 } from "../../modules/EmibInboxRedux";
 
 const styles = {
+  container: {
+    maxHeight: "calc(100vh - 300px)",
+    overflow: "auto",
+    width: 700,
+    paddingBottom: 12
+  },
   icon: {
     float: "left",
     marginTop: 14,
@@ -57,6 +64,7 @@ const styles = {
 class EditActionDialog extends Component {
   static propTypes = {
     emailId: PropTypes.number.isRequired,
+    email: emailShape,
     emailSubject: PropTypes.string,
     showDialog: PropTypes.bool.isRequired,
     handleClose: PropTypes.func.isRequired,
@@ -163,20 +171,23 @@ class EditActionDialog extends Component {
               }
             </Modal.Header>
             <Modal.Body style={styles.modalBody}>
-              {actionType === ACTION_TYPE.email && (
-                <EditEmail
-                  onChange={this.editAction}
-                  action={editMode === EDIT_MODE.update ? this.props.action : null}
-                />
-              )}
-              {actionType === ACTION_TYPE.task && (
-                <EditTask
-                  emailNumber={this.props.emailId}
-                  emailSubject={this.props.emailSubject}
-                  onChange={this.editAction}
-                  action={editMode === EDIT_MODE.update ? this.props.action : null}
-                />
-              )}
+              <div style={styles.container}>
+                <EmailContent email={this.props.email} />
+                {actionType === ACTION_TYPE.email && (
+                  <EditEmail
+                    onChange={this.editAction}
+                    action={editMode === EDIT_MODE.update ? this.props.action : null}
+                  />
+                )}
+                {actionType === ACTION_TYPE.task && (
+                  <EditTask
+                    emailNumber={this.props.emailId}
+                    emailSubject={this.props.emailSubject}
+                    onChange={this.editAction}
+                    action={editMode === EDIT_MODE.update ? this.props.action : null}
+                  />
+                )}
+              </div>
             </Modal.Body>
             <Modal.Footer>
               <div>

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -68,9 +68,7 @@ const styles = {
 
 class EditActionDialog extends Component {
   static propTypes = {
-    emailId: PropTypes.number.isRequired,
     email: emailShape,
-    emailSubject: PropTypes.string,
     showDialog: PropTypes.bool.isRequired,
     handleClose: PropTypes.func.isRequired,
     actionType: PropTypes.oneOf(Object.keys(ACTION_TYPE)).isRequired,
@@ -94,24 +92,24 @@ class EditActionDialog extends Component {
   handleSave = () => {
     this.props.handleClose();
     if (this.props.actionType === ACTION_TYPE.email && this.props.editMode === EDIT_MODE.create) {
-      this.props.addEmail(this.props.emailId, this.state.action);
-      this.props.readEmail(this.props.emailId);
+      this.props.addEmail(this.props.email.id, this.state.action);
+      this.props.readEmail(this.props.email.id);
     } else if (
       this.props.actionType === ACTION_TYPE.task &&
       this.props.editMode === EDIT_MODE.create
     ) {
-      this.props.addTask(this.props.emailId, this.state.action);
-      this.props.readEmail(this.props.emailId);
+      this.props.addTask(this.props.email.id, this.state.action);
+      this.props.readEmail(this.props.email.id);
     } else if (
       this.props.actionType === ACTION_TYPE.email &&
       this.props.editMode === EDIT_MODE.update
     ) {
-      this.props.updateEmail(this.props.emailId, this.props.actionId, this.state.action);
+      this.props.updateEmail(this.props.email.id, this.props.actionId, this.state.action);
     } else if (
       this.props.actionType === ACTION_TYPE.task &&
       this.props.editMode === EDIT_MODE.update
     ) {
-      this.props.updateTask(this.props.emailId, this.props.actionId, this.state.action);
+      this.props.updateTask(this.props.email.id, this.props.actionId, this.state.action);
     }
     this.setState({ action: {} });
   };
@@ -186,8 +184,8 @@ class EditActionDialog extends Component {
                 )}
                 {actionType === ACTION_TYPE.task && (
                   <EditTask
-                    emailNumber={this.props.emailId}
-                    emailSubject={this.props.emailSubject}
+                    emailNumber={this.props.email.id}
+                    emailSubject={this.props.email.subject}
                     onChange={this.editAction}
                     action={editMode === EDIT_MODE.update ? this.props.action : null}
                   />

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -177,10 +177,6 @@ class EditActionDialog extends Component {
             </Modal.Header>
             <Modal.Body style={styles.modalBody}>
               <div style={styles.container}>
-                <h4>Original Email</h4>
-                <div style={styles.originalEmail}>
-                  <EmailContent email={this.props.email} />
-                </div>
                 <h4>Your Response</h4>
                 {actionType === ACTION_TYPE.email && (
                   <EditEmail
@@ -196,6 +192,10 @@ class EditActionDialog extends Component {
                     action={editMode === EDIT_MODE.update ? this.props.action : null}
                   />
                 )}
+                <h4>Original Email</h4>
+                <div style={styles.originalEmail}>
+                  <EmailContent email={this.props.email} />
+                </div>
               </div>
             </Modal.Body>
             <Modal.Footer>

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -177,7 +177,7 @@ class EditActionDialog extends Component {
             </Modal.Header>
             <Modal.Body style={styles.modalBody}>
               <div style={styles.container}>
-                <h4>Your Response</h4>
+                <h4>{LOCALIZE.emibTest.inboxPage.emailCommons.yourResponse}</h4>
                 {actionType === ACTION_TYPE.email && (
                   <EditEmail
                     onChange={this.editAction}
@@ -192,7 +192,7 @@ class EditActionDialog extends Component {
                     action={editMode === EDIT_MODE.update ? this.props.action : null}
                   />
                 )}
-                <h4>Original Email</h4>
+                <h4>{LOCALIZE.emibTest.inboxPage.emailCommons.originalEmail}</h4>
                 <div style={styles.originalEmail}>
                   <EmailContent email={this.props.email} />
                 </div>

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -25,6 +25,11 @@ const styles = {
     width: 700,
     paddingBottom: 12
   },
+  originalEmail: {
+    padding: 12,
+    border: "1px #00565E solid",
+    borderRadius: 4
+  },
   icon: {
     float: "left",
     marginTop: 14,
@@ -172,7 +177,11 @@ class EditActionDialog extends Component {
             </Modal.Header>
             <Modal.Body style={styles.modalBody}>
               <div style={styles.container}>
-                <EmailContent email={this.props.email} />
+                <h4>Original Email</h4>
+                <div style={styles.originalEmail}>
+                  <EmailContent email={this.props.email} />
+                </div>
+                <h4>Your Response</h4>
                 {actionType === ACTION_TYPE.email && (
                   <EditEmail
                     onChange={this.editAction}

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -11,12 +11,6 @@ const MAX_RESPONSE = "3000";
 const MAX_REASON = "650";
 
 const styles = {
-  container: {
-    maxHeight: "calc(100vh - 300px)",
-    overflow: "auto",
-    width: 700,
-    paddingBottom: 12
-  },
   header: {
     responseTypeIcons: {
       marginRight: 10,

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -13,11 +13,6 @@ const MAX_TASK = "650";
 const MAX_REASON = "650";
 
 const styles = {
-  container: {
-    maxHeight: "calc(100vh - 297px)",
-    overflow: "auto",
-    width: 500
-  },
   header: {
     color: "#00565E",
     paddingTop: 12
@@ -126,15 +121,6 @@ class EditTask extends Component {
     return (
       <div style={styles.container}>
         <form>
-          <div>
-            <label style={styles.header}>
-              {LOCALIZE.formatString(
-                LOCALIZE.emibTest.inboxPage.addEmailTask.header,
-                emailNumber + 1,
-                emailSubject
-              )}
-            </label>
-          </div>
           <hr style={styles.hrOne} />
           <div>
             <div className="font-weight-bold form-group">

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -96,8 +96,6 @@ class EditTask extends Component {
   };
 
   static propTypes = {
-    emailNumber: PropTypes.number.isRequired,
-    emailSubject: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
     action: actionShape
   };
@@ -115,7 +113,6 @@ class EditTask extends Component {
   };
 
   render() {
-    const { emailNumber, emailSubject } = this.props;
     const { task, reasonsForAction } = this.state;
 
     return (

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -130,7 +130,14 @@ class Email extends Component {
                     key={id}
                     iconType={ICON_TYPE.email}
                     title={`Email Response #${emailNumber}`}
-                    body={<ActionViewEmail action={action} actionId={id} emailId={email.id} />}
+                    body={
+                      <ActionViewEmail
+                        action={action}
+                        actionId={id}
+                        email={email}
+                        emailId={email.id}
+                      />
+                    }
                   />
                 );
               }
@@ -148,6 +155,7 @@ class Email extends Component {
                       <ActionViewTask
                         action={action}
                         actionId={id}
+                        email={email}
                         emailId={email.id}
                         emailSubject={email.subject}
                       />

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -130,14 +130,7 @@ class Email extends Component {
                     key={id}
                     iconType={ICON_TYPE.email}
                     title={`Email Response #${emailNumber}`}
-                    body={
-                      <ActionViewEmail
-                        action={action}
-                        actionId={id}
-                        email={email}
-                        emailId={email.id}
-                      />
-                    }
+                    body={<ActionViewEmail action={action} actionId={id} email={email} />}
                   />
                 );
               }
@@ -156,7 +149,6 @@ class Email extends Component {
                         action={action}
                         actionId={id}
                         email={email}
-                        emailId={email.id}
                         emailSubject={email.subject}
                       />
                     }
@@ -168,7 +160,6 @@ class Email extends Component {
           })}
         </div>
         <EditActionDialog
-          emailId={email.id}
           email={email}
           showDialog={this.state.showAddEmailDialog}
           handleClose={this.closeEmailDialog}
@@ -176,9 +167,7 @@ class Email extends Component {
           editMode={EDIT_MODE.create}
         />
         <EditActionDialog
-          emailId={email.id}
           email={email}
-          emailSubject={email.subject}
           showDialog={this.state.showAddTaskDialog}
           handleClose={this.closeTaskDialog}
           actionType={ACTION_TYPE.task}

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -76,10 +76,6 @@ class Email extends Component {
     const emailActions = emailActionsArray[email.id];
     let emailNumber = 0;
     let taskNumber = 0;
-    //Split the body on new line characters
-    //This will allow them to be wrapped in <p></p> tags
-    // .filter(Boolean) drops empty elements
-    const bodyArray = email.body.split("\n").filter(Boolean);
     return (
       <div style={styles.email}>
         <div style={styles.header}>

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -30,7 +30,7 @@ const styles = {
     textAlign: "left",
     padding: 16
   },
-  replyAndUser: {
+  replyIcon: {
     color: "#00565E"
   },
   titleEmailDivider: {
@@ -89,7 +89,7 @@ class Email extends Component {
           </h2>
           {hasTakenAction && (
             <div className="font-weight-bold" style={styles.replyStatus}>
-              <i className="fas fa-sign-out-alt" style={styles.replyAndUser} />
+              <i className="fas fa-sign-out-alt" style={styles.replyIcon} />
               {LOCALIZE.formatString(
                 LOCALIZE.emibTest.inboxPage.yourActions,
                 emailCount,

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -8,6 +8,7 @@ import { ACTION_TYPE, EDIT_MODE, emailShape } from "./constants";
 import ActionViewEmail from "./ActionViewEmail";
 import ActionViewTask from "./ActionViewTask";
 import CollapsingItemContainer, { ICON_TYPE } from "./CollapsingItemContainer";
+import EmailContent from "./EmailContent";
 
 const styles = {
   header: {
@@ -36,11 +37,6 @@ const styles = {
     width: "100%",
     borderTop: "1px solid #00565E",
     margin: "16px 0 12px 0"
-  },
-  dataBodyDivider: {
-    width: "100%",
-    borderTop: "1px solid #96a8b2",
-    margin: "12px 0 12px 0"
   }
 };
 
@@ -126,22 +122,7 @@ class Email extends Component {
           </button>
         </div>
         <hr style={styles.titleEmailDivider} />
-        <h3>{email.subject}</h3>
-        <div>
-          {LOCALIZE.emibTest.inboxPage.from}: <span style={styles.replyAndUser}>{email.from}</span>
-        </div>
-        <div>
-          {LOCALIZE.emibTest.inboxPage.to}: <span style={styles.replyAndUser}>{email.to}</span>
-        </div>
-        <div>
-          {LOCALIZE.emibTest.inboxPage.date}: {email.date}
-        </div>
-        <hr style={styles.dataBodyDivider} />
-        <div>
-          {bodyArray.map((paragraph, key) => (
-            <p key={key}>{paragraph}</p>
-          ))}
-        </div>
+        <EmailContent email={email} />
         <div>
           {emailActions.map((action, id) => {
             // populate email responses

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -165,6 +165,7 @@ class Email extends Component {
         </div>
         <EditActionDialog
           emailId={email.id}
+          email={email}
           showDialog={this.state.showAddEmailDialog}
           handleClose={this.closeEmailDialog}
           actionType={ACTION_TYPE.email}
@@ -172,6 +173,7 @@ class Email extends Component {
         />
         <EditActionDialog
           emailId={email.id}
+          email={email}
           emailSubject={email.subject}
           showDialog={this.state.showAddTaskDialog}
           handleClose={this.closeTaskDialog}

--- a/frontend/src/components/eMIB/EmailContent.jsx
+++ b/frontend/src/components/eMIB/EmailContent.jsx
@@ -21,6 +21,9 @@ class EmailContent extends Component {
 
   render() {
     const { email } = this.props;
+    //Split the body on new line characters
+    //This will allow them to be wrapped in <p></p> tags
+    // .filter(Boolean) drops empty elements
     const bodyArray = email.body.split("\n").filter(Boolean);
     return (
       <div>

--- a/frontend/src/components/eMIB/EmailContent.jsx
+++ b/frontend/src/components/eMIB/EmailContent.jsx
@@ -1,0 +1,48 @@
+import React, { Component } from "react";
+import LOCALIZE from "../../text_resources";
+import "../../css/inbox.css";
+import { emailShape } from "./constants";
+
+const styles = {
+  replyAndUser: {
+    color: "#00565E"
+  },
+  dataBodyDivider: {
+    width: "100%",
+    borderTop: "1px solid #96a8b2",
+    margin: "12px 0 12px 0"
+  }
+};
+
+class EmailContent extends Component {
+  static propTypes = {
+    email: emailShape
+  };
+
+  render() {
+    const { email } = this.props;
+    const bodyArray = email.body.split("\n").filter(Boolean);
+    return (
+      <div>
+        <h3>{email.subject}</h3>
+        <div>
+          {LOCALIZE.emibTest.inboxPage.from}: <span style={styles.replyAndUser}>{email.from}</span>
+        </div>
+        <div>
+          {LOCALIZE.emibTest.inboxPage.to}: <span style={styles.replyAndUser}>{email.to}</span>
+        </div>
+        <div>
+          {LOCALIZE.emibTest.inboxPage.date}: {email.date}
+        </div>
+        <hr style={styles.dataBodyDivider} />
+        <div>
+          {bodyArray.map((paragraph, key) => (
+            <p key={key}>{paragraph}</p>
+          ))}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default EmailContent;

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -3,6 +3,15 @@ import { shallow, mount } from "enzyme";
 import { UnconnectedEditActionDialog as EditActionDialog } from "../../../components/eMIB/EditActionDialog";
 import { ACTION_TYPE, EDIT_MODE, EMAIL_TYPE } from "../../../components/eMIB/constants";
 
+const emailStub = {
+  id: 0,
+  to: "To 1",
+  from: "From 1",
+  subject: "hello team",
+  date: "Date 1",
+  body: "body"
+};
+
 describe("email action type", () => {
   it("renders Add Email dialog", () => {
     testCore(ACTION_TYPE.email, EDIT_MODE.create);
@@ -34,8 +43,7 @@ function testCore(actionType, editMode) {
   //shallow wrapper of the dialog
   const wrapper = shallow(
     <EditActionDialog
-      emailId={1}
-      emailSubject={"hello team"}
+      email={emailStub}
       showDialog={true}
       handleClose={() => {}}
       addEmail={addEmail}
@@ -143,8 +151,7 @@ function testMode(actionType, editMode) {
   //mount wrapper of the dialog
   const wrapper = mount(
     <EditActionDialog
-      emailId={1}
-      emailSubject={"hello team"}
+      email={emailStub}
       showDialog={true}
       handleClose={() => {}}
       addEmail={() => {}}
@@ -216,8 +223,7 @@ it("clicking on the button only adds the email once", () => {
   const handleClose = jest.fn();
   const wrapper = mount(
     <EditActionDialog
-      emailId={1}
-      emailSubject={"hello team"}
+      email={emailStub}
       showDialog={true}
       handleClose={handleClose}
       addEmail={addEmail}

--- a/frontend/src/tests/components/eMIB/Email.test.js
+++ b/frontend/src/tests/components/eMIB/Email.test.js
@@ -19,8 +19,6 @@ it("default email renders with subject as an h3", () => {
   const wrapper = shallow(
     <Email email={emailStub} emailCount={0} taskCount={0} emailActionsArray={[[]]} />
   );
-  const subject = <h3>Subject 1</h3>;
-  expect(wrapper.contains(subject)).toEqual(true);
   expect(wrapper.contains(hasAction)).toEqual(false);
 });
 
@@ -28,8 +26,6 @@ it("shows action when email count is non zero", () => {
   const wrapper = shallow(
     <Email email={emailStub} emailCount={1} taskCount={0} emailActionsArray={[[]]} />
   );
-  const subject = <h3>Subject 1</h3>;
-  expect(wrapper.contains(subject)).toEqual(true);
   expect(wrapper.contains(hasAction)).toEqual(true);
 });
 
@@ -37,8 +33,6 @@ it("shows action when task count is non zero", () => {
   const wrapper = shallow(
     <Email email={emailStub} emailCount={0} taskCount={2} emailActionsArray={[[]]} />
   );
-  const subject = <h3>Subject 1</h3>;
-  expect(wrapper.contains(subject)).toEqual(true);
   expect(wrapper.contains(hasAction)).toEqual(true);
 });
 
@@ -95,37 +89,4 @@ describe("shows as many 'CollapsingItemContainer' as there are actions", () => {
     );
     expect(wrapper.find(CollapsingItemContainer).length).toEqual(3);
   });
-});
-
-describe("email body renders the proper number of <p> tags in the body", () => {
-  it("renders only 1 <p> with a short body", () => {
-    testParagraphTags("I am a one line email", 1);
-  });
-
-  it("renders only 2 <p>'s with a single \n body", () => {
-    testParagraphTags("I am a one line\nI am the next", 2);
-  });
-
-  it("renders only 2 <p>'s with a body split by \n\n", () => {
-    testParagraphTags("I am a one line\n\nI am the next", 2);
-  });
-
-  it("renders only 4 <p>'s despite varying  \n's", () => {
-    testParagraphTags("Dear Joe\nHow are you?\n\n\n\n\n\n\nSincerely,\n\nBob", 4);
-  });
-
-  function testParagraphTags(body, expectedCount) {
-    const emailStub = {
-      id: 0,
-      to: "To 1",
-      from: "From 1",
-      subject: "Subject 1",
-      date: "Date 1",
-      body: body
-    };
-    const wrapper = shallow(
-      <Email email={emailStub} emailCount={0} taskCount={2} emailActionsArray={[[]]} />
-    );
-    expect(wrapper.find("p").length).toEqual(expectedCount);
-  }
 });

--- a/frontend/src/tests/components/eMIB/EmailContent.test.js
+++ b/frontend/src/tests/components/eMIB/EmailContent.test.js
@@ -1,0 +1,34 @@
+import React from "react";
+import { shallow } from "enzyme";
+import EmailContent from "../../../components/eMIB/EmailContent";
+
+describe("email body renders the proper number of <p> tags in the body", () => {
+  it("renders only 1 p with a short body", () => {
+    testParagraphTags("I am a one line email", 1);
+  });
+
+  it("renders only 2 p's with a single \n body", () => {
+    testParagraphTags("I am a one line\nI am the next", 2);
+  });
+
+  it("renders only 2 p's with a body split by \n\n", () => {
+    testParagraphTags("I am a one line\n\nI am the next", 2);
+  });
+
+  it("renders only 4 p's despite varying  \n's", () => {
+    testParagraphTags("Dear Joe\nHow are you?\n\n\n\n\n\n\nSincerely,\n\nBob", 4);
+  });
+
+  function testParagraphTags(body, expectedCount) {
+    const emailStub = {
+      id: 0,
+      to: "To 1",
+      from: "From 1",
+      subject: "Subject 1",
+      date: "Date 1",
+      body: body
+    };
+    const wrapper = shallow(<EmailContent email={emailStub} />);
+    expect(wrapper.find("p").length).toEqual(expectedCount);
+  }
+});

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -348,7 +348,9 @@ let LOCALIZE = new LocalizedStrings({
           replyAll: "reply all",
           forward: "forward",
           editButton: "Edit response",
-          deleteButton: "Delete response"
+          deleteButton: "Delete response",
+          originalEmail: "Original email",
+          yourResponse: "Your response"
         },
         addEmailResponse: {
           selectResponseType: "Please select how you would like to respond to the original email:",
@@ -843,7 +845,9 @@ let LOCALIZE = new LocalizedStrings({
           replyAll: "répondre à tous",
           forward: "transmettre",
           editButton: "Modifier réponse",
-          deleteButton: "Supprimer résponse"
+          deleteButton: "Supprimer résponse",
+          originalEmail: "FR Original email",
+          yourResponse: "FR Your response"
         },
         addEmailResponse: {
           selectResponseType:


### PR DESCRIPTION
# Description

Add the original email to the action dialog, so that when adding an email or task candidate has access to the email.

Paired with @MichaelCherry and @fnormand01 

## Type of change
- New feature (non-breaking change which adds functionality)

## Screenshot
![image](https://user-images.githubusercontent.com/4640747/56592895-7a7edb80-65b9-11e9-864f-233908e5d4c6.png)
![image](https://user-images.githubusercontent.com/4640747/56592913-85397080-65b9-11e9-9951-99fc19ad023f.png)


# Testing
Manual steps to reproduce this functionality:

1.  Go to the inbox.
2.  Click add email or add task and see the original email if you scroll down in the dialog.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 10+, Firefox, and Chrome
