### PR TITLE
[Dashboard] Adding dashboard link in nav bar

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,7 @@ import "./css/cat-theme.css";
 import { Helmet } from "react-helmet";
 import Status from "./Status";
 import Home from "./Home";
+import Dashboard from "./Dashboard";
 import Prototype from "./Prototype";
 import Emib from "./components/eMIB/Emib";
 import LoginButton from "./components/commons/LoginButton";
@@ -16,6 +17,7 @@ import psc_header from "./images/psc_header.png";
 
 const PATH = {
   home: "/",
+  dashboard: "/dashboard",
   prototype: "/prototype",
   status: "/status",
   emibSampleTest: "/emib-sample"
@@ -55,6 +57,13 @@ const isHomeActive = (match, location) => {
   if (!location) return false;
   const { pathname } = location;
   return pathname === PATH.home;
+};
+
+//Check if the dashboard page is selected
+const isDashboardActive = (match, location) => {
+  if (!location) return false;
+  const { pathname } = location;
+  return pathname === PATH.dashboard;
 };
 
 //Check if the Prototype page is selected even when you start the eMIB Sample Test
@@ -121,6 +130,16 @@ class App extends Component {
                       <li className="bg-white" role="menuitem">
                         <NavLink
                           aria-current="page"
+                          isActive={isDashboardActive}
+                          className="nav-link"
+                          to={PATH.dashboard}
+                        >
+                          Dashboard
+                        </NavLink>
+                      </li>
+                      <li className="bg-white" role="menuitem">
+                        <NavLink
+                          aria-current="page"
                           isActive={isPrototypeActive}
                           className="nav-link"
                           to={PATH.prototype}
@@ -154,6 +173,7 @@ class App extends Component {
               </nav>
             </header>
             <Route exact path={PATH.home} component={Home} />
+            <Route path={PATH.dashboard} component={Dashboard} />
             <Route path={PATH.prototype} component={Prototype} />
             <Route path={PATH.status} component={Status} />
             <Route path={PATH.emibSampleTest} component={Emib} />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -134,7 +134,7 @@ class App extends Component {
                           className="nav-link"
                           to={PATH.dashboard}
                         >
-                          Dashboard
+                          {LOCALIZE.mainTabs.dashboardTabTitle}
                         </NavLink>
                       </li>
                       <li className="bg-white" role="menuitem">

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -5,12 +5,6 @@ import LOCALIZE from "./text_resources";
 import ContentContainer from "./components/commons/ContentContainer";
 import { Helmet } from "react-helmet";
 
-const styles = {
-  title: {
-    color: "black"
-  }
-};
-
 class Dashboard extends Component {
   static propTypes = {
     // Props from Redux
@@ -23,9 +17,7 @@ class Dashboard extends Component {
         <Helmet>
           <title>{LOCALIZE.titles.dashboard}</title>
         </Helmet>
-        <h2 className="green-divider" style={styles.title}>
-          {LOCALIZE.dashboard.title}
-        </h2>
+        <h1 className="green-divider">{LOCALIZE.dashboard.title}</h1>
         {!this.props.loggedIn && <p>{LOCALIZE.dashboard.descriptionIfLoggedOut}</p>}
         {this.props.loggedIn && <p>{LOCALIZE.dashboard.descriptionIfLoggedIn}</p>}
       </ContentContainer>

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -1,0 +1,45 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import LOCALIZE from "./text_resources";
+import ContentContainer from "./components/commons/ContentContainer";
+import { Helmet } from "react-helmet";
+
+const styles = {
+  title: {
+    color: "black"
+  }
+};
+
+class Dashboard extends Component {
+  static propTypes = {
+    // Props from Redux
+    loggedIn: PropTypes.bool
+  };
+
+  render() {
+    return (
+      <ContentContainer>
+        <Helmet>
+          <title>{LOCALIZE.titles.dashboard}</title>
+        </Helmet>
+        <h2 className="green-divider" style={styles.title}>
+          {LOCALIZE.dashboard.title}
+        </h2>
+        {!this.props.loggedIn && <p>{LOCALIZE.dashboard.descriptionIfLoggedOut}</p>}
+        {this.props.loggedIn && <p>{LOCALIZE.dashboard.descriptionIfLoggedIn}</p>}
+      </ContentContainer>
+    );
+  }
+}
+
+const mapStateToProps = (state, ownProps) => {
+  return {
+    loggedIn: state.login.loggedIn
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  null
+)(Dashboard);

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -33,6 +33,7 @@ class Dashboard extends Component {
   }
 }
 
+export { Dashboard as UnconnectedDashboard };
 const mapStateToProps = (state, ownProps) => {
   return {
     loggedIn: state.login.loggedIn

--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -19,7 +19,8 @@ body {
 /* Headers */
 
 /* h1: add green line underneath */
-h1.green-divider:after {
+h1.green-divider:after,
+h2.green-divider:after {
   content: " ";
   display: block;
   border-bottom: 2px solid #c7e68c;

--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -19,8 +19,7 @@ body {
 /* Headers */
 
 /* h1: add green line underneath */
-h1.green-divider:after,
-h2.green-divider:after {
+h1.green-divider:after {
   content: " ";
   display: block;
   border-bottom: 2px solid #c7e68c;

--- a/frontend/src/tests/Dashboard.test.js
+++ b/frontend/src/tests/Dashboard.test.js
@@ -6,7 +6,7 @@ import LOCALIZE from "../text_resources";
 describe("renders title and description if logged out", () => {
   it("renders title", () => {
     const wrapper = shallow(<UnconnectedDashboard />);
-    const title = <h2>{LOCALIZE.dashboard.title}</h2>;
+    const title = <h1>{LOCALIZE.dashboard.title}</h1>;
     expect(wrapper.containsMatchingElement(title)).toEqual(true);
   });
 

--- a/frontend/src/tests/Dashboard.test.js
+++ b/frontend/src/tests/Dashboard.test.js
@@ -1,0 +1,18 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { UnconnectedDashboard } from "../Dashboard";
+import LOCALIZE from "../text_resources";
+
+describe("renders title and description if logged out", () => {
+  it("renders title", () => {
+    const wrapper = shallow(<UnconnectedDashboard />);
+    const title = <h2>{LOCALIZE.dashboard.title}</h2>;
+    expect(wrapper.containsMatchingElement(title)).toEqual(true);
+  });
+
+  it("renders description if logged out", () => {
+    const wrapper = shallow(<UnconnectedDashboard />);
+    const description = <p>{LOCALIZE.dashboard.descriptionIfLoggedOut}</p>;
+    expect(wrapper.contains(description)).toEqual(true);
+  });
+});

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -5,6 +5,7 @@ let LOCALIZE = new LocalizedStrings({
     //Main Tabs
     mainTabs: {
       homeTabTitle: "Home",
+      dashboardTabTitle: "Dashboard",
       prototypeTabTitle: "Prototype",
       statusTabTitle: "Status"
     },
@@ -556,6 +557,7 @@ let LOCALIZE = new LocalizedStrings({
     //Main Tabs
     mainTabs: {
       homeTabTitle: "Accueil",
+      dashboardTabTitle: "Tableau de bord",
       prototypeTabTitle: "Prototype",
       statusTabTitle: "Statut"
     },

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -15,6 +15,7 @@ let LOCALIZE = new LocalizedStrings({
       eMIB: "eMIB Assessment",
       simulation: "eMIB Assessment Simulation",
       status: "CAT System Status",
+      dashboard: "CAT Dashboard",
       prototypes: "CAT Prototypes",
       home: "CAT Home"
     },
@@ -74,6 +75,13 @@ let LOCALIZE = new LocalizedStrings({
       welcomeMsg: "Welcome to the Compotency Assessment Tool.",
       description:
         "Code for Canada and PSC are working on this tool to help assess managerial canadiates for the federal public service. It is in the alpha phase which means it is currently going through product testing and is subject to change."
+    },
+
+    //Dashboard Page
+    dashboard: {
+      title: "Welcome to your dashboard",
+      descriptionIfLoggedOut: "You can access this after logging in.",
+      descriptionIfLoggedIn: "You can now view your dashboard."
     },
 
     //Prototype Page
@@ -558,6 +566,7 @@ let LOCALIZE = new LocalizedStrings({
       eMIB: "FR eMIB Assessment",
       simulation: "FR eMIB Assessment Simulation",
       status: "FR CAT System Status",
+      dashboard: "FR CAT Dashboard",
       prototypes: "FR CAT Prototypes",
       home: "FR CAT Home"
     },
@@ -618,6 +627,13 @@ let LOCALIZE = new LocalizedStrings({
       welcomeMsg: "Bienvenue dans l'outil d'évaluation des compétences.",
       description:
         "FR Code for Canada and PSC are working on this tool to help assess managerial canadiates for the federal public service. It is in the alpha phase which means it is currently going through product testing and is subject to change."
+    },
+
+    //Dashboard Page
+    dashboard: {
+      title: "FR Welcome to your dashboard",
+      descriptionIfLoggedOut: "FR You can access this after logging in.",
+      descriptionIfLoggedIn: "FR You can now view your dashboard."
     },
 
     //Prototype Page


### PR DESCRIPTION
# Description

This PR is adding the _Dashboard_ link in the nav bar and its content. This _Dashboard_ component is also using the _loggedIn redux state_ in order to display a description depending on the login states.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**If logged out:**

![image](https://user-images.githubusercontent.com/23021242/56986370-8558e380-6b58-11e9-8566-061d8f3c3f4e.png)

**If logged in (after clicking on _Login_ button):**

![image](https://user-images.githubusercontent.com/23021242/56985947-89383600-6b57-11e9-952b-9b48526b0806.png)

# Testing

Manual steps to reproduce this functionality:

1.  Open the _Dashboard_ link.
2.  Make sure that the description is changing if you click on the _Login_ button.

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
