### PR TITLE
[Bug fix] char counter on task reasons for action

### DIFF
--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -177,7 +177,7 @@ class EditTask extends Component {
                   onChange={this.onTaskContentChange}
                 />
               </div>
-              <div style={styles.textCounter}>
+              <div style={styles.textCounter} id="unit-test-task-response">
                 {this.state.task === undefined ? 0 : this.state.task.length}/{MAX_TASK}
               </div>
             </div>
@@ -222,9 +222,9 @@ class EditTask extends Component {
                   onChange={this.onReasonsForActionChange}
                 />
               </div>
-              <div style={styles.textCounter}>
-                {this.state.reasonsForAction === undefined ? 0 : this.state.reasonsForAction}/
-                {MAX_REASON}
+              <div style={styles.textCounter} id="unit-test-task-rfa">
+                {this.state.reasonsForAction === undefined ? 0 : this.state.reasonsForAction.length}
+                /{MAX_REASON}
               </div>
             </div>
           </div>

--- a/frontend/src/tests/components/eMIB/EditTask.test.js
+++ b/frontend/src/tests/components/eMIB/EditTask.test.js
@@ -1,0 +1,46 @@
+import React from "react";
+import { shallow, mount } from "enzyme";
+import EditTask from "../../../components/eMIB/EditTask";
+import { ACTION_TYPE, EDIT_MODE, EMAIL_TYPE } from "../../../components/eMIB/constants";
+
+describe("char counts", () => {
+  it("displays task char count of 0", () => {
+    const wrapper = shallow(
+      <EditTask
+        onChange={() => {}}
+        action={{ actionType: ACTION_TYPE.task, reasonsForAction: "", task: "" }}
+      />
+    );
+    expect(wrapper.find("#unit-test-task-response").text()).toEqual("0/650");
+  });
+
+  it("displays task char count of 5", () => {
+    const wrapper = shallow(
+      <EditTask
+        onChange={() => {}}
+        action={{ actionType: ACTION_TYPE.task, reasonsForAction: "", task: "hello" }}
+      />
+    );
+    expect(wrapper.find("#unit-test-task-response").text()).toEqual("5/650");
+  });
+
+  it("displays reason for action char count of 0", () => {
+    const wrapper = shallow(
+      <EditTask
+        onChange={() => {}}
+        action={{ actionType: ACTION_TYPE.task, reasonsForAction: "", task: "" }}
+      />
+    );
+    expect(wrapper.find("#unit-test-task-rfa").text()).toEqual("0/650");
+  });
+
+  it("displays reason for action char count of 11", () => {
+    const wrapper = shallow(
+      <EditTask
+        onChange={() => {}}
+        action={{ actionType: ACTION_TYPE.task, reasonsForAction: "hello world", task: "" }}
+      />
+    );
+    expect(wrapper.find("#unit-test-task-rfa").text()).toEqual("11/650");
+  });
+});


### PR DESCRIPTION
# Description

Fix character counter on tasks reasons for action - it previously displayed text instead of a count.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

<img width="714" alt="Screen Shot 2019-05-29 at 9 25 32 AM" src="https://user-images.githubusercontent.com/4640747/58560746-c0037980-81f3-11e9-9239-7bdf82fbf948.png">


# Testing
Manual steps to reproduce this functionality:

1.  Create a task.
2.  Start typing reasons for action and notice char count changing.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 11+ and Chrome
