### PR TITLE
[Bug Fix] Default email type

### DIFF
--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -118,11 +118,6 @@ class EditActionDialog extends Component {
 
   handleSave = () => {
     this.props.handleClose();
-    // if it is an email, and there is no emailType defined, default to reply
-    /*if (this.props.actionType === ACTION_TYPE.email && this.state.action.emailType === undefined) {
-      this.state.action.emailType = EMAIL_TYPE.reply;
-    }*/
-
     // determine which function to call depening on action type and edit mode
     if (this.props.actionType === ACTION_TYPE.email && this.props.editMode === EDIT_MODE.create) {
       this.props.addEmail(this.props.email.id, this.state.action);

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -100,12 +100,19 @@ class EditActionDialog extends Component {
 
   // function to check if there already is an emailType or default to reply if there isn't one
   defaultEmailType() {
+    // if a task, return nothing
+    if (this.props.actionType === ACTION_TYPE.task) {
+      return undefined;
+    }
+    // if an email with no action, return reply
     if (this.props.action === undefined) {
       return EMAIL_TYPE.reply;
     }
+    // if an email with no action.emailType, return reply
     if (this.props.action.emailType === undefined) {
       return EMAIL_TYPE.reply;
     }
+    // otherwise, return the emailType
     return this.props.action.emailType;
   }
 

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -8,7 +8,7 @@ import EditTask from "./EditTask";
 import { Modal } from "react-bootstrap";
 import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
 import SystemMessage, { MESSAGE_TYPE } from "../commons/SystemMessage";
-import { ACTION_TYPE, EDIT_MODE, actionShape, emailShape } from "./constants";
+import { ACTION_TYPE, EDIT_MODE, actionShape, emailShape, EMAIL_TYPE } from "./constants";
 import EmailContent from "./EmailContent";
 import {
   addEmail,
@@ -91,12 +91,32 @@ class EditActionDialog extends Component {
   };
 
   state = {
-    action: { ...this.props.action },
+    action: {
+      ...this.props.action,
+      ...{ emailType: this.defaultEmailType() }
+    },
     showCancelConfirmationDialog: false
   };
 
+  // function to check if there already is an emailType or default to reply if there isn't one
+  defaultEmailType() {
+    if (this.props.action === undefined) {
+      return EMAIL_TYPE.reply;
+    }
+    if (this.props.action.emailType === undefined) {
+      return EMAIL_TYPE.reply;
+    }
+    return this.props.action.emailType;
+  }
+
   handleSave = () => {
     this.props.handleClose();
+    // if it is an email, and there is no emailType defined, default to reply
+    /*if (this.props.actionType === ACTION_TYPE.email && this.state.action.emailType === undefined) {
+      this.state.action.emailType = EMAIL_TYPE.reply;
+    }*/
+
+    // determine which function to call depening on action type and edit mode
     if (this.props.actionType === ACTION_TYPE.email && this.props.editMode === EDIT_MODE.create) {
       this.props.addEmail(this.props.email.id, this.state.action);
       this.props.readEmail(this.props.email.id);

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -96,6 +96,8 @@ function testCore(actionType, editMode) {
         .first()
         .hasClass(taskIcon)
     ).toEqual(false);
+    // verify that the empty emailType is overridden to be a reply
+    expect(wrapper.state("action").emailType).toEqual(EMAIL_TYPE.reply);
   }
   if (actionType === ACTION_TYPE.task) {
     expect(
@@ -429,4 +431,39 @@ function emptyActionMount(actionType) {
       />
     </Provider>
   );
+}
+
+it("check that undefined email type is overriden to be reply", () => {
+  checkEmailTypeOverride(undefined);
+});
+
+it("check that replyAll email type is not overridden", () => {
+  checkEmailTypeOverride(EMAIL_TYPE.replyAll);
+});
+
+it("check that forward email type is not overridden", () => {
+  checkEmailTypeOverride(EMAIL_TYPE.forward);
+});
+
+function checkEmailTypeOverride(emailType) {
+  const wrapper = shallow(
+    <EditActionDialog
+      email={emailStub}
+      showDialog={true}
+      handleClose={() => {}}
+      addEmail={() => {}}
+      addTask={() => {}}
+      updateEmail={() => {}}
+      updateTask={() => {}}
+      readEmail={() => {}}
+      actionType={ACTION_TYPE.email}
+      action={{ actionType: ACTION_TYPE.email, emailType: emailType }}
+      editMode={EDIT_MODE.create}
+    />
+  );
+  if (emailType === undefined) {
+    expect(wrapper.state("action").emailType).toEqual(EMAIL_TYPE.reply);
+  } else {
+    expect(wrapper.state("action").emailType).toEqual(emailType);
+  }
 }


### PR DESCRIPTION
# Description

Added logic to check if the if the action in the prop is for an email. of so, and if the emailType is not defined, then default to reply.

Added tests to ensure the default is properly set (this test fails on master)
Added tests to ensure that if a email type is provided, it is not overriden.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

Create a new email:
![image](https://user-images.githubusercontent.com/2746350/57785903-91b87100-7700-11e9-9b32-160a847a1b48.png)

Save immediately with  no changes:
![image](https://user-images.githubusercontent.com/2746350/57785948-a432aa80-7700-11e9-9ebb-b32014f7a9cf.png)

See that it defaults to reply:
![image](https://user-images.githubusercontent.com/2746350/57785998-b876a780-7700-11e9-9739-4f8e9110c81c.png)


# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Start eMIB -> Pre test instructions -> Start test
2.  "Add email Response"
3.  "Save response" without making any changes
4.  View the email reply
5.  **See that there it now defaults to reply**

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
