### PR TITLE
[Accessibility] Remove unnecessary warnings from dialogs

### DIFF
--- a/frontend/src/components/commons/ConfirmStartTest.jsx
+++ b/frontend/src/components/commons/ConfirmStartTest.jsx
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
 import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
-import SystemMessage, { MESSAGE_TYPE } from "../commons/SystemMessage";
 
 class ConfirmStartTest extends Component {
   static propTypes = {
@@ -20,13 +19,7 @@ class ConfirmStartTest extends Component {
           title={LOCALIZE.commons.confirmStartTest.aboutToStart}
           description={
             <div>
-              <div>
-                <SystemMessage
-                  messageType={MESSAGE_TYPE.warning}
-                  title={LOCALIZE.commons.confirmStartTest.timedTest}
-                  message={LOCALIZE.commons.confirmStartTest.timerWarning}
-                />
-              </div>
+              <p>{LOCALIZE.commons.confirmStartTest.timerWarning}</p>
               <p>{LOCALIZE.commons.confirmStartTest.instructionsAccess}</p>
             </div>
           }

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -179,14 +179,8 @@ class Emib extends Component {
           title={LOCALIZE.emibTest.testFooter.submitTestPopupBox.title}
           description={
             <div>
-              <div>
-                <SystemMessage
-                  messageType={MESSAGE_TYPE.warning}
-                  title={LOCALIZE.emibTest.testFooter.submitTestPopupBox.warning.title}
-                  message={LOCALIZE.emibTest.testFooter.submitTestPopupBox.warning.message}
-                />
-              </div>
-              <div>{LOCALIZE.emibTest.testFooter.submitTestPopupBox.description}</div>
+              <p>{LOCALIZE.emibTest.testFooter.submitTestPopupBox.warning.message}</p>
+              <p>{LOCALIZE.emibTest.testFooter.submitTestPopupBox.description}</p>
             </div>
           }
           leftButtonType={BUTTON_TYPE.secondary}

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -464,7 +464,6 @@ let LOCALIZE = new LocalizedStrings({
       startTest: "Start test",
       confirmStartTest: {
         aboutToStart: "You are about to start the test.",
-        timedTest: "This is a timed test.",
         timerWarning:
           "Once you start the timer will begin, and you can only leave the test by submitting or quitting.",
         instructionsAccess:
@@ -963,7 +962,6 @@ let LOCALIZE = new LocalizedStrings({
       startTest: "Commencer le test",
       confirmStartTest: {
         aboutToStart: "FR You are about to start the test.",
-        timedTest: "FR This is a timed test.",
         timerWarning:
           "FR Once you start the timer will begin, and you can only leave the test by submitting or quitting.",
         instructionsAccess:

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -411,7 +411,6 @@ let LOCALIZE = new LocalizedStrings({
         submitTestPopupBox: {
           title: "Confirm test submission?",
           warning: {
-            title: "Warning! The notepad will not be saved.",
             message:
               "Anything written in the notepad will not be submitted with the test for scoring. Ensure that you have reviewed all of your responses before submitting the test as you will not be able to go back to make changes."
           },
@@ -421,7 +420,6 @@ let LOCALIZE = new LocalizedStrings({
         quitTestPopupBox: {
           title: "Are you sure you want to quit this test?",
           warning: {
-            title: "Warning! Once you exit the test, you will not be able to get back in.",
             message:
               "You will not be able to recover your answers, and will be withdrawn from this test session. You may be retested at a later time."
           },


### PR DESCRIPTION
# Description

Remove unnecessary warnings from dialogs, in particular the start test and the submit test. I've added the content to the dialogs in paragraphs. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

<img width="670" alt="Screen Shot 2019-04-25 at 12 09 25 PM" src="https://user-images.githubusercontent.com/4640747/56751024-06783b00-6753-11e9-958b-6f31231e027c.png">
<img width="668" alt="Screen Shot 2019-04-25 at 12 09 35 PM" src="https://user-images.githubusercontent.com/4640747/56751025-06783b00-6753-11e9-8365-348399936a74.png">

# Testing


Manual steps to reproduce this functionality:

1.  Start the test.
2.  Submit the test.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 11+ and Chrome
