### PR TITLE
[Inbox] Move email to top of action dialog

### DIFF
--- a/frontend/src/components/eMIB/CollapsingItemContainer.jsx
+++ b/frontend/src/components/eMIB/CollapsingItemContainer.jsx
@@ -44,7 +44,7 @@ class CollapsingItemContainer extends Component {
   };
 
   state = {
-    isCollapsed: false
+    isCollapsed: true
   };
 
   expandItem = () => {

--- a/frontend/src/components/eMIB/CollapsingItemContainer.jsx
+++ b/frontend/src/components/eMIB/CollapsingItemContainer.jsx
@@ -44,7 +44,7 @@ class CollapsingItemContainer extends Component {
   };
 
   state = {
-    isCollapsed: true
+    isCollapsed: false
   };
 
   expandItem = () => {

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -38,7 +38,8 @@ const styles = {
     maxHeight: "calc(100vh - 300px)",
     overflow: "auto",
     width: 700,
-    paddingBottom: 12
+    paddingBottom: 12,
+    paddingRight: 12
   },
   originalEmail: {
     padding: 12,

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -25,7 +25,8 @@ const customStyles = {
     right: "auto",
     bottom: "auto",
     marginRight: "-50%",
-    transform: "translate(-50%, -50%)"
+    transform: "translate(-50%, -50%)",
+    overflow: "initial"
   },
   overlay: {
     backgroundColor: "rgba(0, 0, 0, 0.7)"

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -7,6 +7,7 @@ import EditEmail from "./EditEmail";
 import EditTask from "./EditTask";
 import { ACTION_TYPE, EDIT_MODE, actionShape, emailShape, EMAIL_TYPE } from "./constants";
 import EmailContent from "./EmailContent";
+import CollapsingItemContainer, { ICON_TYPE } from "./CollapsingItemContainer";
 import {
   addEmail,
   addTask,
@@ -55,6 +56,11 @@ const styles = {
   },
   rightButton: {
     float: "right"
+  },
+  dataBodyDivider: {
+    width: "100%",
+    borderTop: "1px solid #96a8b2",
+    margin: "12px 0 12px 0"
   }
 };
 
@@ -189,6 +195,12 @@ class EditActionDialog extends Component {
             )}
           </div>
           <div style={styles.container}>
+            <CollapsingItemContainer
+              title={LOCALIZE.emibTest.inboxPage.emailCommons.originalEmail}
+              body={<EmailContent email={this.props.email} />}
+              iconType={ICON_TYPE.email}
+            />
+            <hr style={styles.dataBodyDivider} />
             <h4>{LOCALIZE.emibTest.inboxPage.emailCommons.yourResponse}</h4>
             {actionType === ACTION_TYPE.email && (
               <EditEmail
@@ -204,10 +216,6 @@ class EditActionDialog extends Component {
                 action={editMode === EDIT_MODE.update ? this.props.action : null}
               />
             )}
-            <h4>{LOCALIZE.emibTest.inboxPage.emailCommons.originalEmail}</h4>
-            <div style={styles.originalEmail}>
-              <EmailContent email={this.props.email} />
-            </div>
           </div>
           <div style={styles.buttons}>
             <button className={"btn btn-danger"} onClick={this.handleClose}>

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -73,9 +73,6 @@ const styles = {
       width: "100%",
       height: 225,
       resize: "none"
-    },
-    textAreaMargin: {
-      marginRight: 12
     }
   },
   textCounter: {
@@ -84,7 +81,7 @@ const styles = {
     paddingRight: 12
   },
   hr: {
-    margin: "12px 12px 12px 0"
+    margin: "12px 0px"
   },
   reasonsForAction: {
     textArea: {
@@ -94,9 +91,6 @@ const styles = {
       width: "100%",
       height: 150,
       resize: "none"
-    },
-    textAreaMargin: {
-      marginRight: 12
     }
   }
 };
@@ -308,7 +302,7 @@ class EditEmail extends Component {
               <label htmlFor="your-response-text-area">
                 {LOCALIZE.emibTest.inboxPage.addEmailResponse.response}
               </label>
-              <div style={styles.response.textAreaMargin}>
+              <div>
                 <textarea
                   id="your-response-text-area"
                   maxLength={MAX_RESPONSE}
@@ -329,7 +323,7 @@ class EditEmail extends Component {
               <label htmlFor="reasons-for-action-text-area">
                 {LOCALIZE.emibTest.inboxPage.addEmailResponse.reasonsForAction}
               </label>
-              <div style={styles.reasonsForAction.textAreaMargin}>
+              <div>
                 <textarea
                   id="reasons-for-action-text-area"
                   maxLength={MAX_REASON}

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -57,9 +57,6 @@ const styles = {
       width: "100%",
       height: 125,
       resize: "none"
-    },
-    textAreaMargin: {
-      marginRight: 12
     }
   },
   reasonsForAction: {
@@ -89,9 +86,6 @@ const styles = {
       width: "100%",
       height: 100,
       resize: "none"
-    },
-    textAreaMargin: {
-      marginRight: 12
     }
   }
 };
@@ -174,7 +168,7 @@ class EditTask extends Component {
                   onBlur={this.onTaskTooltipBlur}
                 />
               </OverlayTrigger>
-              <div style={styles.tasks.textAreaMargin}>
+              <div>
                 <textarea
                   id="your-tasks-text-area"
                   maxLength={MAX_TASK}
@@ -219,7 +213,7 @@ class EditTask extends Component {
                   onBlur={this.onReasonsForActionTooltipBlur}
                 />
               </OverlayTrigger>
-              <div style={styles.reasonsForAction.textAreaMargin}>
+              <div>
                 <textarea
                   id="reasons-for-action-text-area"
                   maxLength={MAX_REASON}

--- a/frontend/src/components/eMIB/EmailContent.jsx
+++ b/frontend/src/components/eMIB/EmailContent.jsx
@@ -8,7 +8,6 @@ const styles = {
     color: "#00565E"
   },
   dataBodyDivider: {
-    width: "100%",
     borderTop: "1px solid #96a8b2",
     margin: "12px 0 12px 0"
   },

--- a/frontend/src/css/cat-theme.css
+++ b/frontend/src/css/cat-theme.css
@@ -178,8 +178,6 @@ p {
 
 /* formatting for sizing of drop down menus */
 .rrs {
-  padding: 0px 6px;
-  margin-right: 6px;
   width: calc(100% - 35px);
   float: right;
   margin-bottom: 12px;


### PR DESCRIPTION
# Description

Move email to the top of the action dialog and put it in a collapsing container.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

![image](https://user-images.githubusercontent.com/4640747/58491231-a0f5e080-813c-11e9-9257-5a224699175b.png)


# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Go to the sample test and navigate to the inbox.
2.  Select an email and add a response.
3.  Notice the location of the original email.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
