### PR TITLE
[Disabled Components in Instructions 1] Adding disabled flag and tests

### DIFF
--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -100,7 +100,9 @@ const styles = {
 class EditEmail extends Component {
   static propTypes = {
     onChange: PropTypes.func.isRequired,
-    action: actionShape
+    action: actionShape,
+    // optional prop to disable the entire component
+    disabled: PropTypes.bool
   };
 
   state = {
@@ -165,6 +167,7 @@ class EditEmail extends Component {
     const replyAllChecked = this.state.emailType === EMAIL_TYPE.replyAll;
     const forwardChecked = this.state.emailType === EMAIL_TYPE.forward;
     const options = transformAddressBook(this.props.addressBook);
+    let isDisabled = this.props.disabled === true;
 
     return (
       <div style={styles.container}>
@@ -185,6 +188,7 @@ class EditEmail extends Component {
                     value={EMAIL_TYPE.reply}
                     checked={replyChecked}
                     className="visually-hidden"
+                    disabled={isDisabled}
                   />
                   <label
                     htmlFor="reply-radio"
@@ -214,6 +218,7 @@ class EditEmail extends Component {
                     value={EMAIL_TYPE.replyAll}
                     checked={replyAllChecked}
                     className="visually-hidden"
+                    disabled={isDisabled}
                   />
                   <label
                     htmlFor="reply-all-radio"
@@ -243,6 +248,7 @@ class EditEmail extends Component {
                     value={EMAIL_TYPE.forward}
                     checked={forwardChecked}
                     className="visually-hidden"
+                    disabled={isDisabled}
                   />
                   <label
                     htmlFor="forward-radio"
@@ -278,6 +284,7 @@ class EditEmail extends Component {
                   options={options}
                   selectedValues={emailTo}
                   onChange={this.onEmailToChange}
+                  disabled={isDisabled}
                 />
               </span>
             </div>
@@ -295,6 +302,7 @@ class EditEmail extends Component {
                   options={options}
                   selectedValues={emailCc}
                   onChange={this.onEmailCcChange}
+                  disabled={isDisabled}
                 />
               </span>
             </div>
@@ -310,6 +318,7 @@ class EditEmail extends Component {
                 style={styles.response.textArea}
                 value={emailBody}
                 onChange={this.onEmailBodyChange}
+                disabled={isDisabled}
               />
               <div style={styles.textCounter}>
                 {this.state.emailBody.length}/{MAX_RESPONSE}
@@ -328,6 +337,7 @@ class EditEmail extends Component {
                 style={styles.reasonsForAction.textArea}
                 value={reasonsForAction}
                 onChange={this.onReasonsForActionChange}
+                disabled={isDisabled}
               />
               <div style={styles.textCounter}>
                 {this.state.reasonsForAction.length}/{MAX_REASON}

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -167,7 +167,7 @@ class EditEmail extends Component {
     const replyAllChecked = this.state.emailType === EMAIL_TYPE.replyAll;
     const forwardChecked = this.state.emailType === EMAIL_TYPE.forward;
     const options = transformAddressBook(this.props.addressBook);
-    let isDisabled = this.props.disabled === true;
+    const isDisabled = this.props.disabled === true;
 
     return (
       <div style={styles.container}>

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -167,7 +167,6 @@ class EditEmail extends Component {
     const replyAllChecked = this.state.emailType === EMAIL_TYPE.replyAll;
     const forwardChecked = this.state.emailType === EMAIL_TYPE.forward;
     const options = transformAddressBook(this.props.addressBook);
-    const isDisabled = this.props.disabled === true;
 
     return (
       <div style={styles.container}>
@@ -188,7 +187,7 @@ class EditEmail extends Component {
                     value={EMAIL_TYPE.reply}
                     checked={replyChecked}
                     className="visually-hidden"
-                    disabled={isDisabled}
+                    disabled={this.props.disabled}
                   />
                   <label
                     htmlFor="reply-radio"
@@ -218,7 +217,7 @@ class EditEmail extends Component {
                     value={EMAIL_TYPE.replyAll}
                     checked={replyAllChecked}
                     className="visually-hidden"
-                    disabled={isDisabled}
+                    disabled={this.props.disabled}
                   />
                   <label
                     htmlFor="reply-all-radio"
@@ -248,7 +247,7 @@ class EditEmail extends Component {
                     value={EMAIL_TYPE.forward}
                     checked={forwardChecked}
                     className="visually-hidden"
-                    disabled={isDisabled}
+                    disabled={this.props.disabled}
                   />
                   <label
                     htmlFor="forward-radio"
@@ -284,7 +283,7 @@ class EditEmail extends Component {
                   options={options}
                   selectedValues={emailTo}
                   onChange={this.onEmailToChange}
-                  disabled={isDisabled}
+                  disabled={this.props.disabled}
                 />
               </span>
             </div>
@@ -302,7 +301,7 @@ class EditEmail extends Component {
                   options={options}
                   selectedValues={emailCc}
                   onChange={this.onEmailCcChange}
-                  disabled={isDisabled}
+                  disabled={this.props.disabled}
                 />
               </span>
             </div>
@@ -318,7 +317,7 @@ class EditEmail extends Component {
                 style={styles.response.textArea}
                 value={emailBody}
                 onChange={this.onEmailBodyChange}
-                disabled={isDisabled}
+                disabled={this.props.disabled}
               />
               <div style={styles.textCounter}>
                 {this.state.emailBody.length}/{MAX_RESPONSE}
@@ -337,7 +336,7 @@ class EditEmail extends Component {
                 style={styles.reasonsForAction.textArea}
                 value={reasonsForAction}
                 onChange={this.onReasonsForActionChange}
-                disabled={isDisabled}
+                disabled={this.props.disabled}
               />
               <div style={styles.textCounter}>
                 {this.state.reasonsForAction.length}/{MAX_REASON}

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -116,7 +116,6 @@ class EditTask extends Component {
 
   render() {
     const { task, reasonsForAction } = this.state;
-    const isDisabled = this.props.disabled === true;
 
     return (
       <div style={styles.container}>
@@ -127,7 +126,7 @@ class EditTask extends Component {
               <label htmlFor="your-tasks-text-area" style={styles.tasks.title}>
                 {LOCALIZE.emibTest.inboxPage.addEmailTask.task}
               </label>
-              {!isDisabled && (
+              {!this.props.disabled && (
                 <OverlayTrigger
                   trigger="focus"
                   placement="right"
@@ -159,7 +158,7 @@ class EditTask extends Component {
                 style={styles.tasks.textArea}
                 value={task}
                 onChange={this.onTaskContentChange}
-                disabled={isDisabled}
+                disabled={this.props.disabled}
               />
               <div style={styles.textCounter}>
                 {this.state.task.length}/{MAX_TASK}
@@ -172,7 +171,7 @@ class EditTask extends Component {
               <label htmlFor="reasons-for-action-text-area" style={styles.reasonsForAction.title}>
                 {LOCALIZE.emibTest.inboxPage.addEmailTask.reasonsForAction}
               </label>
-              {!isDisabled && (
+              {!this.props.disabled && (
                 <OverlayTrigger
                   trigger="focus"
                   placement="right"
@@ -204,7 +203,7 @@ class EditTask extends Component {
                 style={styles.reasonsForAction.textArea}
                 value={reasonsForAction}
                 onChange={this.onReasonsForActionChange}
-                disabled={isDisabled}
+                disabled={this.props.disabled}
               />
               <div style={styles.textCounter}>
                 {this.state.reasonsForAction.length}/{MAX_REASON}

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -117,7 +117,6 @@ class EditTask extends Component {
   render() {
     const { task, reasonsForAction } = this.state;
     let isDisabled = this.props.disabled === true;
-    isDisabled = true;
 
     return (
       <div style={styles.container}>
@@ -131,7 +130,6 @@ class EditTask extends Component {
               <OverlayTrigger
                 trigger="focus"
                 placement="right"
-                visibility={isDisabled ? "hidden" : "visible"}
                 overlay={
                   <Popover id="task-tooltip" style={styles.tasks.tooltipContainer}>
                     <div>
@@ -194,7 +192,6 @@ class EditTask extends Component {
                   tabIndex="0"
                   className="far fa-question-circle"
                   style={styles.reasonsForAction.icon}
-                  visibility={isDisabled ? "hidden" : "visible"}
                 />
               </OverlayTrigger>
               <textarea

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -116,7 +116,7 @@ class EditTask extends Component {
 
   render() {
     const { task, reasonsForAction } = this.state;
-    let isDisabled = this.props.disabled === true;
+    const isDisabled = this.props.disabled === true;
 
     return (
       <div style={styles.container}>

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -97,7 +97,9 @@ class EditTask extends Component {
 
   static propTypes = {
     onChange: PropTypes.func.isRequired,
-    action: actionShape
+    action: actionShape,
+    // optional prop to disable the entire component
+    disabled: PropTypes.bool
   };
 
   onTaskContentChange = event => {
@@ -114,6 +116,8 @@ class EditTask extends Component {
 
   render() {
     const { task, reasonsForAction } = this.state;
+    let isDisabled = this.props.disabled === true;
+    isDisabled = true;
 
     return (
       <div style={styles.container}>
@@ -127,6 +131,7 @@ class EditTask extends Component {
               <OverlayTrigger
                 trigger="focus"
                 placement="right"
+                visibility={isDisabled ? "hidden" : "visible"}
                 overlay={
                   <Popover id="task-tooltip" style={styles.tasks.tooltipContainer}>
                     <div>
@@ -154,6 +159,7 @@ class EditTask extends Component {
                 style={styles.tasks.textArea}
                 value={task}
                 onChange={this.onTaskContentChange}
+                disabled={isDisabled}
               />
               <div style={styles.textCounter}>
                 {this.state.task.length}/{MAX_TASK}
@@ -188,6 +194,7 @@ class EditTask extends Component {
                   tabIndex="0"
                   className="far fa-question-circle"
                   style={styles.reasonsForAction.icon}
+                  visibility={isDisabled ? "hidden" : "visible"}
                 />
               </OverlayTrigger>
               <textarea
@@ -196,6 +203,7 @@ class EditTask extends Component {
                 style={styles.reasonsForAction.textArea}
                 value={reasonsForAction}
                 onChange={this.onReasonsForActionChange}
+                disabled={isDisabled}
               />
               <div style={styles.textCounter}>
                 {this.state.reasonsForAction.length}/{MAX_REASON}

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -127,30 +127,32 @@ class EditTask extends Component {
               <label htmlFor="your-tasks-text-area" style={styles.tasks.title}>
                 {LOCALIZE.emibTest.inboxPage.addEmailTask.task}
               </label>
-              <OverlayTrigger
-                trigger="focus"
-                placement="right"
-                overlay={
-                  <Popover id="task-tooltip" style={styles.tasks.tooltipContainer}>
-                    <div>
-                      <p style={styles.tasks.tooltipContent}>
-                        {LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart1}
-                      </p>
-                      <p style={styles.tasks.tooltipContent}>
-                        {LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart2}
-                      </p>
-                    </div>
-                  </Popover>
-                }
-              >
-                <i
-                  id="task-tooltip"
-                  aria-label={LOCALIZE.ariaLabel.taskTooltip}
-                  tabIndex="0"
-                  className="far fa-question-circle"
-                  style={styles.tasks.icon}
-                />
-              </OverlayTrigger>
+              {!isDisabled && (
+                <OverlayTrigger
+                  trigger="focus"
+                  placement="right"
+                  overlay={
+                    <Popover id="task-tooltip" style={styles.tasks.tooltipContainer}>
+                      <div>
+                        <p style={styles.tasks.tooltipContent}>
+                          {LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart1}
+                        </p>
+                        <p style={styles.tasks.tooltipContent}>
+                          {LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart2}
+                        </p>
+                      </div>
+                    </Popover>
+                  }
+                >
+                  <i
+                    id="task-tooltip"
+                    aria-label={LOCALIZE.ariaLabel.taskTooltip}
+                    tabIndex="0"
+                    className="far fa-question-circle"
+                    style={styles.tasks.icon}
+                  />
+                </OverlayTrigger>
+              )}
               <textarea
                 id="your-tasks-text-area"
                 maxLength={MAX_TASK}
@@ -170,30 +172,32 @@ class EditTask extends Component {
               <label htmlFor="reasons-for-action-text-area" style={styles.reasonsForAction.title}>
                 {LOCALIZE.emibTest.inboxPage.addEmailTask.reasonsForAction}
               </label>
-              <OverlayTrigger
-                trigger="focus"
-                placement="right"
-                overlay={
-                  <Popover
+              {!isDisabled && (
+                <OverlayTrigger
+                  trigger="focus"
+                  placement="right"
+                  overlay={
+                    <Popover
+                      id="reasons-for-action-tooltip"
+                      style={styles.reasonsForAction.tooltipContainer}
+                    >
+                      <div>
+                        <p style={styles.reasonsForAction.tooltipContent}>
+                          {LOCALIZE.emibTest.inboxPage.taskContent.reasonsForActionTooltip}
+                        </p>
+                      </div>
+                    </Popover>
+                  }
+                >
+                  <i
                     id="reasons-for-action-tooltip"
-                    style={styles.reasonsForAction.tooltipContainer}
-                  >
-                    <div>
-                      <p style={styles.reasonsForAction.tooltipContent}>
-                        {LOCALIZE.emibTest.inboxPage.taskContent.reasonsForActionTooltip}
-                      </p>
-                    </div>
-                  </Popover>
-                }
-              >
-                <i
-                  id="reasons-for-action-tooltip"
-                  aria-label={LOCALIZE.ariaLabel.reasonsForActionTooltip}
-                  tabIndex="0"
-                  className="far fa-question-circle"
-                  style={styles.reasonsForAction.icon}
-                />
-              </OverlayTrigger>
+                    aria-label={LOCALIZE.ariaLabel.reasonsForActionTooltip}
+                    tabIndex="0"
+                    className="far fa-question-circle"
+                    style={styles.reasonsForAction.icon}
+                  />
+                </OverlayTrigger>
+              )}
               <textarea
                 id="reasons-for-action-text-area"
                 maxLength={MAX_REASON}

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -78,7 +78,6 @@ class Email extends Component {
     const emailActions = emailActionsArray[email.id];
     let emailNumber = 0;
     let taskNumber = 0;
-    const isDisabled = this.props.disabled === true;
 
     return (
       <div style={styles.email}>
@@ -104,7 +103,7 @@ class Email extends Component {
             type="button"
             className="btn btn-primary"
             onClick={this.showAddEmailDialog}
-            disabled={isDisabled}
+            disabled={this.props.disabled}
           >
             <i className="fas fa-envelope" />
             &emsp;
@@ -116,7 +115,7 @@ class Email extends Component {
             type="button"
             className="btn btn-primary"
             onClick={this.showAddTaskDialog}
-            disabled={isDisabled}
+            disabled={this.props.disabled}
           >
             <i className="fas fa-tasks" />
             &emsp;

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -45,6 +45,8 @@ class Email extends Component {
     email: emailShape,
     emailCount: PropTypes.number,
     taskCount: PropTypes.number,
+    // optional prop to disable the entire component
+    disabled: PropTypes.bool,
     // Provided by Redux
     emailActionsArray: PropTypes.array
   };
@@ -76,6 +78,7 @@ class Email extends Component {
     const emailActions = emailActionsArray[email.id];
     let emailNumber = 0;
     let taskNumber = 0;
+    let isDisabled = this.props.disabled === true;
     return (
       <div style={styles.email}>
         <div style={styles.header}>
@@ -100,6 +103,7 @@ class Email extends Component {
             type="button"
             className="btn btn-primary"
             onClick={this.showAddEmailDialog}
+            disabled={isDisabled}
           >
             <i className="fas fa-envelope" />
             &emsp;
@@ -111,6 +115,7 @@ class Email extends Component {
             type="button"
             className="btn btn-primary"
             onClick={this.showAddTaskDialog}
+            disabled={isDisabled}
           >
             <i className="fas fa-tasks" />
             &emsp;

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -78,7 +78,8 @@ class Email extends Component {
     const emailActions = emailActionsArray[email.id];
     let emailNumber = 0;
     let taskNumber = 0;
-    let isDisabled = this.props.disabled === true;
+    const isDisabled = this.props.disabled === true;
+
     return (
       <div style={styles.email}>
         <div style={styles.header}>

--- a/frontend/src/tests/components/eMIB/EditEmail.test.js
+++ b/frontend/src/tests/components/eMIB/EditEmail.test.js
@@ -28,13 +28,13 @@ describe("check that the disabled prop works as expected", () => {
         <EditEmail onChange={() => {}} />
       </Provider>
     );
-    expect(wrapper.find("#reply-radio").prop("disabled")).toEqual(false);
-    expect(wrapper.find("#reply-all-radio").prop("disabled")).toEqual(false);
-    expect(wrapper.find("#forward-radio").prop("disabled")).toEqual(false);
-    expect(wrapper.find("#to-field").prop("disabled")).toEqual(false);
-    expect(wrapper.find("#cc-field").prop("disabled")).toEqual(false);
-    expect(wrapper.find("#your-response-text-area").prop("disabled")).toEqual(false);
-    expect(wrapper.find("#reasons-for-action-text-area").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#reply-radio").prop("disabled")).toEqual(undefined);
+    expect(wrapper.find("#reply-all-radio").prop("disabled")).toEqual(undefined);
+    expect(wrapper.find("#forward-radio").prop("disabled")).toEqual(undefined);
+    expect(wrapper.find("#to-field").prop("disabled")).toEqual(undefined);
+    expect(wrapper.find("#cc-field").prop("disabled")).toEqual(undefined);
+    expect(wrapper.find("#your-response-text-area").prop("disabled")).toEqual(undefined);
+    expect(wrapper.find("#reasons-for-action-text-area").prop("disabled")).toEqual(undefined);
   });
 
   it("inputs are not disabled if flag is set to false", () => {

--- a/frontend/src/tests/components/eMIB/EditEmail.test.js
+++ b/frontend/src/tests/components/eMIB/EditEmail.test.js
@@ -1,0 +1,69 @@
+import React from "react";
+import { mount } from "enzyme";
+import EditEmail from "../../../components/eMIB/EditEmail";
+import configureStore from "redux-mock-store";
+import { Provider } from "react-redux";
+
+//Note: need to use mount, otherwise the radiobuttons are not found for some reason
+
+const initialState = {
+  emibInbox: {
+    addressBook: [
+      { id: 0, name: "Joe", role: "Developer" },
+      { id: 1, name: "Bob", role: "Developer" },
+      { id: 2, name: "Smithers", role: "Butler" },
+      { id: 3, name: "Arthur", role: "King of Britain" },
+      { id: 4, name: "Richard", role: "Lionheart" },
+      { id: 5, name: "Robert", role: "The Bruce" }
+    ]
+  }
+};
+
+const mockStore = configureStore();
+
+describe("check that the disabled prop works as expected", () => {
+  it("inputs are not disabled if flag is not present", () => {
+    const wrapper = mount(
+      <Provider store={mockStore(initialState)}>
+        <EditEmail onChange={() => {}} />
+      </Provider>
+    );
+    expect(wrapper.find("#reply-radio").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#reply-all-radio").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#forward-radio").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#to-field").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#cc-field").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#your-response-text-area").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#reasons-for-action-text-area").prop("disabled")).toEqual(false);
+  });
+
+  it("inputs are not disabled if flag is set to false", () => {
+    const wrapper = mount(
+      <Provider store={mockStore(initialState)}>
+        <EditEmail onChange={() => {}} disabled={false} />
+      </Provider>
+    );
+    expect(wrapper.find("#reply-radio").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#reply-all-radio").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#forward-radio").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#to-field").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#cc-field").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#your-response-text-area").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#reasons-for-action-text-area").prop("disabled")).toEqual(false);
+  });
+
+  it("inputs are disabled if flag is set to true", () => {
+    const wrapper = mount(
+      <Provider store={mockStore(initialState)}>
+        <EditEmail onChange={() => {}} disabled={true} />
+      </Provider>
+    );
+    expect(wrapper.find("#reply-radio").prop("disabled")).toEqual(true);
+    expect(wrapper.find("#reply-all-radio").prop("disabled")).toEqual(true);
+    expect(wrapper.find("#forward-radio").prop("disabled")).toEqual(true);
+    expect(wrapper.find("#to-field").prop("disabled")).toEqual(true);
+    expect(wrapper.find("#cc-field").prop("disabled")).toEqual(true);
+    expect(wrapper.find("#your-response-text-area").prop("disabled")).toEqual(true);
+    expect(wrapper.find("#reasons-for-action-text-area").prop("disabled")).toEqual(true);
+  });
+});

--- a/frontend/src/tests/components/eMIB/EditTask.test.js
+++ b/frontend/src/tests/components/eMIB/EditTask.test.js
@@ -5,8 +5,8 @@ import EditTask from "../../../components/eMIB/EditTask";
 describe("check that the disabled prop works as expected", () => {
   it("inputs are not disabled/removed if flag is not present", () => {
     const wrapper = shallow(<EditTask onChange={() => {}} />);
-    expect(wrapper.find("#your-tasks-text-area").prop("disabled")).toEqual(false);
-    expect(wrapper.find("#reasons-for-action-text-area").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#your-tasks-text-area").prop("disabled")).toEqual(undefined);
+    expect(wrapper.find("#reasons-for-action-text-area").prop("disabled")).toEqual(undefined);
     expect(wrapper.find("#task-tooltip").exists()).toEqual(true);
     expect(wrapper.find("#reasons-for-action-tooltip").exists()).toEqual(true);
   });

--- a/frontend/src/tests/components/eMIB/EditTask.test.js
+++ b/frontend/src/tests/components/eMIB/EditTask.test.js
@@ -3,21 +3,27 @@ import { shallow } from "enzyme";
 import EditTask from "../../../components/eMIB/EditTask";
 
 describe("check that the disabled prop works as expected", () => {
-  it("inputs are not disabled if flag is not present", () => {
+  it("inputs are not disabled/removed if flag is not present", () => {
     const wrapper = shallow(<EditTask onChange={() => {}} />);
     expect(wrapper.find("#your-tasks-text-area").prop("disabled")).toEqual(false);
     expect(wrapper.find("#reasons-for-action-text-area").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#task-tooltip").exists()).toEqual(true);
+    expect(wrapper.find("#reasons-for-action-tooltip").exists()).toEqual(true);
   });
 
-  it("inputs are not disabled if flag is set to false", () => {
+  it("inputs are not disabled/removed if flag is set to false", () => {
     const wrapper = shallow(<EditTask onChange={() => {}} disabled={false} />);
     expect(wrapper.find("#your-tasks-text-area").prop("disabled")).toEqual(false);
     expect(wrapper.find("#reasons-for-action-text-area").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#task-tooltip").exists()).toEqual(true);
+    expect(wrapper.find("#reasons-for-action-tooltip").exists()).toEqual(true);
   });
 
-  it("inputs are disabled if flag is set to true", () => {
+  it("inputs are disabled/removed if flag is set to true", () => {
     const wrapper = shallow(<EditTask onChange={() => {}} disabled={true} />);
     expect(wrapper.find("#your-tasks-text-area").prop("disabled")).toEqual(true);
     expect(wrapper.find("#reasons-for-action-text-area").prop("disabled")).toEqual(true);
+    expect(wrapper.find("#task-tooltip").exists()).toEqual(false);
+    expect(wrapper.find("#reasons-for-action-tooltip").exists()).toEqual(false);
   });
 });

--- a/frontend/src/tests/components/eMIB/EditTask.test.js
+++ b/frontend/src/tests/components/eMIB/EditTask.test.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { shallow } from "enzyme";
+import EditTask from "../../../components/eMIB/EditTask";
+
+describe("check that the disabled prop works as expected", () => {
+  it("inputs are not disabled if flag is not present", () => {
+    const wrapper = shallow(<EditTask onChange={() => {}} />);
+    expect(wrapper.find("#your-tasks-text-area").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#reasons-for-action-text-area").prop("disabled")).toEqual(false);
+  });
+
+  it("inputs are not disabled if flag is set to false", () => {
+    const wrapper = shallow(<EditTask onChange={() => {}} disabled={false} />);
+    expect(wrapper.find("#your-tasks-text-area").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#reasons-for-action-text-area").prop("disabled")).toEqual(false);
+  });
+
+  it("inputs are disabled if flag is set to true", () => {
+    const wrapper = shallow(<EditTask onChange={() => {}} disabled={true} />);
+    expect(wrapper.find("#your-tasks-text-area").prop("disabled")).toEqual(true);
+    expect(wrapper.find("#reasons-for-action-text-area").prop("disabled")).toEqual(true);
+  });
+});

--- a/frontend/src/tests/components/eMIB/Email.test.js
+++ b/frontend/src/tests/components/eMIB/Email.test.js
@@ -96,8 +96,8 @@ describe("check that the disabled prop works as expected", () => {
     const wrapper = shallow(
       <Email email={emailStub} emailCount={0} taskCount={0} emailActionsArray={[[]]} />
     );
-    expect(wrapper.find("#unit-test-email-reply-button").prop("disabled")).toEqual(false);
-    expect(wrapper.find("#unit-test-email-task-button").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#unit-test-email-reply-button").prop("disabled")).toEqual(undefined);
+    expect(wrapper.find("#unit-test-email-task-button").prop("disabled")).toEqual(undefined);
   });
 
   it("buttons are not disabled if flag is set to false", () => {

--- a/frontend/src/tests/components/eMIB/Email.test.js
+++ b/frontend/src/tests/components/eMIB/Email.test.js
@@ -90,3 +90,41 @@ describe("shows as many 'CollapsingItemContainer' as there are actions", () => {
     expect(wrapper.find(CollapsingItemContainer).length).toEqual(3);
   });
 });
+
+describe("check that the disabled prop works as expected", () => {
+  it("buttons are not disabled if flag is not present", () => {
+    const wrapper = shallow(
+      <Email email={emailStub} emailCount={0} taskCount={0} emailActionsArray={[[]]} />
+    );
+    expect(wrapper.find("#unit-test-email-reply-button").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#unit-test-email-task-button").prop("disabled")).toEqual(false);
+  });
+
+  it("buttons are not disabled if flag is set to false", () => {
+    const wrapper = shallow(
+      <Email
+        email={emailStub}
+        emailCount={0}
+        taskCount={0}
+        emailActionsArray={[[]]}
+        disabled={false}
+      />
+    );
+    expect(wrapper.find("#unit-test-email-reply-button").prop("disabled")).toEqual(false);
+    expect(wrapper.find("#unit-test-email-task-button").prop("disabled")).toEqual(false);
+  });
+
+  it("buttons are disabled if flag is set to true", () => {
+    const wrapper = shallow(
+      <Email
+        email={emailStub}
+        emailCount={0}
+        taskCount={0}
+        emailActionsArray={[[]]}
+        disabled={true}
+      />
+    );
+    expect(wrapper.find("#unit-test-email-reply-button").prop("disabled")).toEqual(true);
+    expect(wrapper.find("#unit-test-email-task-button").prop("disabled")).toEqual(true);
+  });
+});


### PR DESCRIPTION
# Description

Added disabled props to Email, EditEmail, and EditTask
Elements are disabled or removed when the flag is set to true
Also added tests to ensure that this functionality remains.

## Type of change

- New feature (non-breaking change which adds functionality)
- Code cleanliness or refactor

## Screenshot

Screen shots were taken within the existing Inbox elements (by locally switching on isDisabled), but will look a little different in Instructions

Disabled Email:
![image](https://user-images.githubusercontent.com/2746350/56672819-14f82100-6685-11e9-9355-3a7f7991d2fe.png)

Disabled EditEmail:
![image](https://user-images.githubusercontent.com/2746350/56672968-5dafda00-6685-11e9-813f-22219d760c0c.png)

Disabled EditTask:
![image](https://user-images.githubusercontent.com/2746350/56672993-6dc7b980-6685-11e9-8c90-63afe62ba721.png)

# Testing

Applicable for all code changes.

Currently there is no way to test this functionality without adding one of these components and disabling it. These disabled components will be added to instructions in a future PR that will be merged into this one before merging into master

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
