### PR TITLE
Org chart cleanup - css and default expanded

### DIFF
--- a/frontend/src/components/commons/TreeNode.jsx
+++ b/frontend/src/components/commons/TreeNode.jsx
@@ -47,7 +47,7 @@ class TreeNode extends Component {
       }
 
       if (node.groups) {
-        node.expanded = false;
+        node.expanded = true;
       }
 
       //TODO auto generate:
@@ -347,7 +347,7 @@ class TreeNode extends Component {
     });
 
     return (
-      <div>
+      <div style={{ minWidth: 700 }}>
         <ul
           role="tree"
           aria-labelledby="treeLabel"
@@ -381,14 +381,16 @@ class TreeNode extends Component {
         aria-level={elem.level}
       >
         <span className={elem.focus ? "focus" : ""} id={"span" + elem.id} data-id={elem.id}>
+          <span style={{ float: "left" }}>
+            {elem.expanded ? (
+              <i className="fas fa-chevron-down root" aria-hidden="true" />
+            ) : (
+              <i className="fas fa-chevron-right root" aria-hidden="true" />
+            )}
+          </span>
           <span className="wrapper">
             <span className="inline title">{elem.name}</span>
           </span>
-          {elem.expanded ? (
-            <i className="fas fa-chevron-down root" aria-hidden="true" />
-          ) : (
-            <i className="fas fa-chevron-right root" aria-hidden="true" />
-          )}
         </span>
         {/* this assumes all root nodes will have at least on group */}
         <ul role="group">
@@ -432,14 +434,16 @@ class TreeNode extends Component {
           id={"span" + this.state.nodes[elem].id}
           data-id={this.state.nodes[elem].id}
         >
+          <span style={{ float: "left" }}>
+            {this.state.nodes[elem].expanded ? (
+              <i className="fas fa-chevron-down group" aria-hidden="true" />
+            ) : (
+              <i className="fas fa-chevron-right group" aria-hidden="true" />
+            )}
+          </span>
           <span className="wrapper">
             <span className="inline title">{this.state.nodes[elem].name}</span>
           </span>
-          {this.state.nodes[elem].expanded ? (
-            <i className="fas fa-chevron-down group" aria-hidden="true" />
-          ) : (
-            <i className="fas fa-chevron-right group" aria-hidden="true" />
-          )}
         </span>
         <ul>{this.state.nodes[elem].groups.map(id => this.renderItem(id))}</ul>
       </li>

--- a/frontend/src/css/lib/tree.css
+++ b/frontend/src/css/lib/tree.css
@@ -6,7 +6,6 @@ ul[role="tree"] {
   margin: 0;
   padding: 0;
   list-style: none;
-  font-size: 120%;
 }
 
 [role="treeitem"][aria-expanded="false"] > ul {


### PR DESCRIPTION
# Description

Cleanup CSS of org chart and default the chart to be expanded.

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


## Screenshot

<img width="813" alt="Screen Shot 2019-05-15 at 5 14 56 PM" src="https://user-images.githubusercontent.com/4640747/57810142-1d4bf500-7735-11e9-9a71-d9722ba710c4.png">


# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Go to background page.
2.  Open image description dialogs.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 11+ and Chrome
