### PR TITLE
[eMIB] Tooltip on disabled tabs

### DIFF
--- a/frontend/src/components/commons/Tab.jsx
+++ b/frontend/src/components/commons/Tab.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { OverlayTrigger, Tooltip } from "react-bootstrap";
 
 const styles = {
   li: { position: "relative", display: "block", float: "left", marginBottom: "-1px" },
@@ -66,15 +67,21 @@ class Tab extends Component {
         )}
         {this.props.disabled && (
           <li role="menuitem" style={styles.li}>
-            <button
-              id="unit-test-disabled-tab-button"
-              disabled={true}
-              style={{ ...styles.button, ...styles.disabledButton }}
-              className="side-navigation-button"
-              onClick={this.props.onClick}
+            <OverlayTrigger
+              placement={"top"}
+              overlay={<Tooltip>You can't access this until you start the test.</Tooltip>}
             >
-              {this.props.tabName}
-            </button>
+              <span className="d-inline-block">
+                <button
+                  id="unit-test-disabled-tab-button"
+                  disabled={true}
+                  style={{ ...styles.button, ...styles.disabledButton, pointerEvents: "none" }}
+                  className="side-navigation-button"
+                >
+                  {this.props.tabName}
+                </button>
+              </span>
+            </OverlayTrigger>
           </li>
         )}
       </span>

--- a/frontend/src/components/commons/Tab.jsx
+++ b/frontend/src/components/commons/Tab.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { OverlayTrigger, Tooltip } from "react-bootstrap";
+import LOCALIZE from "../../text_resources";
 
 const styles = {
   li: { position: "relative", display: "block", float: "left", marginBottom: "-1px" },
@@ -69,7 +70,7 @@ class Tab extends Component {
           <li role="menuitem" style={styles.li}>
             <OverlayTrigger
               placement={"top"}
-              overlay={<Tooltip>You can't access this until you start the test.</Tooltip>}
+              overlay={<Tooltip>{LOCALIZE.emibTest.tabs.disabled}</Tooltip>}
             >
               <span className="d-inline-block">
                 <button

--- a/frontend/src/components/commons/Tab.jsx
+++ b/frontend/src/components/commons/Tab.jsx
@@ -70,7 +70,11 @@ class Tab extends Component {
           <li role="menuitem" style={styles.li}>
             <OverlayTrigger
               placement={"top"}
-              overlay={<Tooltip>{LOCALIZE.emibTest.tabs.disabled}</Tooltip>}
+              overlay={
+                <Tooltip id={`disabled-tooltip-${this.props.tabName}`}>
+                  {LOCALIZE.emibTest.tabs.disabled}
+                </Tooltip>
+              }
             >
               <span className="d-inline-block">
                 <button

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -454,7 +454,8 @@ let LOCALIZE = new LocalizedStrings({
       tabs: {
         instructionsTabTitle: "Instructions",
         backgroundTabTitle: "Background",
-        inboxTabTitle: "Inbox"
+        inboxTabTitle: "Inbox",
+        disabled: "You can't access this until you start the test."
       },
 
       //Test Footer
@@ -1003,7 +1004,8 @@ let LOCALIZE = new LocalizedStrings({
       tabs: {
         instructionsTabTitle: "Instructions",
         backgroundTabTitle: "Contexte",
-        inboxTabTitle: "Boîte de réception"
+        inboxTabTitle: "Boîte de réception",
+        disabled: "FR You can't access this until you start the test."
       },
 
       //Test Footer


### PR DESCRIPTION
# Description

Add a tooltip for disabled tabs.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

<img width="481" alt="Screen Shot 2019-04-30 at 10 53 59 PM" src="https://user-images.githubusercontent.com/4640747/57004184-ebfef100-6b9a-11e9-885a-d299b5f14091.png">

# Testing

Manual steps to reproduce this functionality:

1.  Go to the sample test.
2.  Hover over a disabled tab.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 11+ and Chrome
