### PR TITLE
[Accessibility] Add HTML title tags

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -27,7 +27,6 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>CAT - PSC</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -79,6 +79,7 @@ class App extends Component {
       <div>
         <Helmet>
           <html lang={this.props.currentLanguage} />
+          <title>{LOCALIZE.titles.CAT}</title>
         </Helmet>
         <Router>
           <div>

--- a/frontend/src/Home.jsx
+++ b/frontend/src/Home.jsx
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import LOCALIZE from "./text_resources";
 import ContentContainer from "./components/commons/ContentContainer";
 import LoginTabs from "./components/authentication/AuthenticationTabs";
+import { Helmet } from "react-helmet";
 
 class Home extends Component {
   //TODO(fnormand): Remove this part when implementing login functionality in the backend
@@ -18,6 +19,9 @@ class Home extends Component {
   render() {
     return (
       <div className="app">
+        <Helmet>
+          <title>CAT Home</title>
+        </Helmet>
         <ContentContainer>
           <h1>{LOCALIZE.homePage.title}</h1>
           <p>{LOCALIZE.homePage.description}</p>

--- a/frontend/src/Home.jsx
+++ b/frontend/src/Home.jsx
@@ -20,7 +20,7 @@ class Home extends Component {
     return (
       <div className="app">
         <Helmet>
-          <title>CAT Home</title>
+          <title>{LOCALIZE.titles.home}</title>
         </Helmet>
         <ContentContainer>
           <h1>{LOCALIZE.homePage.title}</h1>

--- a/frontend/src/Prototype.jsx
+++ b/frontend/src/Prototype.jsx
@@ -1,10 +1,14 @@
 import React from "react";
 import LOCALIZE from "./text_resources";
 import ContentContainer from "./components/commons/ContentContainer";
+import { Helmet } from "react-helmet";
 
 const Prototype = () => {
   return (
     <ContentContainer>
+      <Helmet>
+        <title>CAT Prototypes</title>
+      </Helmet>
       <h2>{LOCALIZE.prototypePage.title}</h2>
       <p>{LOCALIZE.prototypePage.welcomeMsg}</p>
 

--- a/frontend/src/Prototype.jsx
+++ b/frontend/src/Prototype.jsx
@@ -7,7 +7,7 @@ const Prototype = () => {
   return (
     <ContentContainer>
       <Helmet>
-        <title>CAT Prototypes</title>
+        <title>{LOCALIZE.titles.prototypes}</title>
       </Helmet>
       <h2>{LOCALIZE.prototypePage.title}</h2>
       <p>{LOCALIZE.prototypePage.welcomeMsg}</p>

--- a/frontend/src/Status.jsx
+++ b/frontend/src/Status.jsx
@@ -116,7 +116,7 @@ class Status extends Component {
     return (
       <ContentContainer>
         <Helmet>
-          <title>CAT System Status</title>
+          <title>{LOCALIZE.titles.status}</title>
         </Helmet>
         <div className={"jumbotron"}>
           <h1>{LOCALIZE.statusPage.title}</h1>

--- a/frontend/src/Status.jsx
+++ b/frontend/src/Status.jsx
@@ -7,6 +7,7 @@ import getScreenResolution from "./helpers/getScreenResolution";
 import logo from "./images/logo.png";
 import LOCALIZE from "./text_resources";
 import ContentContainer from "./components/commons/ContentContainer";
+import { Helmet } from "react-helmet";
 
 const styles = {
   logo: {
@@ -114,6 +115,9 @@ class Status extends Component {
     } = this.state;
     return (
       <ContentContainer>
+        <Helmet>
+          <title>CAT System Status</title>
+        </Helmet>
         <div className={"jumbotron"}>
           <h1>{LOCALIZE.statusPage.title}</h1>
           <p>{LOCALIZE.statusPage.welcomeMsg}</p>

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -17,6 +17,7 @@ import SystemMessage, { MESSAGE_TYPE } from "../commons/SystemMessage";
 import { activateTest, deactivateTest } from "../../modules/TestStatusRedux";
 import ConfirmEnterEmib from "./ConfirmEnterEmib";
 import EmibIntroductionPage from "./EmibIntroductionPage";
+import { Helmet } from "react-helmet";
 
 const PAGES = {
   preTest: "preTest",
@@ -143,6 +144,9 @@ class Emib extends Component {
     const submitButtonState = allChecked ? BUTTON_STATE.enabled : BUTTON_STATE.disabled;
     return (
       <div className="app">
+        <Helmet>
+          <title>eMIB Assessment</title>
+        </Helmet>
         <div>{this.state.curPage === PAGES.emibTabs && <EmibTabs />}</div>
         {this.state.curPage !== PAGES.emibTabs && (
           <ContentContainer hideBanner={this.state.curPage === PAGES.emibTabs}>

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -145,7 +145,7 @@ class Emib extends Component {
     return (
       <div className="app">
         <Helmet>
-          <title>eMIB Assessment</title>
+          <title>{LOCALIZE.titles.eMIB}</title>
         </Helmet>
         <div>{this.state.curPage === PAGES.emibTabs && <EmibTabs />}</div>
         {this.state.curPage !== PAGES.emibTabs && (

--- a/frontend/src/components/eMIB/EmibTabs.jsx
+++ b/frontend/src/components/eMIB/EmibTabs.jsx
@@ -7,6 +7,7 @@ import InTestInstructions from "./InTestInstructions";
 import Notepad from "../commons/Notepad";
 import "../../css/emib-tabs.css";
 import { HEADER_HEIGHT, FOOTER_HEIGHT } from "./constants";
+import { Helmet } from "react-helmet";
 
 const TAB_HEIGHT = `calc(100vh - ${HEADER_HEIGHT + FOOTER_HEIGHT}px)`;
 
@@ -51,6 +52,9 @@ class EmibTabs extends Component {
     ];
     return (
       <div style={styles.container}>
+        <Helmet>
+          <title>eMIB Assessment Simulation</title>
+        </Helmet>
         <TabNavigation
           tabSpecs={TABS}
           currentTab={0}

--- a/frontend/src/components/eMIB/EmibTabs.jsx
+++ b/frontend/src/components/eMIB/EmibTabs.jsx
@@ -53,7 +53,7 @@ class EmibTabs extends Component {
     return (
       <div style={styles.container}>
         <Helmet>
-          <title>eMIB Assessment Simulation</title>
+          <title>{LOCALIZE.titles.simulation}</title>
         </Helmet>
         <TabNavigation
           tabSpecs={TABS}

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -9,6 +9,16 @@ let LOCALIZE = new LocalizedStrings({
       statusTabTitle: "Status"
     },
 
+    //HTML Page Titles
+    titles: {
+      CAT: "CAT - PSC",
+      eMIB: "eMIB Assessment",
+      simulation: "eMIB Assessment Simulation",
+      status: "CAT System Status",
+      prototypes: "CAT Prototypes",
+      home: "CAT Home"
+    },
+
     //authentication
     authentication: {
       login: {
@@ -538,6 +548,16 @@ let LOCALIZE = new LocalizedStrings({
       homeTabTitle: "Accueil",
       prototypeTabTitle: "Prototype",
       statusTabTitle: "Statut"
+    },
+
+    //HTML Page Titles
+    titles: {
+      CAT: "FR CAT - PSC",
+      eMIB: "FR eMIB Assessment",
+      simulation: "FR eMIB Assessment Simulation",
+      status: "FR CAT System Status",
+      prototypes: "FR CAT Prototypes",
+      home: "FR CAT Home"
     },
 
     //authentication


### PR DESCRIPTION
# Description

Add HTML title tags anytime a page changes.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

![titles](https://user-images.githubusercontent.com/4640747/56937423-8b07e800-6aca-11e9-8fba-d02c270e4783.gif)

# Testing

Manual steps to reproduce this functionality:

1.  Go to any page.
2.  Inspect element and look for the title element.
3.  Change pages and notice it update.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 11+ and Chrome - I have no way of checking IE because I'm on my macbook.
