### PR TITLE
[eMIB Tabs] Added disabled functionality to Tab component

### DIFF
--- a/frontend/src/components/commons/Tab.jsx
+++ b/frontend/src/components/commons/Tab.jsx
@@ -45,7 +45,7 @@ class Tab extends Component {
       <span>
         {!this.props.disabled && (
           <span>
-            {this.props.selected === false && (
+            {!this.props.selected && (
               <li role="menuitem" style={styles.li}>
                 <button
                   id="unit-test-unselected-tab-button"
@@ -56,7 +56,7 @@ class Tab extends Component {
                 </button>
               </li>
             )}
-            {this.props.selected === true && (
+            {this.props.selected && (
               <li role="menuitem" style={styles.li} aria-current="page">
                 <button
                   id="unit-test-selected-tab-button"

--- a/frontend/src/components/commons/Tab.jsx
+++ b/frontend/src/components/commons/Tab.jsx
@@ -15,13 +15,9 @@ const styles = {
   },
   disabledButton: {
     color: "white",
-    position: "relative",
-    display: "block",
-    padding: "10px 15px",
     backgroundColor: "#8A8A8A",
-    marginRight: "2px",
     border: "none",
-    borderRadius: "4px 4px 0 0",
+    lineHeight: "none",
     marginBottom: 1
   },
   active: {
@@ -74,7 +70,7 @@ class Tab extends Component {
             <button
               id="unit-test-disabled-tab-button"
               disabled={true}
-              style={styles.disabledButton}
+              style={{ ...styles.button, ...styles.disabledButton }}
               className="side-navigation-button"
             >
               {this.props.tabName}

--- a/frontend/src/components/commons/Tab.jsx
+++ b/frontend/src/components/commons/Tab.jsx
@@ -13,6 +13,18 @@ const styles = {
     border: "1px solid transparent",
     borderRadius: "4px 4px 0 0"
   },
+  disabledButton: {
+    color: "white",
+    position: "relative",
+    display: "block",
+    padding: "10px 15px",
+    backgroundColor: "#8A8A8A",
+    marginRight: "2px",
+    lineHeight: "1.42857143",
+    border: "none",
+    borderRadius: "4px 4px 0 0",
+    marginBottom: 1
+  },
   active: {
     color: "black",
     backgroundColor: "white",
@@ -24,23 +36,39 @@ const styles = {
 class Tab extends Component {
   static propTypes = {
     tabName: PropTypes.string.isRequired,
-    selected: PropTypes.bool.isRequired
+    selected: PropTypes.bool.isRequired,
+    disabled: PropTypes.bool
   };
 
   render() {
     return (
       <span>
-        {this.props.selected === false && (
-          <li role="menuitem" style={styles.li}>
-            <button style={styles.button} className="side-navigation-button">
-              {this.props.tabName}
-            </button>
-          </li>
+        {!this.props.disabled && (
+          <span>
+            {this.props.selected === false && (
+              <li role="menuitem" style={styles.li}>
+                <button style={styles.button} className="side-navigation-button">
+                  {this.props.tabName}
+                </button>
+              </li>
+            )}
+            {this.props.selected === true && (
+              <li role="menuitem" style={styles.li} aria-current="page">
+                <button
+                  style={{ ...styles.button, ...styles.active }}
+                  className="side-navigation-button"
+                >
+                  {this.props.tabName}
+                </button>
+              </li>
+            )}
+          </span>
         )}
-        {this.props.selected === true && (
-          <li role="menuitem" style={styles.li} aria-current="page">
+        {this.props.disabled && (
+          <li role="menuitem" style={styles.li}>
             <button
-              style={{ ...styles.button, ...styles.active }}
+              disabled={true}
+              style={styles.disabledButton}
               className="side-navigation-button"
             >
               {this.props.tabName}

--- a/frontend/src/components/commons/Tab.jsx
+++ b/frontend/src/components/commons/Tab.jsx
@@ -47,7 +47,11 @@ class Tab extends Component {
           <span>
             {this.props.selected === false && (
               <li role="menuitem" style={styles.li}>
-                <button style={styles.button} className="side-navigation-button">
+                <button
+                  id="unit-test-unselected-tab-button"
+                  style={styles.button}
+                  className="side-navigation-button"
+                >
                   {this.props.tabName}
                 </button>
               </li>
@@ -55,6 +59,7 @@ class Tab extends Component {
             {this.props.selected === true && (
               <li role="menuitem" style={styles.li} aria-current="page">
                 <button
+                  id="unit-test-selected-tab-button"
                   style={{ ...styles.button, ...styles.active }}
                   className="side-navigation-button"
                 >
@@ -67,6 +72,7 @@ class Tab extends Component {
         {this.props.disabled && (
           <li role="menuitem" style={styles.li}>
             <button
+              id="unit-test-disabled-tab-button"
               disabled={true}
               style={styles.disabledButton}
               className="side-navigation-button"

--- a/frontend/src/components/commons/Tab.jsx
+++ b/frontend/src/components/commons/Tab.jsx
@@ -20,7 +20,6 @@ const styles = {
     padding: "10px 15px",
     backgroundColor: "#8A8A8A",
     marginRight: "2px",
-    lineHeight: "1.42857143",
     border: "none",
     borderRadius: "4px 4px 0 0",
     marginBottom: 1

--- a/frontend/src/components/commons/Tab.jsx
+++ b/frontend/src/components/commons/Tab.jsx
@@ -37,6 +37,7 @@ class Tab extends Component {
   static propTypes = {
     tabName: PropTypes.string.isRequired,
     selected: PropTypes.bool.isRequired,
+    // use this prop to disable the tab
     disabled: PropTypes.bool
   };
 

--- a/frontend/src/tests/components/commons/Tab.test.js
+++ b/frontend/src/tests/components/commons/Tab.test.js
@@ -1,31 +1,52 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
 import Tab, { styles } from "../../../components/commons/Tab";
 
-it("renders selected tab", () => {
-  const wrapper = shallow(<Tab tabName="Tab1" selected={true} />);
-  const initialMessage = (
-    <span>
-      <li role="menuitem" style={styles.li} aria-current="page">
-        <button style={{ ...styles.button, ...styles.active }} className="side-navigation-button">
-          Tab1
-        </button>
-      </li>
-    </span>
-  );
-  expect(wrapper.contains(initialMessage)).toEqual(true);
+describe("renders selected and unselected tabs", () => {
+  it("renders selected tab", () => {
+    const wrapper = shallow(<Tab tabName="Tab1" selected={true} />);
+    const initialMessage = (
+      <span>
+        <li style={styles.li}>
+          <button style={{ ...styles.button, ...styles.active }}>Tab1</button>
+        </li>
+      </span>
+    );
+    expect(wrapper.containsMatchingElement(initialMessage)).toEqual(true);
+  });
+
+  it("renders unselected tab", () => {
+    const wrapper = shallow(<Tab tabName="Tab2" selected={false} />);
+    const initialMessage = (
+      <span>
+        <li style={styles.li}>
+          <button style={styles.button}>Tab2</button>
+        </li>
+      </span>
+    );
+    expect(wrapper.containsMatchingElement(initialMessage)).toEqual(true);
+  });
 });
 
-it("renders unselected tab", () => {
-  const wrapper = shallow(<Tab tabName="Tab2" selected={false} />);
-  const initialMessage = (
-    <span>
-      <li role="menuitem" style={styles.li}>
-        <button style={styles.button} className="side-navigation-button">
-          Tab2
-        </button>
-      </li>
-    </span>
-  );
-  expect(wrapper.contains(initialMessage)).toEqual(true);
+describe("check that the disabled prop works as expected", () => {
+  it("tab is not disabled if flag is not present", () => {
+    const wrapper = mount(<Tab tabName="Tab1" selected={true} />);
+    expect(wrapper.find("#unit-test-selected-tab-button").exists()).toEqual(true);
+    expect(wrapper.find("#unit-test-unselected-tab-button").exists()).toEqual(false);
+    expect(wrapper.find("#unit-test-disabled-tab-button").exists()).toEqual(false);
+  });
+
+  it("tab is not disabled if flag is set to false", () => {
+    const wrapper = mount(<Tab tabName="Tab1" selected={true} disabled={false} />);
+    expect(wrapper.find("#unit-test-selected-tab-button").exists()).toEqual(true);
+    expect(wrapper.find("#unit-test-unselected-tab-button").exists()).toEqual(false);
+    expect(wrapper.find("#unit-test-disabled-tab-button").exists()).toEqual(false);
+  });
+
+  it("tab is disabled if flag is set to true", () => {
+    const wrapper = mount(<Tab tabName="Tab1" selected={true} disabled={true} />);
+    expect(wrapper.find("#unit-test-selected-tab-button").exists()).toEqual(false);
+    expect(wrapper.find("#unit-test-unselected-tab-button").exists()).toEqual(false);
+    expect(wrapper.find("#unit-test-disabled-tab-button").exists()).toEqual(true);
+  });
 });


### PR DESCRIPTION
# Description

I added a disabled functionality that will allow us to disable tabs using props.
However, this functionality is not used yet. It'll be use soon in another PR.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**Here is an example of what the disabled button look like:**

![image](https://user-images.githubusercontent.com/23021242/56814629-94b0f780-680d-11e9-81c4-f2e91ab14720.png)

# Testing

Manual steps to reproduce this functionality:

**If you want to test that functionality, you have to add the following props in _TabNavigation.jsx_ component where the _Tab.jsx_ component is used:**

- `disabled={false}`
- `disabled={true}`
- or just don't put any disabled prop (that will make the tab enabled)

**Example:**

![image](https://user-images.githubusercontent.com/23021242/56814645-9e3a5f80-680d-11e9-9ebc-a4a53fbbb4b3.png)

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 11+ and Chrome
