### PR TITLE
[Test Footer] Adding test footer toggle functionality

### DIFF
--- a/frontend/src/components/commons/TestFooter.jsx
+++ b/frontend/src/components/commons/TestFooter.jsx
@@ -18,6 +18,10 @@ const styles = {
     borderTop: "2px solid #96a8b2",
     margin: 0
   },
+  startTestBtn: {
+    float: "right",
+    paddingTop: 17
+  },
   submitBtn: {
     float: "right",
     paddingTop: 17
@@ -30,8 +34,10 @@ const styles = {
 
 class TestFooter extends Component {
   static propTypes = {
-    submitTest: PropTypes.func.isRequired,
-    quitTest: PropTypes.func.isRequired
+    startTest: PropTypes.func,
+    submitTest: PropTypes.func,
+    quitTest: PropTypes.func,
+    testIsStarted: PropTypes.bool.isRequired
   };
 
   render() {
@@ -39,26 +45,42 @@ class TestFooter extends Component {
       <div>
         <hr style={styles.hr} />
         <div style={styles.footer}>
-          <div style={styles.submitBtn}>
-            <button
-              id="unit-test-submit-btn"
-              type="button"
-              className="btn btn-primary"
-              onClick={this.props.submitTest}
-            >
-              {LOCALIZE.commons.submitTestButton}
-            </button>
-          </div>
-          <div style={styles.quitTestBtn}>
-            <button
-              id="unit-test-quit-btn"
-              type="button"
-              className="btn btn-danger"
-              onClick={this.props.quitTest}
-            >
-              {LOCALIZE.commons.quitTest}
-            </button>
-          </div>
+          {!this.props.testIsStarted && (
+            <div style={styles.startTestBtn}>
+              <button
+                id="unit-test-start-btn"
+                type="button"
+                className="btn btn-primary"
+                onClick={this.props.startTest}
+              >
+                {LOCALIZE.commons.startTest}
+              </button>
+            </div>
+          )}
+          {this.props.testIsStarted && (
+            <div>
+              <div style={styles.submitBtn}>
+                <button
+                  id="unit-test-submit-btn"
+                  type="button"
+                  className="btn btn-primary"
+                  onClick={this.props.submitTest}
+                >
+                  {LOCALIZE.commons.submitTestButton}
+                </button>
+              </div>
+              <div style={styles.quitTestBtn}>
+                <button
+                  id="unit-test-quit-btn"
+                  type="button"
+                  className="btn btn-danger"
+                  onClick={this.props.quitTest}
+                >
+                  {LOCALIZE.commons.quitTest}
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     );

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -164,7 +164,11 @@ class Emib extends Component {
           </ContentContainer>
         )}
         {this.state.curPage === PAGES.emibTabs && (
-          <TestFooter submitTest={this.openSubmitPopup} quitTest={this.openQuitPopup} />
+          <TestFooter
+            submitTest={this.openSubmitPopup}
+            quitTest={this.openQuitPopup}
+            testIsStarted={true}
+          />
         )}
 
         <ConfirmStartTest

--- a/frontend/src/tests/components/commons/TestFooter.test.js
+++ b/frontend/src/tests/components/commons/TestFooter.test.js
@@ -2,12 +2,30 @@ import React from "react";
 import { shallow } from "enzyme";
 import TestFooter from "../../../components/commons/TestFooter";
 
-it("calls submit test and quit test when the buttons are clicked", () => {
+describe("displays and calls the right buttons depending on the testIsStarted state", () => {
   const submitMock1 = jest.fn();
   const submitMock2 = jest.fn();
-  const wrapper = shallow(<TestFooter submitTest={submitMock1} quitTest={submitMock2} />);
-  wrapper.find("#unit-test-submit-btn").simulate("click");
-  wrapper.find("#unit-test-quit-btn").simulate("click");
-  expect(submitMock1).toHaveBeenCalledTimes(1);
-  expect(submitMock2).toHaveBeenCalledTimes(1);
+  const submitMock3 = jest.fn();
+
+  it("test is not started - calls start test when the buttons is clicked", () => {
+    const wrapper = shallow(<TestFooter startTest={submitMock1} testIsStarted={false} />);
+    wrapper.find("#unit-test-start-btn").simulate("click");
+    expect(wrapper.find("#unit-test-start-btn").exists()).toEqual(true);
+    expect(wrapper.find("#unit-test-submit-btn").exists()).toEqual(false);
+    expect(wrapper.find("#unit-test-quit-btn").exists()).toEqual(false);
+    expect(submitMock1).toHaveBeenCalledTimes(1);
+  });
+
+  it("test is started - calls submit test and quit test when the buttons are clicked", () => {
+    const wrapper = shallow(
+      <TestFooter submitTest={submitMock2} quitTest={submitMock3} testIsStarted={true} />
+    );
+    wrapper.find("#unit-test-submit-btn").simulate("click");
+    wrapper.find("#unit-test-quit-btn").simulate("click");
+    expect(wrapper.find("#unit-test-start-btn").exists()).toEqual(false);
+    expect(wrapper.find("#unit-test-submit-btn").exists()).toEqual(true);
+    expect(wrapper.find("#unit-test-quit-btn").exists()).toEqual(true);
+    expect(submitMock2).toHaveBeenCalledTimes(1);
+    expect(submitMock3).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
# Description

I added a toggle functionality in _TestFooter.jsx_ component that allows us to display two different test footers depending on the **testIsStarted** flag.

If **testIsStarted** is set to false, it should show the _Start test_ button.
If **testIsStarted** is set to true, it should show the _Quit test_ and _Submit Test_ buttons.

**Note that if you put the _testIsStarted_ flag to false, the _Start test_ button does nothing. An action will be added to this button in a future PR.**

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**_testIsStarted_ is set to false:**

![image](https://user-images.githubusercontent.com/23021242/56817192-0e97af80-6813-11e9-9529-d0c00d83bedd.png)

**_testIsStarted_ is set to true:**

![image](https://user-images.githubusercontent.com/23021242/56817230-2a9b5100-6813-11e9-9013-b1e9120cda62.png)

# Testing

Manual steps to reproduce this functionality:

**- this functionality can be tested by changing the _testIsStarted_ flag in _Emib.jsx_ component, where the _TestFooter.jsx_ component is used:**

**Shows _Start test_ button:**

![image](https://user-images.githubusercontent.com/23021242/56817380-7948eb00-6813-11e9-8e8c-39c9bb8ab400.png)

**Shows _Quit test_ and _Submit test_ buttons:**

![image](https://user-images.githubusercontent.com/23021242/56817421-9087d880-6813-11e9-94c9-85320a0b18e6.png)

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 11+ and Chrome
