### PR TITLE
[Task Tooltips] Added states to control the tooltip icons

### DIFF
--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -92,7 +92,9 @@ const styles = {
 class EditTask extends Component {
   state = {
     task: !this.props.action ? "" : this.props.action.task,
-    reasonsForAction: !this.props.action ? "" : this.props.action.reasonsForAction
+    taskTooltipIcon: "far fa-question-circle",
+    reasonsForAction: !this.props.action ? "" : this.props.action.reasonsForAction,
+    reasonsForActionTooltipIcon: "far fa-question-circle"
   };
 
   static propTypes = {
@@ -112,8 +114,24 @@ class EditTask extends Component {
     this.props.onChange({ ...this.state, reasonsForAction: newReasonForAction });
   };
 
+  onTaskTooltipFocus = () => {
+    this.setState({ taskTooltipIcon: "fas fa-question-circle" });
+  };
+
+  onTaskTooltipBlur = () => {
+    this.setState({ taskTooltipIcon: "far fa-question-circle" });
+  };
+
+  onReasonsForActionTooltipFocus = () => {
+    this.setState({ reasonsForActionTooltipIcon: "fas fa-question-circle" });
+  };
+
+  onReasonsForActionTooltipBlur = () => {
+    this.setState({ reasonsForActionTooltipIcon: "far fa-question-circle" });
+  };
+
   render() {
-    const { task, reasonsForAction } = this.state;
+    const { task, taskTooltipIcon, reasonsForAction, reasonsForActionTooltipIcon } = this.state;
 
     return (
       <div style={styles.container}>
@@ -144,8 +162,10 @@ class EditTask extends Component {
                   id="task-tooltip"
                   aria-label={LOCALIZE.ariaLabel.taskTooltip}
                   tabIndex="0"
-                  className="far fa-question-circle"
+                  className={taskTooltipIcon}
                   style={styles.tasks.icon}
+                  onFocus={this.onTaskTooltipFocus}
+                  onBlur={this.onTaskTooltipBlur}
                 />
               </OverlayTrigger>
               <textarea
@@ -186,8 +206,10 @@ class EditTask extends Component {
                   id="reasons-for-action-tooltip"
                   aria-label={LOCALIZE.ariaLabel.reasonsForActionTooltip}
                   tabIndex="0"
-                  className="far fa-question-circle"
+                  className={reasonsForActionTooltipIcon}
                   style={styles.reasonsForAction.icon}
+                  onFocus={this.onReasonsForActionTooltipFocus}
+                  onBlur={this.onReasonsForActionTooltipBlur}
                 />
               </OverlayTrigger>
               <textarea


### PR DESCRIPTION
# Description

I added two states (_taskTooltipIcon_ and _reasonsForActionTooltipIcon_) in order to control the tooltip icon to display according to the tooltip focus.

## Type of change

- Code cleanliness or refactor

## Screenshot

**Task Tooltip Focused:**

![image](https://user-images.githubusercontent.com/23021242/56681526-7cb76780-6697-11e9-97fd-3587041d2049.png)

**Reasons For Action Tooltip Focused:**

![image](https://user-images.githubusercontent.com/23021242/56681558-922c9180-6697-11e9-909b-4a74ecf1d40f.png)

**Both Tooltip Icons are not Focused:**

![image](https://user-images.githubusercontent.com/23021242/56681496-67dad400-6697-11e9-8c74-503a21343004.png)

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB Sample Test.
2.  Complete the pre-test process.
3.  Open the _Inbox_ tab.
4.  Click on _Create a task_.
5.  Click on the tooltip icons and make sure that the icons are changing as expected.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 11+ and Chrome
