### PR TITLE
[emib] Remove aria-pressed on notepad toggle

### DIFF
--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -103,7 +103,6 @@ class Notepad extends Component {
             )}
             <button
               id="notepad-button"
-              aria-pressed={notepadHidden}
               onClick={this.toggleNotepad}
               style={notepadHidden ? styles.openNotepadBtn : styles.hideNotepadBtn}
             >


### PR DESCRIPTION
# Description

Since the text on the button updates, aria-pressed attribute no longer makes sense.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

N/A

# Testing
Manual steps to reproduce this functionality:

1.  Toggle notepad with a screenreader open.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
