### PR TITLE
[Emib Tabs] eMIB test is now starting on instructions tab, not background tab

### DIFF
--- a/frontend/src/components/eMIB/EmibTabs.jsx
+++ b/frontend/src/components/eMIB/EmibTabs.jsx
@@ -53,7 +53,7 @@ class EmibTabs extends Component {
       <div style={styles.container}>
         <TabNavigation
           tabSpecs={TABS}
-          currentTab={1}
+          currentTab={0}
           menuName={LOCALIZE.ariaLabel.tabMenu}
           style={styles.tabNavigation}
         />


### PR DESCRIPTION
# Description

I simply updated the _currentTab_ value in _EmibTab.jsx_ component in order to display the instructions tab first instead of the background tab.

## Type of change

- Code cleanliness or refactor

## Screenshot

**First thing you see when you start the eMIB test:**

![image](https://user-images.githubusercontent.com/23021242/56818332-67684780-6815-11e9-9f75-e1cd9bb29a14.png)

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB Sample Test.
2.  Make sure that the first page is the instructions tab.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 11+ and Chrome
