### PR TITLE
[Login / Logout] Adding login/logout buttons in the nav bar

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,6 +9,7 @@ import Status from "./Status";
 import Home from "./Home";
 import Prototype from "./Prototype";
 import Emib from "./components/eMIB/Emib";
+import LoginButton from "./components/commons/LoginButton";
 import Translation from "./components/commons/Translation";
 import LOCALIZE from "./text_resources";
 import psc_header from "./images/psc_header.png";
@@ -34,6 +35,12 @@ const styles = {
     position: "fixed",
     top: 20,
     left: 20
+  },
+  loginButton: {
+    position: "fixed",
+    right: 115,
+    top: 15,
+    left: "auto"
   },
   languageButton: {
     position: "fixed",
@@ -133,6 +140,9 @@ class App extends Component {
                     </ul>
                   </div>
                 )}
+                <div aria-label="login-button" className="fixed-top" style={styles.loginButton}>
+                  <LoginButton />
+                </div>
                 <div
                   aria-label={LOCALIZE.ariaLabel.languageToggleBtn}
                   className="fixed-top"

--- a/frontend/src/components/commons/LoginButton.jsx
+++ b/frontend/src/components/commons/LoginButton.jsx
@@ -3,7 +3,7 @@ import LOCALIZE from "../../text_resources";
 
 const styles = {
   button: {
-    width: 125
+    width: 136
   }
 };
 
@@ -12,16 +12,34 @@ class LoginButton extends Component {
     loggedIn: false
   };
 
+  handleLogin = () => {
+    this.setState({ loggedIn: true });
+  };
+
+  handleLogoff = () => {
+    this.setState({ loggedIn: false });
+  };
+
   render() {
     return (
       <div>
         {!this.state.loggedIn && (
-          <button type="button" className="btn btn-primary" style={styles.button}>
+          <button
+            type="button"
+            className="btn btn-primary"
+            style={styles.button}
+            onClick={this.handleLogin}
+          >
             {LOCALIZE.commons.login}
           </button>
         )}
         {this.state.loggedIn && (
-          <button type="button" className="btn btn-primary" style={styles.button}>
+          <button
+            type="button"
+            className="btn btn-primary"
+            style={styles.button}
+            onClick={this.handleLogoff}
+          >
             {LOCALIZE.commons.logout}
           </button>
         )}

--- a/frontend/src/components/commons/LoginButton.jsx
+++ b/frontend/src/components/commons/LoginButton.jsx
@@ -1,0 +1,33 @@
+import React, { Component } from "react";
+import LOCALIZE from "../../text_resources";
+
+const styles = {
+  button: {
+    width: 125
+  }
+};
+
+class LoginButton extends Component {
+  state = {
+    loggedIn: false
+  };
+
+  render() {
+    return (
+      <div>
+        {!this.state.loggedIn && (
+          <button type="button" className="btn btn-primary" style={styles.button}>
+            {LOCALIZE.commons.login}
+          </button>
+        )}
+        {this.state.loggedIn && (
+          <button type="button" className="btn btn-primary" style={styles.button}>
+            {LOCALIZE.commons.logout}
+          </button>
+        )}
+      </div>
+    );
+  }
+}
+
+export default LoginButton;

--- a/frontend/src/components/commons/LoginButton.jsx
+++ b/frontend/src/components/commons/LoginButton.jsx
@@ -16,7 +16,7 @@ class LoginButton extends Component {
     this.setState({ loggedIn: true });
   };
 
-  handleLogoff = () => {
+  handleLogout = () => {
     this.setState({ loggedIn: false });
   };
 
@@ -38,7 +38,7 @@ class LoginButton extends Component {
             type="button"
             className="btn btn-primary"
             style={styles.button}
-            onClick={this.handleLogoff}
+            onClick={this.handleLogout}
           >
             {LOCALIZE.commons.logout}
           </button>

--- a/frontend/src/components/commons/Translation.jsx
+++ b/frontend/src/components/commons/Translation.jsx
@@ -10,6 +10,12 @@ const LANGUAGES = {
   french: "fr"
 };
 
+const styles = {
+  button: {
+    width: 86
+  }
+};
+
 class Translation extends Component {
   state = {
     currentLanguage: LANGUAGES.english
@@ -36,12 +42,22 @@ class Translation extends Component {
     return (
       <div>
         {this.state.currentLanguage === LANGUAGES.english && (
-          <button type="button" className="btn btn-secondary" onClick={this.onSetLanguageToFrench}>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            style={styles.button}
+            onClick={this.onSetLanguageToFrench}
+          >
             Français
           </button>
         )}
         {this.state.currentLanguage === LANGUAGES.french && (
-          <button type="button" className="btn btn-secondary" onClick={this.onSetLanguageToEnglish}>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            style={styles.button}
+            onClick={this.onSetLanguageToEnglish}
+          >
             English
           </button>
         )}

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -538,7 +538,9 @@ let LOCALIZE = new LocalizedStrings({
       },
       cancel: "Cancel",
       cancelResponse: "Cancel response",
-      close: "Close"
+      close: "Close",
+      login: "Login",
+      logout: "Logout"
     }
   },
 
@@ -1088,7 +1090,9 @@ let LOCALIZE = new LocalizedStrings({
       },
       cancel: "Annuler",
       cancelResponse: "Annuler la réponse",
-      close: "Fermer"
+      close: "Fermer",
+      login: "Se connecter",
+      logout: "Se déconnecter"
     }
   }
 });


### PR DESCRIPTION
# Description

This PR is adding the Login/Logout buttons in the nav bar with basic functionalities. It only switches the state of the login/logout buttons when you click on it.

Other actions will be added to these buttons in future PRs.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**Default View:**

![image](https://user-images.githubusercontent.com/23021242/56971789-e2906d00-6b37-11e9-9565-4cbcc76d45f5.png)

**After clicking on _Login_:**

![image](https://user-images.githubusercontent.com/23021242/56971839-f76d0080-6b37-11e9-8599-cd55fbdf8148.png)

# Testing

Manual steps to reproduce this functionality:

1.  Run the app.
2.  Make sure that the buttons are switching when clicking on it.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
