### PR TITLE
[Accessibility] Remove numbers for h headings

### DIFF
--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -152,14 +152,14 @@ let LOCALIZE = new LocalizedStrings({
             description:
               "You can respond to the emails you receive in two ways: by sending an email or by adding tasks to your task list. A description of both methods of responding is presented below, followed by examples.",
             part1: {
-              title: "1. Sending an email",
+              title: "Sending an email",
               para1:
                 "You can send an email in response to one you received in your inbox. The written responses should reflect how you would respond as a manager.",
               para2:
                 "You can send an email using the following options: reply, reply all, forward, or write a new email. If you choose to write a new email, you will have access to a directory with all of your contacts. You can write as many emails as you like in response to an email you received."
             },
             part2: {
-              title: "2. Adding a task to the task list",
+              title: "Adding a task to the task list",
               para1:
                 "In addition to, or instead of, responding to an email you can add a task to the task list. A task is an action that you intend to take to address a situation presented in the emails. Example tasks could include planning a meeting or asking a colleague for information. You should provide enough information in your task description to ensure it is clear which situation you are addressing. You should also specify what actions you plan to take, and with whom. You can add, delete, or edit tasks on the task list."
             },
@@ -645,14 +645,14 @@ let LOCALIZE = new LocalizedStrings({
             description:
               "Vous pouvez répondre aux courriels que vous avez reçus de deux façons : en envoyant un courriel ou en ajoutant une tâche à votre liste de tâches. Les deux méthodes de réponse sont décrites ci-dessous, suivies d’exemples.",
             part1: {
-              title: "1. Envoyer un courriel",
+              title: "Envoyer un courriel",
               para1:
                 "Vous pouvez envoyer un courriel pour répondre à celui que vous avez reçu dans votre boîte de réception. Vos réponses écrites devraient représenter ce que vous feriez en tant que gestionnaire.",
               para2:
                 "Vous pouvez envoyer un courriel en utilisant les fonctions suivantes : répondre, répondre à tous, transférer ou rédiger un nouveau courriel. Si vous choisissez de rédiger un nouveau courriel, vous aurez accès à un répertoire de noms et d’adresses de courriel. Vous pouvez écrire autant de courriels que vous le souhaitez pour répondre à un courriel que vous avez reçu."
             },
             part2: {
-              title: "2. Ajouter une tâche à la liste de tâches",
+              title: "Ajouter une tâche à la liste de tâches",
               para1:
                 "En plus de répondre à un courriel, ou au lieu d’y répondre, vous pouvez ajouter des tâches à la liste de tâches. Une tâche représente une mesure que vous comptez prendre pour gérer une situation présentée dans les courriels. Voici des exemples de tâches : planifier une rencontre ou communiquer avec un collègue afin d’obtenir de l’information. Assurez-vous de fournir suffisamment d’information dans votre description de la tâche pour que nous sachions à quelle situation vous répondez. Vous devez également préciser quelles mesures vous envisagez prendre et qui devra participer à cette tâche. Vous pouvez ajouter, supprimer ou modifier vos tâches dans la liste des tâches."
             },


### PR DESCRIPTION
# Description

Putting numbers in headings is confusing when you hear it from a screen reader. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

<img width="827" alt="Screen Shot 2019-04-25 at 11 52 07 AM" src="https://user-images.githubusercontent.com/4640747/56749885-98cb0f80-6750-11e9-9c3d-5ef42681cce4.png">


# Testing
Manual steps to reproduce this functionality:

1.  Go to test instructions.

# Checklist - N/A text change only.

