### PR TITLE
[Inbox] Save current email when changing tabs

### DIFF
--- a/frontend/src/components/eMIB/Inbox.jsx
+++ b/frontend/src/components/eMIB/Inbox.jsx
@@ -6,7 +6,7 @@ import EmailPreview from "./EmailPreview";
 import Email from "./Email";
 import "../../css/inbox.css";
 import { HEADER_HEIGHT, FOOTER_HEIGHT, emailShape } from "./constants";
-import { readEmail } from "../../modules/EmibInboxRedux";
+import { readEmail, changeCurrentEmail } from "../../modules/EmibInboxRedux";
 
 const INBOX_HEIGHT = `calc(100vh - ${HEADER_HEIGHT + FOOTER_HEIGHT}px)`;
 
@@ -31,16 +31,14 @@ class Inbox extends Component {
     // Provided by redux
     emails: PropTypes.arrayOf(emailShape),
     emailSummaries: PropTypes.array.isRequired,
-    readEmail: PropTypes.func.isRequired
-  };
-
-  state = {
-    currentEmail: 0
+    currentEmail: PropTypes.number.isRequired,
+    readEmail: PropTypes.func.isRequired,
+    changeCurrentEmail: PropTypes.func.isRequired
   };
 
   changeEmail = index => {
-    this.props.readEmail(this.state.currentEmail);
-    this.setState({ currentEmail: index });
+    this.props.readEmail(this.props.currentEmail);
+    this.props.changeCurrentEmail(index);
   };
 
   render() {
@@ -63,7 +61,7 @@ class Inbox extends Component {
                   isRepliedTo={
                     emailSummaries[index].emailCount + emailSummaries[index].taskCount > 0
                   }
-                  isSelected={index === this.state.currentEmail}
+                  isSelected={index === this.props.currentEmail}
                 />
               </div>
             ))}
@@ -71,9 +69,9 @@ class Inbox extends Component {
         </nav>
         <div className="inbox-grid-content-cell" style={styles.bodyContent}>
           <Email
-            email={emails[this.state.currentEmail]}
-            emailCount={emailSummaries[this.state.currentEmail].emailCount}
-            taskCount={emailSummaries[this.state.currentEmail].taskCount}
+            email={emails[this.props.currentEmail]}
+            emailCount={emailSummaries[this.props.currentEmail].emailCount}
+            taskCount={emailSummaries[this.props.currentEmail].taskCount}
           />
         </div>
       </div>
@@ -85,14 +83,16 @@ export { Inbox as UnconnectedInbox };
 const mapStateToProps = (state, ownProps) => {
   return {
     emails: state.emibInbox.emails,
-    emailSummaries: state.emibInbox.emailSummaries
+    emailSummaries: state.emibInbox.emailSummaries,
+    currentEmail: state.emibInbox.currentEmail
   };
 };
 
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
-      readEmail
+      readEmail,
+      changeCurrentEmail
     },
     dispatch
   );

--- a/frontend/src/modules/EmibInboxRedux.js
+++ b/frontend/src/modules/EmibInboxRedux.js
@@ -27,6 +27,7 @@ const UPDATE_EMAIL = "emibInbox/UPDATE_EMAIL";
 const UPDATE_TASK = "emibInbox/UPDATE_TASK";
 const DELETE_EMAIL = "emibInbox/DELETE_EMAIL";
 const DELETE_TASK = "emibInbox/DELETE_TASK";
+const CHANGE_CURRENT_EMAIL = "emibInbox/CHANGE_CURRENT_EMAIL";
 
 // Action Creators
 const readEmail = emailIndex => ({ type: READ_EMAIL, emailIndex });
@@ -61,6 +62,12 @@ const deleteTask = (emailIndex, responseId) => ({
   responseId
 });
 
+// emailIndex refers to the index of the currently visible email
+const changeCurrentEmail = emailIndex => ({
+  type: CHANGE_CURRENT_EMAIL,
+  emailIndex
+});
+
 // Initial State
 // emails - represents an array of emailShape objects in the currently selected language.
 // emailSummaries - represents an array of objects indicating read state of each email.
@@ -71,7 +78,8 @@ const initialState = {
   emails: emailsJson.emailsEN,
   emailSummaries: initializeEmailSummaries(emailsJson.emailsEN.length),
   emailActions: initializeEmailActions(emailsJson.emailsEN.length),
-  addressBook: addressBookJson.addressBookEN
+  addressBook: addressBookJson.addressBookEN,
+  currentEmail: 0
 };
 
 // Reducer
@@ -161,6 +169,12 @@ const emibInbox = (state = initialState, action) => {
         emailSummaries: purifiedEmailSummaries,
         emailActions: purifiedEmailActions
       };
+    case CHANGE_CURRENT_EMAIL:
+      return {
+        ...state,
+        currentEmail: action.emailIndex
+      };
+
     default:
       return state;
   }
@@ -181,5 +195,6 @@ export {
   updateTask,
   deleteEmail,
   deleteTask,
-  selectEmailActions
+  selectEmailActions,
+  changeCurrentEmail
 };

--- a/frontend/src/tests/components/eMIB/Inbox.test.js
+++ b/frontend/src/tests/components/eMIB/Inbox.test.js
@@ -16,7 +16,9 @@ it("Displays 3 email previews when there are 3 emails", () => {
         { isRead: false, taskCount: 0, emailCount: 0 },
         { isRead: false, taskCount: 0, emailCount: 0 }
       ]}
+      currentEmail={0}
       readEmail={() => {}}
+      changeCurrentEmail={() => {}}
     />
   );
   expect(wrapper.find(EmailPreview).length).toEqual(INBOX_SPECS.length);

--- a/frontend/src/tests/modules/EmibInboxRedux.test.js
+++ b/frontend/src/tests/modules/EmibInboxRedux.test.js
@@ -6,7 +6,8 @@ import emibInbox, {
   updateEmail,
   deleteEmail,
   deleteTask,
-  updateTask
+  updateTask,
+  changeCurrentEmail
 } from "../../modules/EmibInboxRedux";
 import { EMAIL_TYPE, ACTION_TYPE } from "../../components/eMIB/constants";
 import { setLanguage } from "../../modules/LocalizeRedux";
@@ -18,7 +19,8 @@ describe("EmibInboxRedux", () => {
     stubbedInitialState = {
       emails: emailsJson.emailsEN,
       emailSummaries: initializeEmailSummaries(emailsJson.emailsEN.length),
-      emailActions: [[], [], []]
+      emailActions: [[], [], []],
+      currentEmail: 0
     };
   });
 
@@ -333,6 +335,18 @@ describe("EmibInboxRedux", () => {
       const addAction = addTask(0, taskAction);
       const newState = emibInbox(stubbedInitialState, addAction);
       expect(newState.emailActions[0]).toEqual([{ ...taskAction, actionType: ACTION_TYPE.task }]);
+    });
+
+    it("should change curent email", () => {
+      const changeAction1 = changeCurrentEmail(1);
+      const newState1 = emibInbox(stubbedInitialState, changeAction1);
+      expect(newState1.currentEmail).toEqual(1);
+      const changeAction2 = changeCurrentEmail(2);
+      const newState2 = emibInbox(newState1, changeAction2);
+      expect(newState2.currentEmail).toEqual(2);
+      const changeAction3 = changeCurrentEmail(3);
+      const newState3 = emibInbox(newState2, changeAction3);
+      expect(newState3.currentEmail).toEqual(3);
     });
   });
 });


### PR DESCRIPTION
# Description

Preserving current email in inbox redux rather than inbox state

## Type of change

- Code cleanliness or refactor

## Screenshot

Select 2nd email:
![image](https://user-images.githubusercontent.com/2746350/57142771-62fadc00-6d8b-11e9-9946-abe9ae471f10.png)

Change Tab:
![image](https://user-images.githubusercontent.com/2746350/57142801-7443e880-6d8b-11e9-96d9-d7a80c2f7d7b.png)

Change back:
![image](https://user-images.githubusercontent.com/2746350/57142821-7c038d00-6d8b-11e9-9124-d1fd99a1ee94.png)


# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Enter the test, open an email (other than the first)
2.  Change tabs
3.  Change back to Inbox, see that same email is open

# Checklist

Applicable for all code changes.

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
