### PR TITLE
[Inbox] Add action dialog should not be close-able by clicking backdrop

### DIFF
--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -132,7 +132,7 @@ class EditActionDialog extends Component {
     const { showDialog, handleClose, actionType, editMode } = this.props;
     return (
       <div>
-        <Modal show={showDialog} onHide={this.showCancelConfirmationDialog}>
+        <Modal show={showDialog} onHide={this.showCancelConfirmationDialog} backdrop={"static"}>
           <div>
             <Modal.Header style={styles.modalHeader}>
               {


### PR DESCRIPTION
# Description

Add action dialog should not be close-able by clicking backdrop.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

N/A

# Testing

Manual steps to reproduce this functionality:

1.  Go to inbox.
2.  Click add email.
3. Try clicking the backdrop outside the dialog to close.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 11+ and Chrome
