### PR TITLE
[Accessibility] Notepad toggle should be one button

### DIFF
--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -100,6 +100,9 @@ class Notepad extends Component {
               </div>
             )}
             <button
+              id="notepad-button"
+              role="button"
+              aria-pressed={notepadHidden}
               onClick={this.toggleNotepad}
               style={notepadHidden ? styles.openNotepadBtn : styles.hideNotepadBtn}
             >

--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -42,6 +42,9 @@ const styles = {
     minWidth: 300,
     height: NOTEPAD_HEIGHT
   },
+  hiddenContent: {
+    width: 50
+  },
   notepadSection: {
     overflow: "auto",
     width: "100%",
@@ -60,7 +63,12 @@ const styles = {
     borderBottomRightRadius: 0,
     cursor: "pointer",
     whiteSpace: "normal",
-    padding: 8
+    padding: 8,
+    backgroundColor: "#00565e",
+    borderColor: "#00565e"
+  },
+  openText: {
+    color: "#FFFFFF"
   }
 };
 
@@ -70,12 +78,8 @@ class Notepad extends Component {
     notepadContent: ""
   };
 
-  handleHide = () => {
-    this.setState({ notepadHidden: true });
-  };
-
-  handleOpen = () => {
-    this.setState({ notepadHidden: false });
+  toggleNotepad = () => {
+    this.setState({ notepadHidden: !this.state.notepadHidden });
   };
 
   handleNotepadContent = event => {
@@ -86,19 +90,34 @@ class Notepad extends Component {
     const { notepadHidden } = this.state;
     return (
       <div style={styles.windowPadding}>
-        {!notepadHidden && (
-          <div style={styles.content}>
-            <div style={styles.headerSection}>
+        <div style={notepadHidden ? styles.hiddenContent : styles.content}>
+          <div style={notepadHidden ? {} : styles.headerSection}>
+            {!notepadHidden && (
               <div style={styles.label}>
                 <label htmlFor={"text-area-notepad"}>
                   {LOCALIZE.commons.notepad.title.toUpperCase()}
                 </label>
               </div>
-              <button onClick={this.handleHide} style={styles.hideNotepadBtn}>
-                <i style={styles.hideNotepadBtnIcon} className="fas fa-minus-circle" />
-                {LOCALIZE.commons.notepad.hideButton}
-              </button>
-            </div>
+            )}
+            <button
+              onClick={this.toggleNotepad}
+              style={notepadHidden ? styles.openNotepadBtn : styles.hideNotepadBtn}
+            >
+              {!notepadHidden && (
+                <span>
+                  <i style={styles.hideNotepadBtnIcon} className="fas fa-minus-circle" />
+                  {LOCALIZE.commons.notepad.hideButton}
+                </span>
+              )}
+              {notepadHidden && (
+                <span style={styles.openText}>
+                  <i style={styles.hideNotepadBtnIcon} className="fas fa-plus-circle" />
+                  {LOCALIZE.commons.notepad.openButton}
+                </span>
+              )}
+            </button>
+          </div>
+          {!notepadHidden && (
             <div style={styles.notepadSection}>
               <TextareaAutosize
                 id="text-area-notepad"
@@ -112,18 +131,8 @@ class Notepad extends Component {
                 onChange={this.handleNotepadContent}
               />
             </div>
-          </div>
-        )}
-        {notepadHidden && (
-          <button
-            className="btn btn-primary"
-            onClick={this.handleOpen}
-            style={styles.openNotepadBtn}
-          >
-            <i className="fas fa-external-link-alt" />
-            {LOCALIZE.commons.notepad.openButton}
-          </button>
-        )}
+          )}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
# Description

Notepad toggle needs to be one button so that the keyboard focus is never null. It was suggested to use aria-pressed to build this toggle: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role

There are no visual changes.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

![notepad-toggle](https://user-images.githubusercontent.com/4640747/57815953-7755b600-7747-11e9-8898-6c3bcbb06959.gif)


# Testing

Manual steps to reproduce this functionality:

1.  Go to sample test.
2.  Navigate to the keyboard using tabs. Press enter to toggle the notepad.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 11+ and Chrome
