### PR TITLE
[Inbox] Move action buttons to after the original email

### DIFF
--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -96,8 +96,12 @@ class Email extends Component {
             </div>
           )}
         </div>
+        <hr style={styles.titleEmailDivider} />
+        <EmailContent email={email} />
+
         {!this.props.disabled && (
           <div>
+            <hr style={styles.titleEmailDivider} />
             <button
               id="unit-test-email-reply-button"
               type="button"
@@ -121,8 +125,6 @@ class Email extends Component {
             </button>
           </div>
         )}
-        <hr style={styles.titleEmailDivider} />
-        <EmailContent email={email} />
         <div>
           {emailActions.map((action, id) => {
             // populate email responses


### PR DESCRIPTION
# Description

Move action buttons to after the original email. This is helpful for a screen reader because it's a bit more logical, and it ensures that keyboard focus after closing a dialog is on the added emails.

It also ensures the page is scrolled down when a new email gets added.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

<img width="1290" alt="Screen Shot 2019-04-29 at 10 07 11 AM" src="https://user-images.githubusercontent.com/4640747/56901949-40a14f80-6a67-11e9-989b-d64ec938b619.png">


# Testing


Manual steps to reproduce this functionality:

1.  Go to inbox.
2.  Select an email and notice action button location.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 11+ and Chrome
