### PR TITLE
[Instructions and background] Add tab-index to main content

### DIFF
--- a/frontend/src/components/eMIB/SideNavigation.jsx
+++ b/frontend/src/components/eMIB/SideNavigation.jsx
@@ -49,7 +49,7 @@ class SideNavigation extends Component {
             </Nav>
           </Col>
           <Col sm={9}>
-            <Tab.Content>
+            <Tab.Content tabIndex={0}>
               {specs.map((item, index) => {
                 return (
                   <Tab.Pane key={index} eventKey={EVENT_KEYS[index]}>


### PR DESCRIPTION
# Description

Add tab index to the center column of content - this means you can tab to the content once selecting the side navigation. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

No visible changes.

# Testing

Manual steps to reproduce this functionality:

1.  go to the sample test
2. tab to the side nav and select an option
3. the next time you tab should take you to the main text content.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
