### PR TITLE
[Accessibility] Remove unnecessary headings

### DIFF
--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -14,10 +14,6 @@ import { contactNameFromId } from "../../helpers/transformations";
 
 const styles = {
   responseType: {
-    description: {
-      float: "left",
-      margin: "4px 0 0 0"
-    },
     icon: {
       color: "white",
       margin: "0 8px",
@@ -29,23 +25,6 @@ const styles = {
     attribute: {
       color: "#00565E",
       textDecoration: "underline"
-    }
-  },
-  header: {
-    zone: {
-      minHeight: 95
-    },
-    elementHeight: {
-      minHeight: 24
-    },
-    toAndCcTitle: {
-      float: "left",
-      width: 32,
-      height: 32,
-      margin: "2px 0 0 0"
-    },
-    toFieldMargin: {
-      margin: "9px 0 12px 0"
     }
   },
   hr: {
@@ -115,11 +94,9 @@ class ActionViewEmail extends Component {
     const visibleCcNames = this.generateEmailNameList(action.emailCc);
     return (
       <div aria-label={LOCALIZE.ariaLabel.responseDetails}>
-        <div style={styles.header.zone}>
-          <div style={styles.header.elementHeight}>
-            <h6 style={styles.responseType.description}>
-              {LOCALIZE.emibTest.inboxPage.emailResponse.description}
-            </h6>
+        <div>
+          <div>
+            {LOCALIZE.emibTest.inboxPage.emailResponse.description}
             {action.emailType === EMAIL_TYPE.reply && (
               <>
                 <i className="fas fa-reply" style={styles.responseType.icon} />
@@ -128,6 +105,7 @@ class ActionViewEmail extends Component {
                 </span>
               </>
             )}
+
             {action.emailType === EMAIL_TYPE.replyAll && (
               <>
                 <i className="fas fa-reply-all" style={styles.responseType.icon} />
@@ -145,27 +123,23 @@ class ActionViewEmail extends Component {
               </>
             )}
           </div>
-          <div style={{ ...styles.header.toFieldMargin, ...styles.header.elementHeight }}>
-            <h6 style={styles.header.toAndCcTitle}>
-              {LOCALIZE.emibTest.inboxPage.emailCommons.to}
-            </h6>
+          <div>
+            {LOCALIZE.emibTest.inboxPage.emailCommons.to}
             <span>{visibleToNames}</span>
           </div>
-          <div style={styles.header.elementHeight}>
-            <h6 style={styles.header.toAndCcTitle}>
-              {LOCALIZE.emibTest.inboxPage.emailCommons.cc}
-            </h6>
+          <div>
+            {LOCALIZE.emibTest.inboxPage.emailCommons.cc}
             <span>{visibleCcNames}</span>
           </div>
         </div>
         <hr style={styles.hr} />
         <div>
-          <h6>{LOCALIZE.emibTest.inboxPage.emailResponse.response}</h6>
+          <div>{LOCALIZE.emibTest.inboxPage.emailResponse.response}</div>
           <p style={styles.preWrap}>{action.emailBody}</p>
         </div>
         <hr style={styles.hr} />
         <div>
-          <h6>{LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}</h6>
+          <div>{LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}</div>
           <p style={styles.preWrap}>{action.reasonsForAction}</p>
         </div>
         {!this.props.disabled && (

--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -105,7 +105,9 @@ class ActionViewEmail extends Component {
       <div aria-label={LOCALIZE.ariaLabel.responseDetails}>
         <div>
           <div style={styles.type}>
-            {LOCALIZE.emibTest.inboxPage.emailResponse.description}
+            <span style={styles.headings}>
+              {LOCALIZE.emibTest.inboxPage.emailResponse.description}
+            </span>
             {action.emailType === EMAIL_TYPE.reply && (
               <>
                 <i className="fas fa-reply" style={styles.responseType.icon} />

--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -13,6 +13,15 @@ import { contactShape } from "./constants";
 import { contactNameFromId } from "../../helpers/transformations";
 
 const styles = {
+  type: {
+    minHeight: 35
+  },
+  replyAndUser: {
+    color: "#00565E"
+  },
+  headings: {
+    fontWeight: "bold"
+  },
   responseType: {
     icon: {
       color: "white",
@@ -95,7 +104,7 @@ class ActionViewEmail extends Component {
     return (
       <div aria-label={LOCALIZE.ariaLabel.responseDetails}>
         <div>
-          <div>
+          <div style={styles.type}>
             {LOCALIZE.emibTest.inboxPage.emailResponse.description}
             {action.emailType === EMAIL_TYPE.reply && (
               <>
@@ -124,22 +133,24 @@ class ActionViewEmail extends Component {
             )}
           </div>
           <div>
-            {LOCALIZE.emibTest.inboxPage.emailCommons.to}
-            <span>{visibleToNames}</span>
+            {LOCALIZE.emibTest.inboxPage.emailCommons.to}{" "}
+            <span style={styles.replyAndUser}>{visibleToNames}</span>
           </div>
           <div>
-            {LOCALIZE.emibTest.inboxPage.emailCommons.cc}
-            <span>{visibleCcNames}</span>
+            {LOCALIZE.emibTest.inboxPage.emailCommons.cc}{" "}
+            <span style={styles.replyAndUser}>{visibleCcNames}</span>
           </div>
         </div>
         <hr style={styles.hr} />
         <div>
-          <div>{LOCALIZE.emibTest.inboxPage.emailResponse.response}</div>
+          <div style={styles.headings}>{LOCALIZE.emibTest.inboxPage.emailResponse.response}</div>
           <p style={styles.preWrap}>{action.emailBody}</p>
         </div>
         <hr style={styles.hr} />
         <div>
-          <div>{LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}</div>
+          <div style={styles.headings}>
+            {LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}
+          </div>
           <p style={styles.preWrap}>{action.reasonsForAction}</p>
         </div>
         {!this.props.disabled && (

--- a/frontend/src/components/eMIB/ActionViewTask.jsx
+++ b/frontend/src/components/eMIB/ActionViewTask.jsx
@@ -11,9 +11,6 @@ import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
 import SystemMessage, { MESSAGE_TYPE } from "../commons/SystemMessage";
 
 const styles = {
-  taskStyle: {
-    marginTop: 18
-  },
   hr: {
     margin: "16px 0 16px 0"
   },
@@ -62,12 +59,12 @@ class ActionViewTask extends Component {
     return (
       <div aria-label={LOCALIZE.ariaLabel.taskDetails}>
         <div>
-          <h6 style={styles.taskStyle}>{LOCALIZE.emibTest.inboxPage.taskContent.task}</h6>
+          <div>{LOCALIZE.emibTest.inboxPage.taskContent.task}</div>
           <p style={styles.preWrap}>{action.task}</p>
         </div>
         <hr style={styles.hr} />
         <div>
-          <h6>{LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}</h6>
+          <div>{LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}</div>
           <p style={styles.preWrap}>{action.reasonsForAction}</p>
         </div>
         {!this.props.disabled && (

--- a/frontend/src/components/eMIB/ActionViewTask.jsx
+++ b/frontend/src/components/eMIB/ActionViewTask.jsx
@@ -11,6 +11,9 @@ import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
 import SystemMessage, { MESSAGE_TYPE } from "../commons/SystemMessage";
 
 const styles = {
+  headings: {
+    fontWeight: "bold"
+  },
   hr: {
     margin: "16px 0 16px 0"
   },
@@ -59,12 +62,14 @@ class ActionViewTask extends Component {
     return (
       <div aria-label={LOCALIZE.ariaLabel.taskDetails}>
         <div>
-          <div>{LOCALIZE.emibTest.inboxPage.taskContent.task}</div>
+          <div style={styles.headings}>{LOCALIZE.emibTest.inboxPage.taskContent.task}</div>
           <p style={styles.preWrap}>{action.task}</p>
         </div>
         <hr style={styles.hr} />
         <div>
-          <div>{LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}</div>
+          <div style={styles.headings}>
+            {LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}
+          </div>
           <p style={styles.preWrap}>{action.reasonsForAction}</p>
         </div>
         {!this.props.disabled && (

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -31,7 +31,7 @@ const styles = {
     paddingBottom: 12
   },
   originalEmail: {
-    padding: "0 12px",
+    padding: 12,
     marginRight: 12,
     border: "1px #00565E solid",
     borderRadius: 4

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -81,10 +81,10 @@ class Email extends Component {
     return (
       <div style={styles.email}>
         <div style={styles.header}>
-          <h2 style={styles.emailId}>
+          <div style={styles.emailId}>
             {LOCALIZE.emibTest.inboxPage.emailId.toUpperCase()}
             {email.id + 1}
-          </h2>
+          </div>
           {hasTakenAction && (
             <div className="font-weight-bold" style={styles.replyStatus}>
               <i className="fas fa-sign-out-alt" style={styles.replyIcon} />

--- a/frontend/src/components/eMIB/EmailContent.jsx
+++ b/frontend/src/components/eMIB/EmailContent.jsx
@@ -16,7 +16,7 @@ const styles = {
     whiteSpace: "pre-wrap"
   },
   subject: {
-    marginTop: 0
+    fontSize: 20
   }
 };
 
@@ -29,7 +29,9 @@ class EmailContent extends Component {
     const { email } = this.props;
     return (
       <div>
-        <h3 style={styles.subject}>{email.subject}</h3>
+        <div style={styles.subject}>
+          {LOCALIZE.emibTest.inboxPage.subject + ": " + email.subject}
+        </div>
         <div>
           {LOCALIZE.emibTest.inboxPage.from}: <span style={styles.replyAndUser}>{email.from}</span>
         </div>

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -367,6 +367,7 @@ let LOCALIZE = new LocalizedStrings({
       //Inbox Page
       inboxPage: {
         emailId: " email id# ",
+        subject: "Subject",
         to: "To",
         from: "From",
         date: "Date",
@@ -902,6 +903,7 @@ let LOCALIZE = new LocalizedStrings({
       //Inbox Page
       inboxPage: {
         emailId: " courriel # ",
+        subject: "FR Subject",
         to: "À",
         from: "Expéditeur",
         date: "Date",


### PR DESCRIPTION
# Description

Remove unnecessary headings in the original email, action view email and action view task. These were really hard to navigate with a screen reader.

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Screenshot
<img width="590" alt="Screen Shot 2019-05-15 at 9 24 00 AM" src="https://user-images.githubusercontent.com/4640747/57779014-4ea3d100-76f3-11e9-9992-a5c4a62c9932.png">
<img width="587" alt="Screen Shot 2019-05-15 at 9 24 13 AM" src="https://user-images.githubusercontent.com/4640747/57779015-4ea3d100-76f3-11e9-9e55-f43acab56a2d.png">
<img width="585" alt="Screen Shot 2019-05-15 at 9 24 20 AM" src="https://user-images.githubusercontent.com/4640747/57779016-4ea3d100-76f3-11e9-8428-fbdcf815ff58.png">
<img width="579" alt="Screen Shot 2019-05-15 at 9 24 32 AM" src="https://user-images.githubusercontent.com/4640747/57779017-4ea3d100-76f3-11e9-8b8a-88839857e4cf.png">
<img width="563" alt="Screen Shot 2019-05-15 at 9 24 44 AM" src="https://user-images.githubusercontent.com/4640747/57779018-4ea3d100-76f3-11e9-86df-d8f049e0749c.png">


# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Go to the sample test.
2. See examples in the instructions
3. See emails in the inbox (original, and ones you add)

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 11+ and Chrome
