### PR TITLE
[PopupBox] Added new props for additional customization purposes

### DIFF
--- a/frontend/src/components/commons/PopupBox.jsx
+++ b/frontend/src/components/commons/PopupBox.jsx
@@ -13,10 +13,6 @@ export const BUTTON_STATE = {
   enabled: false
 };
 
-export const BACKDROP = {
-  static: "static"
-};
-
 const styles = {
   boxshape: {
     borderWidth: "1px 1px 0 1px",
@@ -69,7 +65,7 @@ class PopupBox extends Component {
       rightButtonTitle: PropTypes.string,
       rightButtonAction: PropTypes.func,
       rightButtonState: PropTypes.string,
-      backdrop: PropTypes.string,
+      isBackdropStatic: PropTypes.bool,
       isCloseButtonVisible: PropTypes.bool
     };
     // display 'close button' by default
@@ -113,7 +109,7 @@ class PopupBox extends Component {
         autoFocus={true}
         enforceFocus={true}
         aria-hidden={false}
-        backdrop={this.props.backdrop}
+        backdrop={this.props.isBackdropStatic ? false : true}
       >
         <div style={styles.boxContent}>
           <Modal.Header closeButton={this.props.isCloseButtonVisible} style={styles.modalHeader}>

--- a/frontend/src/components/commons/PopupBox.jsx
+++ b/frontend/src/components/commons/PopupBox.jsx
@@ -70,11 +70,11 @@ class PopupBox extends Component {
       rightButtonAction: PropTypes.func,
       rightButtonState: PropTypes.string,
       backdrop: PropTypes.string,
-      closeButton: PropTypes.bool
+      isCloseButtonVisible: PropTypes.bool
     };
     // display 'close button' by default
     PopupBox.defaultProps = {
-      closeButton: true
+      isCloseButtonVisible: true
     };
   }
 
@@ -116,7 +116,7 @@ class PopupBox extends Component {
         backdrop={this.props.backdrop}
       >
         <div style={styles.boxContent}>
-          <Modal.Header closeButton={this.props.closeButton} style={styles.modalHeader}>
+          <Modal.Header closeButton={this.props.isCloseButtonVisible} style={styles.modalHeader}>
             <Modal.Title id="unit-test-popup-box-title" style={styles.modelTitle}>
               {title}
             </Modal.Title>

--- a/frontend/src/components/commons/PopupBox.jsx
+++ b/frontend/src/components/commons/PopupBox.jsx
@@ -13,6 +13,10 @@ export const BUTTON_STATE = {
   enabled: false
 };
 
+export const BACKDROP = {
+  static: "static"
+};
+
 const styles = {
   boxshape: {
     borderWidth: "1px 1px 0 1px",
@@ -64,7 +68,13 @@ class PopupBox extends Component {
       rightButtonType: PropTypes.string,
       rightButtonTitle: PropTypes.string,
       rightButtonAction: PropTypes.func,
-      rightButtonState: PropTypes.string
+      rightButtonState: PropTypes.string,
+      backdrop: PropTypes.string,
+      closeButton: PropTypes.bool
+    };
+    // display 'close button' by default
+    PopupBox.defaultProps = {
+      closeButton: true
     };
   }
 
@@ -103,9 +113,10 @@ class PopupBox extends Component {
         autoFocus={true}
         enforceFocus={true}
         aria-hidden={false}
+        backdrop={this.props.backdrop}
       >
         <div style={styles.boxContent}>
-          <Modal.Header closeButton style={styles.modalHeader}>
+          <Modal.Header closeButton={this.props.closeButton} style={styles.modalHeader}>
             <Modal.Title id="unit-test-popup-box-title" style={styles.modelTitle}>
               {title}
             </Modal.Title>


### PR DESCRIPTION
# Description

This PR is adding two new _props_ in **PopupBox** component. These new _props_ allow us to display or not the close button in the top right corner and allow us to set the **backdrop** to true or false (if set to true, you will not be able to close the popup box by clicking outside of it).

Here is an example that shows how to use it:

![image](https://user-images.githubusercontent.com/23021242/57643237-4dee2c00-7587-11e9-8873-d947558b9ab0.png)

These new _props_ will definitely be helpful in future PRs.

## Type of change

- New feature (non-breaking change which adds functionality)
- Code cleanliness or refactor

## Screenshot

**isCloseButtonVisible set to _false_:**

![image](https://user-images.githubusercontent.com/23021242/57618160-aa822480-7550-11e9-8aa1-9ae640d68cd4.png)

**isCloseButtonVisible set to _true_ or isCloseButtonVisible prop not present:**

![image](https://user-images.githubusercontent.com/23021242/57618340-1c5a6e00-7551-11e9-96fa-558204e4ef60.png)

**isBackdropStatic set to true (cannot close popup by clicking outside of it):**

![image](https://user-images.githubusercontent.com/23021242/57618410-4b70df80-7551-11e9-820f-1863ffc1feed.png)

**isBackdropStatic set to false or prop not present (can close popup by clicking outside of it):**

![image](https://user-images.githubusercontent.com/23021242/57618493-8ffc7b00-7551-11e9-8c6f-6aedc232c864.png)

# Testing

Manual steps to reproduce this functionality:

1.  Add these new props to one of the existing popup box.
2.  Make sure you get the expected behavior.

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 11+ and Chrome
