### PR TITLE
[Accessibility] Adding override for btn-danger:disabled

### DIFF
--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -243,3 +243,8 @@ p {
 .form-group {
   margin-bottom: 0;
 }
+
+.btn-danger:disabled {
+  background-color: #db3336;
+  border-color: #db3336;
+}

--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -245,6 +245,6 @@ p {
 }
 
 .btn-danger:disabled {
-  background-color: #db3336;
-  border-color: #db3336;
+  background-color: #923534;
+  border-color: #923534;
 }


### PR DESCRIPTION
# Description

Changing disabled danger button color to improve contrast.
WIP as the contrast seems worse

## Type of change

- Code cleanliness or refactor

## Screenshot
Before:
![image](https://user-images.githubusercontent.com/2746350/57854217-ac005680-77b5-11e9-97f5-f8d6be617626.png)

After:
![image](https://user-images.githubusercontent.com/2746350/57861670-048b2000-77c5-11e9-8c1a-bcb6e1e50e77.png)

# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1. Start the test
2.  Quit the test
3.  See that the disabled quit button is a different color

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
