### PR TITLE
[Accessibility] Linking login and registration labels to their respective fields

### DIFF
--- a/frontend/src/components/authentication/LoginForm.jsx
+++ b/frontend/src/components/authentication/LoginForm.jsx
@@ -83,7 +83,9 @@ class LoginForm extends Component {
               <form onSubmit={this.handleSubmit}>
                 <div>
                   <div style={styles.inputTitles}>
-                    <span>{LOCALIZE.authentication.login.content.inputs.emailTitle}</span>
+                    <label htmlFor={"username"}>
+                      {LOCALIZE.authentication.login.content.inputs.emailTitle}
+                    </label>
                   </div>
                   <input
                     aria-label={LOCALIZE.authentication.login.content.inputs.emailTitle}
@@ -97,7 +99,9 @@ class LoginForm extends Component {
                 </div>
                 <div>
                   <div style={styles.inputTitles}>
-                    <span>{LOCALIZE.authentication.login.content.inputs.passwordTitle}</span>
+                    <label htmlFor={"password"}>
+                      {LOCALIZE.authentication.login.content.inputs.passwordTitle}
+                    </label>
                   </div>
                   <input
                     aria-label={LOCALIZE.authentication.login.content.inputs.passwordTitle}

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -192,9 +192,9 @@ class RegistrationForm extends Component {
               <div className="names-grid">
                 <div className="names-grid-first-name">
                   <div style={styles.inputTitle}>
-                    <span>
+                    <label htmlFor={"first-name-field"}>
                       {LOCALIZE.authentication.createAccount.content.inputs.firstNameTitle}
-                    </span>
+                    </label>
                   </div>
                   {isValidFirstName && (
                     <span className="far fa-check-circle" style={styles.iconForNames} />
@@ -205,6 +205,7 @@ class RegistrationForm extends Component {
                     className={
                       isValidFirstName || isFirstLoad ? validFieldClass : invalidFieldClass
                     }
+                    id="first-name-field"
                     type="text"
                     placeholder={
                       LOCALIZE.authentication.createAccount.content.inputs.firstNamePlaceholder
@@ -216,9 +217,9 @@ class RegistrationForm extends Component {
                 </div>
                 <div className="names-grid-last-name">
                   <div style={styles.inputTitle}>
-                    <span style={styles.inputTitle}>
+                    <label htmlFor={"last-name-field"}>
                       {LOCALIZE.authentication.createAccount.content.inputs.lastNameTitle}
-                    </span>
+                    </label>
                   </div>
                   {isValidLastName && (
                     <span className="far fa-check-circle" style={styles.iconForNames} />
@@ -226,6 +227,7 @@ class RegistrationForm extends Component {
                   <input
                     aria-label={LOCALIZE.authentication.createAccount.content.inputs.lastNameTitle}
                     className={isValidLastName || isFirstLoad ? validFieldClass : invalidFieldClass}
+                    id="last-name-field"
                     type="text"
                     placeholder={
                       LOCALIZE.authentication.createAccount.content.inputs.lastNamePlaceholder
@@ -238,7 +240,9 @@ class RegistrationForm extends Component {
               </div>
               <div>
                 <div style={styles.inputTitle}>
-                  <span>{LOCALIZE.authentication.createAccount.content.inputs.emailTitle}</span>
+                  <label htmlFor={"email-address-field"}>
+                    {LOCALIZE.authentication.createAccount.content.inputs.emailTitle}
+                  </label>
                 </div>
                 {isValidEmail && (
                   <span className="far fa-check-circle" style={styles.iconForOtherFields} />
@@ -246,6 +250,7 @@ class RegistrationForm extends Component {
                 <input
                   aria-label={LOCALIZE.authentication.createAccount.content.inputs.emailTitle}
                   className={isValidEmail || isFirstLoad ? validFieldClass : invalidFieldClass}
+                  id="email-address-field"
                   type="text"
                   placeholder={
                     LOCALIZE.authentication.createAccount.content.inputs.emailPlaceholder
@@ -262,7 +267,9 @@ class RegistrationForm extends Component {
               )}
               <div>
                 <div style={styles.inputTitle}>
-                  <span>{LOCALIZE.authentication.createAccount.content.inputs.passwordTitle}</span>
+                  <label htmlFor={"password-field"}>
+                    {LOCALIZE.authentication.createAccount.content.inputs.passwordTitle}
+                  </label>
                 </div>
                 {isValidPassword && (
                   <span className="far fa-check-circle" style={styles.iconForOtherFields} />
@@ -270,6 +277,7 @@ class RegistrationForm extends Component {
                 <input
                   aria-label={LOCALIZE.authentication.createAccount.content.inputs.passwordTitle}
                   className={isValidPassword || isFirstLoad ? validFieldClass : invalidFieldClass}
+                  id="password-field"
                   type="password"
                   placeholder={
                     LOCALIZE.authentication.createAccount.content.inputs.passwordPlaceholder
@@ -317,9 +325,9 @@ class RegistrationForm extends Component {
               </div>
               <div>
                 <div style={styles.inputTitle}>
-                  <span>
+                  <label htmlFor={"password-confirmation-field"}>
                     {LOCALIZE.authentication.createAccount.content.inputs.passwordConfirmationTitle}
-                  </span>
+                  </label>
                 </div>
                 {isValidPasswordConfirmation && (
                   <span className="far fa-check-circle" style={styles.iconForOtherFields} />
@@ -331,6 +339,7 @@ class RegistrationForm extends Component {
                   className={
                     isValidPasswordConfirmation || isFirstLoad ? validFieldClass : invalidFieldClass
                   }
+                  id="password-confirmation-field"
                   type="password"
                   placeholder={
                     LOCALIZE.authentication.createAccount.content.inputs


### PR DESCRIPTION
# Description

This PR is linking all the Login and Registration labels to their respective fields.

## Type of change

- Code cleanliness or refactor

## Screenshot

(N/A)

# Testing

Manual steps to reproduce this functionality:

1.  Open the Login and Registration forms.
2.  Click on each labels and make sure that they are linked to their respective fields.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
