### PR TITLE
[Background] Org chart as a nested list

### DIFF
--- a/frontend/src/components/eMIB/OrganizationalStructure.jsx
+++ b/frontend/src/components/eMIB/OrganizationalStructure.jsx
@@ -54,25 +54,35 @@ class OrganizationalStructure extends Component {
             <div>
               <ul>
                 <li>
-                  Jenna Icard - President
+                  {LOCALIZE.emibTest.background.organizationalStructure.dialog.president}
                   <ul>
                     <li>
-                      Amari Kinsler - Corporate Affairs Director
+                      {LOCALIZE.emibTest.background.organizationalStructure.dialog.corpDirector}
                       <ul>
-                        <li>Marc Sheridan - Human Resources Manager</li>
-                        <li>Bob McNutt - Finance Manager</li>
-                        <li>Lana Hussad - Information Technology Manager</li>
+                        <li>{LOCALIZE.emibTest.background.organizationalStructure.dialog.hr}</li>
+                        <li>
+                          {LOCALIZE.emibTest.background.organizationalStructure.dialog.finance}
+                        </li>
+                        <li>{LOCALIZE.emibTest.background.organizationalStructure.dialog.it}</li>
                       </ul>
                     </li>
-                    <li>Geneviève Bédard - Research and Innovations Director</li>
-                    <li>Bartosz Greco - Program Development Director</li>
+                    <li>{LOCALIZE.emibTest.background.organizationalStructure.dialog.research}</li>
                     <li>
-                      Nancy Ward - Services and Communications Director
+                      {LOCALIZE.emibTest.background.organizationalStructure.dialog.programDev}
+                    </li>
+                    <li>
+                      {LOCALIZE.emibTest.background.organizationalStructure.dialog.communications}
                       <ul>
-                        <li>Claude Huard - Quality Assurance Manager (You)</li>
-                        <li>Haydar Kalil - Services and Support Manager</li>
-                        <li>Geoffrey Hamma - Audits Manager</li>
-                        <li>Lucy Trang - E-Training Manager</li>
+                        <li>{LOCALIZE.emibTest.background.organizationalStructure.dialog.qa}</li>
+                        <li>
+                          {LOCALIZE.emibTest.background.organizationalStructure.dialog.services}
+                        </li>
+                        <li>
+                          {LOCALIZE.emibTest.background.organizationalStructure.dialog.audits}
+                        </li>
+                        <li>
+                          {LOCALIZE.emibTest.background.organizationalStructure.dialog.training}
+                        </li>
                       </ul>
                     </li>
                   </ul>

--- a/frontend/src/components/eMIB/OrganizationalStructure.jsx
+++ b/frontend/src/components/eMIB/OrganizationalStructure.jsx
@@ -51,7 +51,34 @@ class OrganizationalStructure extends Component {
           handleClose={this.closePopup}
           title={LOCALIZE.emibTest.background.organizationalStructure.dialog.title}
           description={
-            <div>{LOCALIZE.emibTest.background.organizationalStructure.dialog.description}</div>
+            <div>
+              <ul>
+                <li>
+                  Jenna Icard - President
+                  <ul>
+                    <li>
+                      Amari Kinsler - Corporate Affairs Director
+                      <ul>
+                        <li>Marc Sheridan - Human Resources Manager</li>
+                        <li>Bob McNutt - Finance Manager</li>
+                        <li>Lana Hussad - Information Technology Manager</li>
+                      </ul>
+                    </li>
+                    <li>Geneviève Bédard - Research and Innovations Director</li>
+                    <li>Bartosz Greco - Program Development Director</li>
+                    <li>
+                      Nancy Ward - Services and Communications Director
+                      <ul>
+                        <li>Claude Huard - Quality Assurance Manager (You)</li>
+                        <li>Haydar Kalil - Services and Support Manager</li>
+                        <li>Geoffrey Hamma - Audits Manager</li>
+                        <li>Lucy Trang - E-Training Manager</li>
+                      </ul>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
           }
           rightButtonType={BUTTON_TYPE.secondary}
           rightButtonTitle={LOCALIZE.commons.close}

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -309,9 +309,7 @@ let LOCALIZE = new LocalizedStrings({
             link: "Image Description"
           },
           dialog: {
-            title: "The Organizational Chart of the ODC",
-            description:
-              "This is the organizational chart for the Organizational Development Council (ODC). At the top is the President: Jenna Icart. Under the president are 4 directors, one representing each unit of the council. These are presented left to right as: Amari Kinsler from Corporate Affairs, Geneviève Bédard from Research and Innovations, Bartosz Greco from Program Development, Nancy Ward from Services and Communications.  Corporate Affairs has 3 managers: Marc Sheridan from Human Resources, Bob McNutt from Finance, and Lana Hussad from Information Technology. Services and Communications has 4 managers: You are Claude Huard from Quality Assurance, Haydar Kalil from Services and Support, Geoffrey Hamma from Audits, and Lucy Trang from E-Training."
+            title: "The Organizational Chart of the ODC"
           }
         },
         teamInformation: {
@@ -836,9 +834,7 @@ let LOCALIZE = new LocalizedStrings({
             link: "Description de l'image"
           },
           dialog: {
-            title: "FR The Organizational Chart of the ODC",
-            description:
-              "FR This is the organizational chart for the Organizational Development Council (ODC). At the top is the President: Jenna Icart. Under the president are 4 directors, one representing each unit of the council. These are presented left to right as: Amari Kinsler from Corporate Affairs, Geneviève Bédard from Research and Innovations, Bartosz Greco from Program Development, Nancy Ward from Services and Communications.  Corporate Affairs has 3 managers: Marc Sheridan from Human Resources, Bob McNutt from Finance, and Lana Hussad from Information Technology. Services and Communications has 4 managers: You are Claude Huard from Quality Assurance, Haydar Kalil from Services and Support, Geoffrey Hamma from Audits, and Lucy Trang from E-Training."
+            title: "FR The Organizational Chart of the ODC"
           }
         },
         teamInformation: {

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -309,7 +309,19 @@ let LOCALIZE = new LocalizedStrings({
             link: "Image Description"
           },
           dialog: {
-            title: "The Organizational Chart of the ODC"
+            title: "The Organizational Chart of the ODC",
+            president: "Jenna Icard - President",
+            corpDirector: "Amari Kinsler - Corporate Affairs Director",
+            hr: "Marc Sheridan - Human Resources Manager",
+            finance: "Bob McNutt - Finance Manager",
+            it: "Lana Hussad - Information Technology Manager",
+            research: "Research and Innovations Director",
+            programDev: "Bartosz Greco - Program Development Director",
+            communications: "Nancy Ward - Services and Communications Director",
+            qa: "Claude Huard - Quality Assurance Manager (You)",
+            services: "Haydar Kalil - Services and Support Manager",
+            audits: "Geoffrey Hamma - Audits Manager",
+            training: "Lucy Trang - E-Training Manager"
           }
         },
         teamInformation: {
@@ -834,7 +846,19 @@ let LOCALIZE = new LocalizedStrings({
             link: "Description de l'image"
           },
           dialog: {
-            title: "FR The Organizational Chart of the ODC"
+            title: "FR The Organizational Chart of the ODC",
+            president: "FR Jenna Icard - President",
+            corpDirector: "FR Amari Kinsler - Corporate Affairs Director",
+            hr: "FR Marc Sheridan - Human Resources Manager",
+            finance: "FR Bob McNutt - Finance Manager",
+            it: "FR Lana Hussad - Information Technology Manager",
+            research: "FR Research and Innovations Director",
+            programDev: "FR Bartosz Greco - Program Development Director",
+            communications: "FR Nancy Ward - Services and Communications Director",
+            qa: "FR Claude Huard - Quality Assurance Manager (You)",
+            services: "FR Haydar Kalil - Services and Support Manager",
+            audits: "FR Geoffrey Hamma - Audits Manager",
+            training: "FR Lucy Trang - E-Training Manager"
           }
         },
         teamInformation: {


### PR DESCRIPTION
# Description

Make the multi-level org chart a nested tree - better for accessibility.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

<img width="588" alt="Screen Shot 2019-04-29 at 12 07 27 PM" src="https://user-images.githubusercontent.com/4640747/56910006-8239f680-6a77-11e9-82b3-fb3124874691.png">


# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Go to the background page and click image description.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 11+ and Chrome
