### PR TITLE
[Inbox - Email Actions] Auto Scroll Down to Added Actions

### DIFF
--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -40,6 +40,9 @@ const styles = {
   }
 };
 
+// used to allow or prevent focusing on action-views div (see componentWillUpdate() function)
+let TABINDEX = "-1";
+
 class Email extends Component {
   static propTypes = {
     email: emailShape,
@@ -71,9 +74,21 @@ class Email extends Component {
   };
 
   componentWillUpdate = () => {
-    // removes the focus from the action buttons
-    document.getElementById("unit-test-email-reply-button").blur();
-    document.getElementById("unit-test-email-task-button").blur();
+    // focusing on the action view items depending on the existing state
+    const actionItem = document.getElementById("action-views");
+    // there is no action item created yet
+    if (actionItem === null) {
+      // allowing focus to the action-view div
+      TABINDEX = "0";
+      // focusing on it
+      actionItem.focus();
+      // preventing focus to the action-view div
+      TABINDEX = "-1";
+      // there is at least one action item
+    } else {
+      // simply focus on it
+      actionItem.focus();
+    }
   };
 
   componentDidUpdate = () => {
@@ -131,7 +146,7 @@ class Email extends Component {
         </div>
         <hr style={styles.titleEmailDivider} />
         <EmailContent email={email} />
-        <div id="action-views">
+        <div id="action-views" tabIndex={TABINDEX}>
           {emailActions.map((action, id) => {
             // populate email responses
             for (let i = 0; i < emailCount; i++) {

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -57,6 +57,11 @@ class Email extends Component {
     showAddTaskDialog: false
   };
 
+  constructor(props) {
+    super(props);
+    this.actionViewsRef = React.createRef();
+  }
+
   showAddEmailDialog = () => {
     this.setState({ showAddEmailDialog: true });
   };
@@ -75,7 +80,7 @@ class Email extends Component {
 
   componentWillUpdate = () => {
     // focusing on the action view items depending on the existing state
-    const actionItem = document.getElementById("action-views");
+    const actionItem = this.actionViewsRef.current;
     // there is no action item created yet
     if (actionItem === null) {
       // allowing focus to the action-view div
@@ -93,7 +98,7 @@ class Email extends Component {
 
   componentDidUpdate = () => {
     // scroll to bottom of the page
-    const elmnt = document.getElementById("action-views");
+    const elmnt = this.actionViewsRef.current;
     elmnt.scrollIntoView();
   };
 
@@ -146,7 +151,7 @@ class Email extends Component {
         </div>
         <hr style={styles.titleEmailDivider} />
         <EmailContent email={email} />
-        <div id="action-views" tabIndex={TABINDEX}>
+        <div ref={this.actionViewsRef} tabIndex={TABINDEX}>
           {emailActions.map((action, id) => {
             // populate email responses
             for (let i = 0; i < emailCount; i++) {

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -70,6 +70,18 @@ class Email extends Component {
     this.setState({ showAddTaskDialog: false });
   };
 
+  componentWillUpdate = () => {
+    // removes the focus from the action buttons
+    document.getElementById("unit-test-email-reply-button").blur();
+    document.getElementById("unit-test-email-task-button").blur();
+  };
+
+  componentDidUpdate = () => {
+    // scroll to bottom of the page
+    const elmnt = document.getElementById("action-views");
+    elmnt.scrollIntoView();
+  };
+
   render() {
     const { email, emailCount, taskCount, emailActionsArray } = this.props;
     const hasTakenAction = emailCount + taskCount > 0;
@@ -119,7 +131,7 @@ class Email extends Component {
         </div>
         <hr style={styles.titleEmailDivider} />
         <EmailContent email={email} />
-        <div>
+        <div id="action-views">
           {emailActions.map((action, id) => {
             // populate email responses
             for (let i = 0; i < emailCount; i++) {


### PR DESCRIPTION
# Description

I added two new functions to auto scroll down at the bottom of the inbox window when creating new email actions (email response and task).

After creating a new email action, the next _Tab Key Entry_ will bring you to the first action view item at the bottom of the page.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**Creating a new email action (task for example):**

![image](https://user-images.githubusercontent.com/23021242/56743547-c01bdf80-6744-11e9-95a0-68d664bb10a5.png)

![image](https://user-images.githubusercontent.com/23021242/56743583-d1fd8280-6744-11e9-858e-fd3f20e235a2.png)

**After hitting _Save_ button, it brings you here:**

![image](https://user-images.githubusercontent.com/23021242/56743623-eb9eca00-6744-11e9-8e11-a43d1276997a.png)

**After the next _Tab Key Entry_:**

![image](https://user-images.githubusercontent.com/23021242/56743695-10933d00-6745-11e9-9f8d-694afdae3d0c.png)

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB Sample Test.
2.  Complete the pre-instruction process.
3.  Open the _Inbox_ tab.
4.  Create a new **Email Action** (email response or task).
5.  When you hit **Save**, make sure it brings you at the bottom of the page.
6.  Make also sure that the next _Tab Key Entry_ focuses on the first action view item.

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 11+ and Chrome
