### PR TITLE
[Bug Fix] Empty response patch

### DIFF
--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -99,6 +99,9 @@ class ActionViewEmail extends Component {
   // the return is a string in the following format:
   //  "<name 1> (<role 1>), <name 2> (<role 2>), ...""
   generateEmailNameList(contactIdList) {
+    if (contactIdList === undefined) {
+      return "";
+    }
     let visibleContactNames = [];
     for (let id of contactIdList) {
       visibleContactNames.push(contactNameFromId(this.props.addressBook, id));

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -318,7 +318,8 @@ class EditEmail extends Component {
                 />
               </div>
               <div style={styles.textCounter}>
-                {this.state.emailBody.length}/{MAX_RESPONSE}
+                {this.state.emailBody === undefined ? 0 : this.state.emailBody.length}/
+                {MAX_RESPONSE}
               </div>
             </div>
           </div>
@@ -338,7 +339,8 @@ class EditEmail extends Component {
                 />
               </div>
               <div style={styles.textCounter}>
-                {this.state.reasonsForAction.length}/{MAX_REASON}
+                {this.state.reasonsForAction === undefined ? 0 : this.state.reasonsForAction.length}
+                /{MAX_REASON}
               </div>
             </div>
           </div>

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -184,7 +184,7 @@ class EditTask extends Component {
                 />
               </div>
               <div style={styles.textCounter}>
-                {this.state.task.length}/{MAX_TASK}
+                {this.state.task === undefined ? 0 : this.state.task.length}/{MAX_TASK}
               </div>
             </div>
           </div>
@@ -229,7 +229,8 @@ class EditTask extends Component {
                 />
               </div>
               <div style={styles.textCounter}>
-                {this.state.reasonsForAction.length}/{MAX_REASON}
+                {this.state.reasonsForAction === undefined ? 0 : this.state.reasonsForAction}/
+                {MAX_REASON}
               </div>
             </div>
           </div>

--- a/frontend/src/tests/components/eMIB/ActionViewEmail.test.js
+++ b/frontend/src/tests/components/eMIB/ActionViewEmail.test.js
@@ -148,3 +148,15 @@ function createWrapper(responseType, cc, deleteEmail) {
     />
   );
 }
+
+it("it renders when the email is undefined", () => {
+  shallow(
+    <UnconnectedActionViewEmail
+      actionId={0}
+      action={{ actionType: ACTION_TYPE.email }}
+      email={emailStub}
+      deleteEmail={() => {}}
+      addressBook={addressBook}
+    />
+  );
+});

--- a/frontend/src/tests/components/eMIB/ActionViewTask.test.js
+++ b/frontend/src/tests/components/eMIB/ActionViewTask.test.js
@@ -87,3 +87,15 @@ describe("check that the disabled prop works as expected", () => {
     expect(wrapper.find("#unit-test-view-task-delete-button").exists()).toEqual(false);
   });
 });
+
+it("it renders when the email is undefined", () => {
+  shallow(
+    <UnconnectedActionViewTask
+      actionId={0}
+      action={{ actionType: ACTION_TYPE.task }}
+      email={emailStub}
+      deleteTask={() => {}}
+      disabled={false}
+    />
+  );
+});

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -400,3 +400,33 @@ describe("edit action dialog helper file", () => {
     ).toBe(true);
   });
 });
+
+it("renders EditActionDialog with an edit empty email response", () => {
+  emptyActionMount(ACTION_TYPE.email);
+});
+
+it("renders EditActionDialog with an edit empty task response", () => {
+  emptyActionMount(ACTION_TYPE.task);
+});
+
+function emptyActionMount(actionType) {
+  mount(
+    <Provider store={mockStore(initialState)}>
+      <EditActionDialog
+        email={emailStub}
+        showDialog={true}
+        handleClose={() => {}}
+        addEmail={() => {}}
+        addTask={() => {}}
+        updateEmail={() => {}}
+        updateTask={() => {}}
+        readEmail={() => {}}
+        actionType={actionType}
+        editMode={EDIT_MODE.update}
+        action={{
+          actionType: actionType
+        }}
+      />
+    </Provider>
+  );
+}

--- a/frontend/src/tests/modules/EmibInboxRedux.test.js
+++ b/frontend/src/tests/modules/EmibInboxRedux.test.js
@@ -349,4 +349,24 @@ describe("EmibInboxRedux", () => {
       expect(newState3.currentEmail).toEqual(3);
     });
   });
+
+  it("should add an empty email action to the action list", () => {
+    const addAction = addEmail(0, {});
+    const newState1 = emibInbox(stubbedInitialState, addAction);
+    expect(newState1.emailActions[0]).toEqual([{ ...{}, actionType: ACTION_TYPE.email }]);
+
+    const updateAction = updateEmail(0, 0, {});
+    const newState2 = emibInbox(newState1, updateAction);
+    expect(newState2.emailActions[0]).toEqual([{ ...{}, actionType: ACTION_TYPE.email }]);
+  });
+
+  it("should add an empty task action to the action list", () => {
+    const addAction = addTask(0, {});
+    const newState1 = emibInbox(stubbedInitialState, addAction);
+    expect(newState1.emailActions[0]).toEqual([{ ...{}, actionType: ACTION_TYPE.task }]);
+
+    const updateAction = updateTask(0, 0, {});
+    const newState2 = emibInbox(newState1, updateAction);
+    expect(newState2.emailActions[0]).toEqual([{ ...{}, actionType: ACTION_TYPE.task }]);
+  });
 });


### PR DESCRIPTION
# Description

Fixing the bug where an empty email response will not render in the preview; cannot be edited; and where an empty task cannot be edited.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

N/A

# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Add an empty email and task
2.  Verify that you can preview both without a crash
3.  Verify that you can edit both without a crash

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
