### PR TITLE
[Login / Logout] Introducing login states with Redux

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -76,6 +76,7 @@ const isStatusActive = (match, location) => {
 class App extends Component {
   static propTypes = {
     // Props from Redux
+    loggedIn: PropTypes.bool,
     currentLanguage: PropTypes.string,
     isTestActive: PropTypes.bool.isRequired
   };
@@ -166,6 +167,7 @@ export { PATH };
 
 const mapStateToProps = (state, ownProps) => {
   return {
+    loggedIn: state.login.loggedIn,
     currentLanguage: state.localize.language,
     isTestActive: state.testStatus.isTestActive
   };

--- a/frontend/src/components/commons/LoginButton.jsx
+++ b/frontend/src/components/commons/LoginButton.jsx
@@ -14,27 +14,22 @@ const styles = {
 class LoginButton extends Component {
   static propTypes = {
     // Props from Redux
-    setLoginState: PropTypes.func
-  };
-
-  state = {
-    loggedIn: false
+    setLoginState: PropTypes.func,
+    loggedIn: PropTypes.bool
   };
 
   handleLogin = () => {
-    this.setState({ loggedIn: true });
     this.props.setLoginState(true);
   };
 
   handleLogout = () => {
-    this.setState({ loggedIn: false });
     this.props.setLoginState(false);
   };
 
   render() {
     return (
       <div>
-        {!this.state.loggedIn && (
+        {!this.props.loggedIn && (
           <button
             type="button"
             className="btn btn-primary"
@@ -44,7 +39,7 @@ class LoginButton extends Component {
             {LOCALIZE.commons.login}
           </button>
         )}
-        {this.state.loggedIn && (
+        {this.props.loggedIn && (
           <button
             type="button"
             className="btn btn-primary"
@@ -59,6 +54,12 @@ class LoginButton extends Component {
   }
 }
 
+const mapStateToProps = (state, ownProps) => {
+  return {
+    loggedIn: state.login.loggedIn
+  };
+};
+
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
@@ -68,6 +69,6 @@ const mapDispatchToProps = dispatch =>
   );
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps
 )(LoginButton);

--- a/frontend/src/components/commons/LoginButton.jsx
+++ b/frontend/src/components/commons/LoginButton.jsx
@@ -1,5 +1,9 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
+import { setLoginState } from "../../modules/LoginRedux";
+import { bindActionCreators } from "redux";
+import { connect } from "react-redux";
 
 const styles = {
   button: {
@@ -8,16 +12,23 @@ const styles = {
 };
 
 class LoginButton extends Component {
+  static propTypes = {
+    // Props from Redux
+    setLoginState: PropTypes.func
+  };
+
   state = {
     loggedIn: false
   };
 
   handleLogin = () => {
     this.setState({ loggedIn: true });
+    this.props.setLoginState(true);
   };
 
   handleLogout = () => {
     this.setState({ loggedIn: false });
+    this.props.setLoginState(false);
   };
 
   render() {
@@ -48,4 +59,15 @@ class LoginButton extends Component {
   }
 }
 
-export default LoginButton;
+const mapDispatchToProps = dispatch =>
+  bindActionCreators(
+    {
+      setLoginState
+    },
+    dispatch
+  );
+
+export default connect(
+  null,
+  mapDispatchToProps
+)(LoginButton);

--- a/frontend/src/modules/LoginRedux.js
+++ b/frontend/src/modules/LoginRedux.js
@@ -2,11 +2,11 @@
 export const SET_LOGIN_STATE = "localize/SET_LOGIN_STATE";
 
 // Action Creators
-const setLoginState = loginState => ({ type: SET_LANGUAGE, loginState });
+const setLoginState = loggedIn => ({ type: SET_LOGIN_STATE, loggedIn });
 
 // Initial State
 const initialState = {
-  loginState: "en"
+  loggedIn: false
 };
 
 // Reducer
@@ -15,7 +15,7 @@ const login = (state = initialState, action) => {
     case SET_LOGIN_STATE:
       return {
         ...state,
-        loginState: action.loginState
+        loggedIn: action.loggedIn
       };
 
     default:

--- a/frontend/src/modules/LoginRedux.js
+++ b/frontend/src/modules/LoginRedux.js
@@ -1,0 +1,27 @@
+// Action Types
+export const SET_LOGIN_STATE = "localize/SET_LOGIN_STATE";
+
+// Action Creators
+const setLoginState = loginState => ({ type: SET_LANGUAGE, loginState });
+
+// Initial State
+const initialState = {
+  loginState: "en"
+};
+
+// Reducer
+const login = (state = initialState, action) => {
+  switch (action.type) {
+    case SET_LOGIN_STATE:
+      return {
+        ...state,
+        loginState: action.loginState
+      };
+
+    default:
+      return state;
+  }
+};
+
+export default login;
+export { setLoginState, initialState };

--- a/frontend/src/modules/index.js
+++ b/frontend/src/modules/index.js
@@ -1,6 +1,7 @@
 import { combineReducers } from "redux";
 import localize from "./LocalizeRedux";
+import login from "./LoginRedux";
 import testStatus from "./TestStatusRedux";
 import emibInbox from "./EmibInboxRedux";
 
-export default combineReducers({ localize, emibInbox, testStatus });
+export default combineReducers({ localize, login, emibInbox, testStatus });

--- a/frontend/src/tests/modules/LoginRedux.test.js
+++ b/frontend/src/tests/modules/LoginRedux.test.js
@@ -1,0 +1,10 @@
+import login, { setLoginState, initialState } from "../../modules/LoginRedux";
+
+describe("setLoginState action", () => {
+  it("should update loggedIn state", () => {
+    const action1 = setLoginState(true);
+    expect(login(initialState, action1)).toEqual({ loggedIn: true });
+    const action2 = setLoginState(false);
+    expect(login(initialState, action2)).toEqual({ loggedIn: false });
+  });
+});


### PR DESCRIPTION
# Description

This PR is introducing the login states with Redux, so we'll be able to control what we want to display depending on the candidate's login state.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**I used the following console.log to demonstrate the operation of the login states using Redux**

![image](https://user-images.githubusercontent.com/23021242/56976854-e32e0100-6b41-11e9-8021-6d42b4b6d724.png)

**If logged out:**

![image](https://user-images.githubusercontent.com/23021242/56976941-153f6300-6b42-11e9-827e-3f5da022eccb.png)

![image](https://user-images.githubusercontent.com/23021242/56976955-1cff0780-6b42-11e9-9afb-b15c8d660f74.png)

**If logged in (after clicking on _Login_ button):**

![image](https://user-images.githubusercontent.com/23021242/56976974-27b99c80-6b42-11e9-9f74-c0ed779d745d.png)

![image](https://user-images.githubusercontent.com/23021242/56976984-2e481400-6b42-11e9-8cdf-2fe97ba96c57.png)

# Testing

Manual steps to reproduce this functionality:

**- To test that functionality, you would have to do the exact same thing I did in the screenshots, meaning that you would need to add a _console.log_ to make sure that the login states are working as expected.**

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [ ] ~~My changes look good on IE 11+ and Chrome~~
