### PR TITLE
Setup server-ready version of application with Docker

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -25,4 +25,4 @@ ENV ENVIRONMENT="dev"
 
 EXPOSE 8000
 
-ENTRYPOINT ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+ENTRYPOINT ["sh", "entrypoint.sh"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,28 @@
+# Pull base image from https://hub.docker.com/_/python/
+FROM nikolaik/python-nodejs:python3.6-nodejs10
+
+# Set environment varibles
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# Add Backend
+ADD ./backend /backend/
+WORKDIR /backend
+RUN pip install -r requirements.txt
+
+# Add frontend 
+ADD ./frontend /frontend/
+WORKDIR /frontend
+# Build production-ready frontend and serve it through Django
+RUN npm install && npm run build 
+RUN cp -r build /backend/backend/static
+# Remove un-built frontend
+RUN rm -rf /frontend
+
+WORKDIR /backend
+
+ENV ENVIRONMENT="dev"
+
+EXPOSE 8000
+
+ENTRYPOINT ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -79,15 +79,32 @@ WSGI_APPLICATION = 'backend.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'postgres',
-        'USER': 'postgres',
-        'HOST': 'db', # set in docker-compose.yml
-        'PORT': 5432 # default postgres port
+# Dev/Production servers will use environment variables injected at runtime
+# to connect to a static PostgreSQL Database.
+DATABASES = {}
+if os.environ.get('ENVIRONMENT') == 'dev':
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'NAME': os.environ.get('DATABASE_NAME', ''),
+            'USER': os.environ.get('DATABASE_USER', ''),
+            'PASSWORD': os.environ.get('DATABASE_PASSWORD', ''),
+            'HOST': os.environ.get('DATABASE_HOST', ''),
+            'PORT': os.environ.get('DATABASE_PORT', ''),
+        }
     }
-}
+else:
+    # Local development will use a virtual databse setup in Docker-compose
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': 'postgres',
+            'USER': 'postgres', 
+            'HOST': 'db', # set in docker-compose.yml
+            'PORT': 5432 # default postgres port
+        }
+    }
+
 
 
 # Password validation

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,5 +1,4 @@
 #!bin/bash
-pip install -r requirements.txt
-python manage.py makemigrations backend
-python manage.py migrate backend
+python manage.py makemigrations
+python manage.py migrate
 python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
This does 2 important things for our server setup:
 - Creates a "production-ready" version of a docker file to be used on dev (but can also be used on test, prod, etc) instead of serving the JS in a node container.
 - Sets up environment variables to manage "secret" information about the static PostgreSQL database, and defaults the dev database to what we have today. These variables will be injected to the docker containers at runtime via Azure -> App Service -> Application Settings.

## Database setup
The database locally will remain virtual locally so that developers can manage their own migrations and experiment with changes in a safe environment. 

Each server environment will have environment variables (stored in Azure), that set the respective database. (See `settings.py` change) This is important because all of these are kept secret and out of GitHub. I have a screenshot of how to set these if needed.

Once a [PostgreSQL static DB](https://azure.microsoft.com/en-ca/services/postgresql/) is configured in Azure, it will provide each of those settings that need to be added as environment variables. [More Python+PostgreSQL+Azure Docs](https://docs.microsoft.com/en-us/azure/app-service/containers/tutorial-python-postgresql-app).

## Dockerfile + deploying
The local setup stays as-is and is based off of [this tutorial](https://blog.bam.tech/developper-news/dockerize-your-app-and-keep-hot-reloading) to ensure hot-reloading of the react application and a local virtual database.

The server version is based off of this [HackerNoon article](https://hackernoon.com/serving-react-and-django-together-2089645046e4) which adds our React application to the static folder within the Django application. This makes sense given the scale of users taking the eMIB and the simplicity.

To deploy, our code will get pulled from GitHub, the Dockerfile.dev will get run through Azure, an image will be pushed to the registry, and Azure will deploy the latest image. https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/docker?view=azure-devops

## Diagrams

Local - same as now.
![image](https://user-images.githubusercontent.com/4640747/56762701-7647ef00-676e-11e9-8ef7-79fa7dea54f9.png)

Server.
![server](https://user-images.githubusercontent.com/4640747/56762969-27e72000-676f-11e9-99ad-70d529a20acf.png)
