### PR TITLE
Accessibility - remove tab indexes

### DIFF
--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -112,7 +112,7 @@ class ActionViewEmail extends Component {
     const visibleCcNames = this.generateEmailNameList(action.emailCc);
     return (
       <div aria-label={LOCALIZE.ariaLabel.responseDetails}>
-        <div style={styles.header.zone} tabIndex="0">
+        <div style={styles.header.zone}>
           <div style={styles.header.elementHeight}>
             <h6 style={styles.responseType.description}>
               {LOCALIZE.emibTest.inboxPage.emailResponse.description}
@@ -156,12 +156,12 @@ class ActionViewEmail extends Component {
           </div>
         </div>
         <hr style={styles.hr} />
-        <div tabIndex="0">
+        <div>
           <h6>{LOCALIZE.emibTest.inboxPage.emailResponse.response}</h6>
           <p style={styles.preWrap}>{action.emailBody}</p>
         </div>
         <hr style={styles.hr} />
-        <div tabIndex="0">
+        <div>
           <h6>{LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}</h6>
           <p style={styles.preWrap}>{action.reasonsForAction}</p>
         </div>

--- a/frontend/src/components/eMIB/ActionViewTask.jsx
+++ b/frontend/src/components/eMIB/ActionViewTask.jsx
@@ -61,12 +61,12 @@ class ActionViewTask extends Component {
     const action = this.props.action;
     return (
       <div aria-label={LOCALIZE.ariaLabel.taskDetails}>
-        <div tabIndex="0">
+        <div>
           <h6 style={styles.taskStyle}>{LOCALIZE.emibTest.inboxPage.taskContent.task}</h6>
           <p style={styles.preWrap}>{action.task}</p>
         </div>
         <hr style={styles.hr} />
-        <div tabIndex="0">
+        <div>
           <h6>{LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}</h6>
           <p style={styles.preWrap}>{action.reasonsForAction}</p>
         </div>

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -168,7 +168,6 @@ class EditTask extends Component {
                 <i
                   id="task-tooltip"
                   aria-label={LOCALIZE.ariaLabel.taskTooltip}
-                  tabIndex="0"
                   className={taskTooltipIcon}
                   style={styles.tasks.icon}
                   onFocus={this.onTaskTooltipFocus}
@@ -214,7 +213,6 @@ class EditTask extends Component {
                 <i
                   id="reasons-for-action-tooltip"
                   aria-label={LOCALIZE.ariaLabel.reasonsForActionTooltip}
-                  tabIndex="0"
                   className={reasonsForActionTooltipIcon}
                   style={styles.reasonsForAction.icon}
                   onFocus={this.onReasonsForActionTooltipFocus}


### PR DESCRIPTION
# Description

Where we have tab indexes is causing problems so removing them for now.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

no visual change.

# Testing

Shouldn't tab into examples anymore.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new compiler warnings
- [ ] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 11+ and Chrome
