### PR TITLE
[Accessibility] inbox navigation 

### DIFF
--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -79,7 +79,7 @@ class Email extends Component {
     let emailNumber = 0;
     let taskNumber = 0;
     return (
-      <div style={styles.email}>
+      <div style={styles.email} tabIndex={0}>
         <div style={styles.header}>
           <div style={styles.emailId}>
             {LOCALIZE.emibTest.inboxPage.emailId.toUpperCase()}

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -79,7 +79,7 @@ class Email extends Component {
     let emailNumber = 0;
     let taskNumber = 0;
     return (
-      <div style={styles.email} tabIndex={0}>
+      <div style={styles.email}>
         <div style={styles.header}>
           <div style={styles.emailId}>
             {LOCALIZE.emibTest.inboxPage.emailId.toUpperCase()}

--- a/frontend/src/components/eMIB/EmailPreview.jsx
+++ b/frontend/src/components/eMIB/EmailPreview.jsx
@@ -7,10 +7,9 @@ import "../../css/inbox.css";
 const styles = {
   //buttons
   button: {
-    width: 202,
     textAlign: "left",
-    padding: 8,
-    borderWidth: "0 1px 1px 1px",
+    padding: 10,
+    borderWidth: "0px 1px 1px 1px",
     borderStyle: "solid",
     borderColor: "#00565E",
     cursor: "pointer",
@@ -64,7 +63,6 @@ const styles = {
 class EmailPreview extends Component {
   static propTypes = {
     email: emailShape,
-    selectEmail: PropTypes.func.isRequired,
     isRead: PropTypes.bool.isRequired,
     isRepliedTo: PropTypes.bool.isRequired,
     isSelected: PropTypes.bool.isRequired
@@ -103,21 +101,15 @@ class EmailPreview extends Component {
     };
     const email = this.props.email;
     return (
-      <li
+      <div
         id={
           this.props.isSelected
             ? "unit-test-selected-email-preview"
             : "unit-test-unselected-email-preview"
         }
         style={styles.li}
-        aria-current={this.props.isSelected ? "page" : ""}
-        role="menuitem"
       >
-        <button
-          className={this.props.isSelected ? "" : "email-preview-button"}
-          style={buttonStyle}
-          onClick={() => this.props.selectEmail(email.id)}
-        >
+        <div className={this.props.isSelected ? "" : "email-preview-button"} style={buttonStyle}>
           <div id={this.props.isRead ? "read-email-preview" : "unread-email-preview"}>
             {this.props.isRead ? (
               <i className="far fa-envelope-open" style={imageStyle} />
@@ -133,8 +125,8 @@ class EmailPreview extends Component {
           </div>
           <div style={subject}>{email.subject}</div>
           <div style={styles.truncated}>{email.from}</div>
-        </button>
-      </li>
+        </div>
+      </div>
     );
   }
 }

--- a/frontend/src/components/eMIB/EmibTabs.jsx
+++ b/frontend/src/components/eMIB/EmibTabs.jsx
@@ -60,29 +60,27 @@ class EmibTabs extends Component {
         <Helmet>
           <title>{LOCALIZE.titles.simulation}</title>
         </Helmet>
-        <Container>
-          <Row>
-            <Col>
-              <Tabs
-                defaultActiveKey="instructions"
-                id="emib-tabs"
-                activeKey={this.props.currentTab}
-                onSelect={key => this.props.switchTab(key)}
-              >
-                {TABS.map((tab, index) => {
-                  return (
-                    <Tab key={index} eventKey={tab.key} title={tab.tabName}>
-                      {tab.body}
-                    </Tab>
-                  );
-                })}
-              </Tabs>
-            </Col>
-            <Col md="auto" style={styles.notepad}>
-              <Notepad />
-            </Col>
-          </Row>
-        </Container>
+        <Row>
+          <Col>
+            <Tabs
+              defaultActiveKey="instructions"
+              id="emib-tabs"
+              activeKey={this.props.currentTab}
+              onSelect={key => this.props.switchTab(key)}
+            >
+              {TABS.map((tab, index) => {
+                return (
+                  <Tab key={index} eventKey={tab.key} title={tab.tabName}>
+                    {tab.body}
+                  </Tab>
+                );
+              })}
+            </Tabs>
+          </Col>
+          <Col md="auto" style={styles.notepad}>
+            <Notepad />
+          </Col>
+        </Row>
       </div>
     );
   }

--- a/frontend/src/components/eMIB/Inbox.jsx
+++ b/frontend/src/components/eMIB/Inbox.jsx
@@ -12,20 +12,33 @@ import { Tab, Row, Col, Nav } from "react-bootstrap";
 const INBOX_HEIGHT = `calc(100vh - ${HEADER_HEIGHT + FOOTER_HEIGHT}px)`;
 
 const styles = {
-  ul: {
-    borderBottom: "none"
-  },
-  buttonList: {
-    overflow: "auto",
-    height: INBOX_HEIGHT
-  },
   bodyContent: {
     overflow: "auto",
     height: INBOX_HEIGHT
+  },
+  contentColumn: {
+    paddingLeft: 0
+  },
+  navItem: {
+    width: "100%"
+  },
+  navLink: {
+    padding: 0
   }
 };
 
-const eventKeys = ["first", "second", "third"];
+const EVENT_KEYS = [
+  "first",
+  "second",
+  "third",
+  "fourth",
+  "fifth",
+  "sixth",
+  "seventh",
+  "eigth",
+  "nineth",
+  "tenth"
+];
 
 class Inbox extends Component {
   static propTypes = {
@@ -38,8 +51,7 @@ class Inbox extends Component {
   };
 
   changeEmail = eventKey => {
-    console.log(eventKey);
-    const index = eventKeys.indexOf(eventKey);
+    const index = EVENT_KEYS.indexOf(eventKey);
     this.props.readEmail(this.props.currentEmail);
     this.props.changeCurrentEmail(index);
   };
@@ -48,13 +60,13 @@ class Inbox extends Component {
     const { emails, emailSummaries } = this.props;
     return (
       <div>
-        <Tab.Container id="left-tabs-example" defaultActiveKey="first" onSelect={this.changeEmail}>
+        <Tab.Container id="inbox-tabs" defaultActiveKey="first" onSelect={this.changeEmail}>
           <Row>
             <Col sm={4}>
               <Nav className="flex-column">
                 {emails.map((email, index) => (
-                  <Nav.Item key={index} style={{ width: "100%" }}>
-                    <Nav.Link eventKey={eventKeys[index]} style={{ padding: 0 }}>
+                  <Nav.Item key={index} style={styles.navItem}>
+                    <Nav.Link eventKey={EVENT_KEYS[index]} style={styles.navLink}>
                       <EmailPreview
                         email={email}
                         isRead={this.props.emailSummaries[index].isRead}
@@ -68,10 +80,10 @@ class Inbox extends Component {
                 ))}
               </Nav>
             </Col>
-            <Col sm={8} style={{ paddingLeft: 0 }}>
+            <Col sm={8} tabIndex={0} style={styles.contentColumn}>
               <Tab.Content style={styles.bodyContent}>
                 {emails.map((email, index) => (
-                  <Tab.Pane eventKey={eventKeys[index]} key={index}>
+                  <Tab.Pane eventKey={EVENT_KEYS[index]} key={index}>
                     <Email
                       email={email}
                       emailCount={emailSummaries[this.props.currentEmail].emailCount}

--- a/frontend/src/components/eMIB/Inbox.jsx
+++ b/frontend/src/components/eMIB/Inbox.jsx
@@ -7,6 +7,7 @@ import Email from "./Email";
 import "../../css/inbox.css";
 import { HEADER_HEIGHT, FOOTER_HEIGHT, emailShape } from "./constants";
 import { readEmail, changeCurrentEmail } from "../../modules/EmibInboxRedux";
+import { Tab, Row, Col, Nav } from "react-bootstrap";
 
 const INBOX_HEIGHT = `calc(100vh - ${HEADER_HEIGHT + FOOTER_HEIGHT}px)`;
 
@@ -16,8 +17,6 @@ const styles = {
   },
   buttonList: {
     overflow: "auto",
-    width: 219,
-    paddingRight: 25,
     height: INBOX_HEIGHT
   },
   bodyContent: {
@@ -25,6 +24,8 @@ const styles = {
     height: INBOX_HEIGHT
   }
 };
+
+const eventKeys = ["first", "second", "third"];
 
 class Inbox extends Component {
   static propTypes = {
@@ -36,7 +37,9 @@ class Inbox extends Component {
     changeCurrentEmail: PropTypes.func.isRequired
   };
 
-  changeEmail = index => {
+  changeEmail = eventKey => {
+    console.log(eventKey);
+    const index = eventKeys.indexOf(eventKey);
     this.props.readEmail(this.props.currentEmail);
     this.props.changeCurrentEmail(index);
   };
@@ -44,36 +47,42 @@ class Inbox extends Component {
   render() {
     const { emails, emailSummaries } = this.props;
     return (
-      <div className="inbox-grid">
-        <nav
-          className="inbox-grid-buttons-cell"
-          style={styles.buttonList}
-          role="dialog"
-          aria-label={"Inbox"}
-        >
-          <ul className="nav nav-tabs" style={styles.ul} role="menubar">
-            {emails.map((email, index) => (
-              <div key={index}>
-                <EmailPreview
-                  email={email}
-                  selectEmail={this.changeEmail}
-                  isRead={this.props.emailSummaries[index].isRead}
-                  isRepliedTo={
-                    emailSummaries[index].emailCount + emailSummaries[index].taskCount > 0
-                  }
-                  isSelected={index === this.props.currentEmail}
-                />
-              </div>
-            ))}
-          </ul>
-        </nav>
-        <div className="inbox-grid-content-cell" style={styles.bodyContent}>
-          <Email
-            email={emails[this.props.currentEmail]}
-            emailCount={emailSummaries[this.props.currentEmail].emailCount}
-            taskCount={emailSummaries[this.props.currentEmail].taskCount}
-          />
-        </div>
+      <div>
+        <Tab.Container id="left-tabs-example" defaultActiveKey="first" onSelect={this.changeEmail}>
+          <Row>
+            <Col sm={4}>
+              <Nav className="flex-column">
+                {emails.map((email, index) => (
+                  <Nav.Item key={index} style={{ width: "100%" }}>
+                    <Nav.Link eventKey={eventKeys[index]} style={{ padding: 0 }}>
+                      <EmailPreview
+                        email={email}
+                        isRead={this.props.emailSummaries[index].isRead}
+                        isRepliedTo={
+                          emailSummaries[index].emailCount + emailSummaries[index].taskCount > 0
+                        }
+                        isSelected={index === this.props.currentEmail}
+                      />
+                    </Nav.Link>
+                  </Nav.Item>
+                ))}
+              </Nav>
+            </Col>
+            <Col sm={8} style={{ paddingLeft: 0 }}>
+              <Tab.Content style={styles.bodyContent}>
+                {emails.map((email, index) => (
+                  <Tab.Pane eventKey={eventKeys[index]} key={index}>
+                    <Email
+                      email={email}
+                      emailCount={emailSummaries[this.props.currentEmail].emailCount}
+                      taskCount={emailSummaries[this.props.currentEmail].taskCount}
+                    />
+                  </Tab.Pane>
+                ))}
+              </Tab.Content>
+            </Col>
+          </Row>
+        </Tab.Container>
       </div>
     );
   }

--- a/frontend/src/tests/components/eMIB/EmailPreview.test.js
+++ b/frontend/src/tests/components/eMIB/EmailPreview.test.js
@@ -47,7 +47,6 @@ function testCore(isRead, isRepliedTo, isSelected) {
   const wrapper = mount(
     <EmailPreview
       email={emailStub}
-      selectEmail={() => {}}
       isRead={isRead}
       isRepliedTo={isRepliedTo}
       isSelected={isSelected}

--- a/frontend/src/tests/components/eMIB/Inbox.test.js
+++ b/frontend/src/tests/components/eMIB/Inbox.test.js
@@ -22,5 +22,5 @@ it("Displays 3 email previews when there are 3 emails", () => {
     />
   );
   expect(wrapper.find(EmailPreview).length).toEqual(INBOX_SPECS.length);
-  expect(wrapper.find(Email).length).toEqual(1);
+  expect(wrapper.find(Email).length).toEqual(INBOX_SPECS.length);
 });


### PR DESCRIPTION
# Description

Change inbox navigation to be closer to the current implementation of side navigation. This makes the navigation consistent throughout the simulation. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

![emailtabs](https://user-images.githubusercontent.com/4640747/57809100-ce9d5b80-7732-11e9-89cf-e0144db9a956.gif)

# Testing

Manual steps to reproduce this functionality:

1.  Go to the inbox.
2.  Navigate between emails using the arrow keys, and press tab to get to the email content.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 11+ and Chrome
