### PR TITLE
Replace tabs with Bootstrap tabs

### DIFF
--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -9,8 +9,8 @@ const SECTION_HEIGHT = `calc(100vh - ${HEADER_HEIGHT + FOOTER_HEIGHT + 53}px)`;
 
 const styles = {
   windowPadding: {
-    paddingTop: 43,
-    order: 2
+    paddingTop: 38,
+    maxWidth: 300
   },
   h4: {
     textAlign: "left",
@@ -40,7 +40,6 @@ const styles = {
     borderWidth: "1px 1px 0 3px",
     borderStyle: "solid",
     borderColor: "#00565e",
-    borderRadius: "0 5px 0 0",
     width: "100%",
     height: NOTEPAD_HEIGHT
   },
@@ -67,8 +66,7 @@ const styles = {
     border: "none",
     backgroundColor: "#00565e",
     height: NOTEPAD_HEIGHT,
-    cursor: "pointer",
-    borderRadius: "0 5px 0 0"
+    cursor: "pointer"
   },
   openNotepadBtnIcon: {
     position: "absolute",

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -53,7 +53,7 @@ class Emib extends Component {
 
   state = {
     curPage: PAGES.preTest,
-    initialTab: 0,
+    currentTab: "instructions",
     disabledTabs: [1, 2],
     showEnterEmibPopup: false,
     testIsStarted: false,
@@ -82,6 +82,7 @@ class Emib extends Component {
     }
   };
 
+  // Pre-test functions
   openEnterEmibPopup = () => {
     this.setState({ showEnterEmibPopup: true });
   };
@@ -90,8 +91,13 @@ class Emib extends Component {
     this.setState({ showEnterEmibPopup: false });
   };
 
+  // Within eMIB Tabs functions
   handleStartTest = () => {
-    this.setState({ testIsStarted: true, disabledTabs: [], initialTab: 1 });
+    this.setState({ testIsStarted: true, disabledTabs: [], currentTab: "background" });
+  };
+
+  switchTab = tabId => {
+    this.setState({ currentTab: tabId });
   };
 
   openStartTestPopup = () => {
@@ -102,6 +108,7 @@ class Emib extends Component {
     this.setState({ showStartTestPopup: false });
   };
 
+  // Leaving the eMIB functions
   openSubmitPopup = () => {
     this.setState({ showSubmitPopup: true });
   };
@@ -140,16 +147,15 @@ class Emib extends Component {
         <Helmet>
           <title>{LOCALIZE.titles.eMIB}</title>
         </Helmet>
-        <div>
-          {this.state.curPage === PAGES.emibTabs && (
-            <EmibTabs
-              initialTab={this.state.initialTab}
-              disabledTabsArray={this.state.disabledTabs}
-            />
-          )}
-        </div>
+        {this.state.curPage === PAGES.emibTabs && (
+          <EmibTabs
+            currentTab={this.state.currentTab}
+            switchTab={this.switchTab}
+            disabledTabsArray={this.state.disabledTabs}
+          />
+        )}
         {this.state.curPage !== PAGES.emibTabs && (
-          <ContentContainer hideBanner={this.state.curPage === PAGES.emibTabs}>
+          <ContentContainer hideBanner={false}>
             {this.state.curPage === PAGES.preTest && (
               <EmibIntroductionPage showEnterEmibPopup={this.openEnterEmibPopup} />
             )}

--- a/frontend/src/components/eMIB/EmibTabs.jsx
+++ b/frontend/src/components/eMIB/EmibTabs.jsx
@@ -9,6 +9,7 @@ import Notepad from "../commons/Notepad";
 import "../../css/emib-tabs.css";
 import { HEADER_HEIGHT, FOOTER_HEIGHT } from "./constants";
 import { Helmet } from "react-helmet";
+import { Tabs, Tab } from "react-bootstrap";
 
 const TAB_HEIGHT = `calc(100vh - ${HEADER_HEIGHT + FOOTER_HEIGHT}px)`;
 
@@ -16,19 +17,10 @@ const styles = {
   container: {
     maxWidth: 1400,
     minWidth: 900,
-    margin: "0px auto",
     paddingTop: 20,
-    display: "flex",
     paddingRight: 20,
-    paddingLeft: 20
-  },
-  tabNavigation: {
-    height: TAB_HEIGHT,
-    backgroundColor: "white",
-    borderWidth: "0 1px",
-    borderStyle: "solid",
-    borderColor: "#00565e",
-    borderTopColor: "white"
+    paddingLeft: 20,
+    margin: "0px auto"
   }
 };
 
@@ -64,13 +56,17 @@ class EmibTabs extends Component {
         <Helmet>
           <title>{LOCALIZE.titles.simulation}</title>
         </Helmet>
-        <TabNavigation
-          tabSpecs={TABS}
-          initialTab={this.props.initialTab}
-          menuName={LOCALIZE.ariaLabel.tabMenu}
-          style={styles.tabNavigation}
-          disabledTabsArray={this.props.disabledTabsArray}
-        />
+        <Tabs defaultActiveKey="instructions" id="emib-tabs">
+          <Tab eventKey="instructions" title="Instructions">
+            <InTestInstructions />
+          </Tab>
+          <Tab eventKey="background" title="Background">
+            <Background />
+          </Tab>
+          <Tab eventKey="inbox" title="Inbox">
+            <Inbox />
+          </Tab>
+        </Tabs>
         <Notepad />
       </div>
     );

--- a/frontend/src/components/eMIB/EmibTabs.jsx
+++ b/frontend/src/components/eMIB/EmibTabs.jsx
@@ -3,11 +3,8 @@ import PropTypes from "prop-types";
 import Background from "./Background";
 import Inbox from "./Inbox";
 import LOCALIZE from "../../text_resources";
-import TabNavigation from "../commons/TabNavigation";
 import InTestInstructions from "./InTestInstructions";
 import Notepad from "../commons/Notepad";
-import "../../css/emib-tabs.css";
-import { HEADER_HEIGHT, FOOTER_HEIGHT } from "./constants";
 import { Helmet } from "react-helmet";
 import { Tabs, Tab, Container, Row, Col } from "react-bootstrap";
 
@@ -24,7 +21,8 @@ const styles = {
 
 class EmibTabs extends Component {
   static propTypes = {
-    initialTab: PropTypes.number.isRequired,
+    currentTab: PropTypes.string.isRequired,
+    switchTab: PropTypes.func.isRequired,
     /* used to disable specific tabs
     disabledTabsArray={[1, 2]} will disable the second and third tabs
     disabledTabsArray={[]} will keep all the tabs enabled */
@@ -34,17 +32,17 @@ class EmibTabs extends Component {
   render() {
     const TABS = [
       {
-        id: 0,
+        key: "instructions",
         tabName: LOCALIZE.emibTest.tabs.instructionsTabTitle,
         body: <InTestInstructions />
       },
       {
-        id: 1,
+        key: "background",
         tabName: LOCALIZE.emibTest.tabs.backgroundTabTitle,
         body: <Background />
       },
       {
-        id: 2,
+        key: "inbox",
         tabName: LOCALIZE.emibTest.tabs.inboxTabTitle,
         body: <Inbox />
       }
@@ -57,16 +55,20 @@ class EmibTabs extends Component {
         <Container>
           <Row>
             <Col>
-              <Tabs defaultActiveKey="instructions" id="emib-tabs">
-                <Tab eventKey="instructions" title="Instructions">
-                  <InTestInstructions />
-                </Tab>
-                <Tab eventKey="background" title="Background">
-                  <Background />
-                </Tab>
-                <Tab eventKey="inbox" title="Inbox">
-                  <Inbox />
-                </Tab>
+              <Tabs
+                defaultActiveKey="instructions"
+                id="emib-tabs"
+                activeKey={this.props.currentTab}
+                onSelect={key => this.props.switchTab(key)}
+              >
+                {TABS.map((tab, index) => {
+                  const isDisabled = this.props.disabledTabsArray.indexOf(index) > -1;
+                  return (
+                    <Tab key={index} eventKey={tab.key} title={tab.tabName} disabled={isDisabled}>
+                      {tab.body}
+                    </Tab>
+                  );
+                })}
               </Tabs>
             </Col>
             <Col md="auto">

--- a/frontend/src/components/eMIB/EmibTabs.jsx
+++ b/frontend/src/components/eMIB/EmibTabs.jsx
@@ -9,9 +9,7 @@ import Notepad from "../commons/Notepad";
 import "../../css/emib-tabs.css";
 import { HEADER_HEIGHT, FOOTER_HEIGHT } from "./constants";
 import { Helmet } from "react-helmet";
-import { Tabs, Tab } from "react-bootstrap";
-
-const TAB_HEIGHT = `calc(100vh - ${HEADER_HEIGHT + FOOTER_HEIGHT}px)`;
+import { Tabs, Tab, Container, Row, Col } from "react-bootstrap";
 
 const styles = {
   container: {
@@ -56,18 +54,26 @@ class EmibTabs extends Component {
         <Helmet>
           <title>{LOCALIZE.titles.simulation}</title>
         </Helmet>
-        <Tabs defaultActiveKey="instructions" id="emib-tabs">
-          <Tab eventKey="instructions" title="Instructions">
-            <InTestInstructions />
-          </Tab>
-          <Tab eventKey="background" title="Background">
-            <Background />
-          </Tab>
-          <Tab eventKey="inbox" title="Inbox">
-            <Inbox />
-          </Tab>
-        </Tabs>
-        <Notepad />
+        <Container>
+          <Row>
+            <Col>
+              <Tabs defaultActiveKey="instructions" id="emib-tabs">
+                <Tab eventKey="instructions" title="Instructions">
+                  <InTestInstructions />
+                </Tab>
+                <Tab eventKey="background" title="Background">
+                  <Background />
+                </Tab>
+                <Tab eventKey="inbox" title="Inbox">
+                  <Inbox />
+                </Tab>
+              </Tabs>
+            </Col>
+            <Col md="auto">
+              <Notepad />
+            </Col>
+          </Row>
+        </Container>
       </div>
     );
   }

--- a/frontend/src/components/eMIB/SideNavigation.jsx
+++ b/frontend/src/components/eMIB/SideNavigation.jsx
@@ -13,7 +13,8 @@ const styles = {
     paddingRight: 20,
     paddingTop: 10,
     paddingBottom: 10,
-    height: BODY_HEIGHT
+    height: BODY_HEIGHT,
+    textAlign: "left"
   },
   nav: {
     marginTop: 10,

--- a/frontend/src/components/eMIB/constants.js
+++ b/frontend/src/components/eMIB/constants.js
@@ -1,8 +1,8 @@
 import PropTypes from "prop-types";
 
 // Display
-export const HEADER_HEIGHT = 130;
-export const FOOTER_HEIGHT = 62;
+export const HEADER_HEIGHT = 125;
+export const FOOTER_HEIGHT = 60;
 
 // Data structures
 


### PR DESCRIPTION
# Description

Replacing eMIB tabs with reactbootstrap tabs for accessibility purposes. 

Still need to in future prs:
 - replace tabs on logins
 - delete custom tabs
 - add "disabled" tooltips to the boostrap tabs
 - have a pairing session with joey

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Code cleanliness or refactor

## Screenshot
<img width="1210" alt="Screen Shot 2019-05-03 at 12 28 07 PM" src="https://user-images.githubusercontent.com/4640747/57151426-f2f65100-6d9e-11e9-8d69-9958a139fd6a.png">


# Testing

Manual steps to reproduce this functionality:

1.  Navigate through the sample test.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~ using a component library that's already tested
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 11+ and Chrome - I'm on my macbook.
