### PR TITLE
[Accessibility] Linking login and registration form errors to their respective fields

### DIFF
--- a/frontend/src/components/authentication/LoginForm.jsx
+++ b/frontend/src/components/authentication/LoginForm.jsx
@@ -26,7 +26,9 @@ const styles = {
     margin: "24px auto"
   },
   loginError: {
-    color: "red"
+    marginTop: 12,
+    color: "#923534",
+    fontWeight: "bold"
   },
   validationError: {
     color: "red",
@@ -46,7 +48,8 @@ class LoginForm extends Component {
   state = {
     username: "",
     password: "",
-    wrongCredentials: false
+    wrongCredentials: false,
+    passwordFieldAriaLabel: LOCALIZE.authentication.login.content.inputs.passwordTitle
   };
 
   // TODO(fnormand): encrypt passwords
@@ -54,8 +57,17 @@ class LoginForm extends Component {
     this.props
       .loginAction({ username: this.state.username, password: this.state.password })
       .then(response => {
+        // credentials are wrong
         if (response.non_field_errors || typeof response.token === "undefined") {
-          this.setState({ wrongCredentials: true });
+          this.setState({
+            wrongCredentials: true,
+            passwordFieldAriaLabel:
+              LOCALIZE.authentication.login.invalidCredentials +
+              LOCALIZE.authentication.login.passwordFieldSelected
+          });
+          // focus on password field
+          document.getElementById("password").focus();
+          // right authentication
         } else {
           this.setState({ wrongCredentials: false });
           this.props.handleAuthResponseAndState(
@@ -109,7 +121,8 @@ class LoginForm extends Component {
                     </label>
                   </div>
                   <input
-                    aria-label={LOCALIZE.authentication.login.content.inputs.passwordTitle}
+                    aria-label={this.state.passwordFieldAriaLabel}
+                    aria-invalid={this.state.wrongCredentials}
                     type="password"
                     placeholder={LOCALIZE.authentication.login.content.inputs.passwordPlaceholder}
                     id="password"
@@ -120,9 +133,9 @@ class LoginForm extends Component {
                 </div>
                 <div>
                   {this.state.wrongCredentials && (
-                    <p style={styles.loginError}>
+                    <label htmlFor={"password"} style={styles.loginError}>
                       {LOCALIZE.authentication.login.invalidCredentials}
-                    </p>
+                    </label>
                   )}
                 </div>
                 <input

--- a/frontend/src/components/authentication/LoginForm.jsx
+++ b/frontend/src/components/authentication/LoginForm.jsx
@@ -107,7 +107,6 @@ class LoginForm extends Component {
                   <input
                     aria-label={LOCALIZE.authentication.login.content.inputs.emailTitle}
                     type="text"
-                    placeholder={LOCALIZE.authentication.login.content.inputs.emailPlaceholder}
                     id="username"
                     style={styles.inputs}
                     onChange={this.handleUsernameChange}
@@ -124,7 +123,6 @@ class LoginForm extends Component {
                     aria-label={this.state.passwordFieldAriaLabel}
                     aria-invalid={this.state.wrongCredentials}
                     type="password"
-                    placeholder={LOCALIZE.authentication.login.content.inputs.passwordPlaceholder}
                     id="password"
                     style={styles.inputs}
                     onChange={this.handlePasswordChange}

--- a/frontend/src/components/authentication/LoginForm.jsx
+++ b/frontend/src/components/authentication/LoginForm.jsx
@@ -48,8 +48,7 @@ class LoginForm extends Component {
   state = {
     username: "",
     password: "",
-    wrongCredentials: false,
-    passwordFieldAriaLabel: LOCALIZE.authentication.login.content.inputs.passwordTitle
+    wrongCredentials: false
   };
 
   // TODO(fnormand): encrypt passwords
@@ -60,10 +59,7 @@ class LoginForm extends Component {
         // credentials are wrong
         if (response.non_field_errors || typeof response.token === "undefined") {
           this.setState({
-            wrongCredentials: true,
-            passwordFieldAriaLabel:
-              LOCALIZE.authentication.login.invalidCredentials +
-              LOCALIZE.authentication.login.passwordFieldSelected
+            wrongCredentials: true
           });
           // focus on password field
           document.getElementById("password").focus();
@@ -121,7 +117,12 @@ class LoginForm extends Component {
                     </label>
                   </div>
                   <input
-                    aria-label={this.state.passwordFieldAriaLabel}
+                    aria-label={
+                      this.state.wrongCredentials
+                        ? LOCALIZE.authentication.login.invalidCredentials +
+                          LOCALIZE.authentication.login.passwordFieldSelected
+                        : LOCALIZE.authentication.login.content.inputs.passwordTitle
+                    }
                     aria-invalid={this.state.wrongCredentials}
                     aria-required={"true"}
                     type="password"

--- a/frontend/src/components/authentication/LoginForm.jsx
+++ b/frontend/src/components/authentication/LoginForm.jsx
@@ -106,6 +106,7 @@ class LoginForm extends Component {
                   </div>
                   <input
                     aria-label={LOCALIZE.authentication.login.content.inputs.emailTitle}
+                    aria-required={"true"}
                     type="text"
                     id="username"
                     style={styles.inputs}
@@ -122,6 +123,7 @@ class LoginForm extends Component {
                   <input
                     aria-label={this.state.passwordFieldAriaLabel}
                     aria-invalid={this.state.wrongCredentials}
+                    aria-required={"true"}
                     type="password"
                     id="password"
                     style={styles.inputs}

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -282,7 +282,11 @@ class RegistrationForm extends Component {
                   <FontAwesomeIcon style={styles.iconForOtherFields} icon={faCheckCircle} />
                 )}
                 <input
-                  aria-label={LOCALIZE.ariaLabel.passwordCreationRequirements}
+                  aria-label={
+                    isValidPassword
+                      ? LOCALIZE.authentication.createAccount.content.inputs.passwordTitle
+                      : LOCALIZE.ariaLabel.passwordCreationRequirements
+                  }
                   className={isValidPassword || isFirstLoad ? validFieldClass : invalidFieldClass}
                   aria-invalid={!this.state.isValidPassword}
                   aria-required={"true"}

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -208,6 +208,7 @@ class RegistrationForm extends Component {
                       isValidFirstName || isFirstLoad ? validFieldClass : invalidFieldClass
                     }
                     aria-invalid={!this.state.isValidFirstName}
+                    aria-required={"true"}
                     id="first-name-field"
                     type="text"
                     value={firstNameContent}
@@ -228,6 +229,7 @@ class RegistrationForm extends Component {
                     aria-label={LOCALIZE.authentication.createAccount.content.inputs.lastNameTitle}
                     className={isValidLastName || isFirstLoad ? validFieldClass : invalidFieldClass}
                     aria-invalid={!this.state.isValidLastName}
+                    aria-required={"true"}
                     id="last-name-field"
                     type="text"
                     value={lastNameContent}
@@ -249,6 +251,7 @@ class RegistrationForm extends Component {
                   aria-label={LOCALIZE.authentication.createAccount.content.inputs.emailTitle}
                   className={isValidEmail || isFirstLoad ? validFieldClass : invalidFieldClass}
                   aria-invalid={!this.state.isValidEmail}
+                  aria-required={"true"}
                   id="email-address-field"
                   type="text"
                   value={emailContent}
@@ -274,6 +277,7 @@ class RegistrationForm extends Component {
                   aria-label={LOCALIZE.authentication.createAccount.content.inputs.passwordTitle}
                   className={isValidPassword || isFirstLoad ? validFieldClass : invalidFieldClass}
                   aria-invalid={!this.state.isValidPassword}
+                  aria-required={"true"}
                   id="password-field"
                   type="password"
                   value={passwordContent}
@@ -334,6 +338,7 @@ class RegistrationForm extends Component {
                     isValidPasswordConfirmation || isFirstLoad ? validFieldClass : invalidFieldClass
                   }
                   aria-invalid={!this.state.isValidPasswordConfirmation}
+                  aria-required={"true"}
                   id="password-confirmation-field"
                   type="password"
                   value={passwordConfirmationContent}

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -7,6 +7,8 @@ import { registerAction } from "../../modules/LoginRedux";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCheckCircle } from "@fortawesome/free-solid-svg-icons";
 
 const styles = {
   createAccountContent: {
@@ -197,7 +199,7 @@ class RegistrationForm extends Component {
                     </label>
                   </div>
                   {isValidFirstName && (
-                    <span className="far fa-check-circle" style={styles.iconForNames} />
+                    <FontAwesomeIcon style={styles.iconForNames} icon={faCheckCircle} />
                   )}
 
                   <input
@@ -222,7 +224,7 @@ class RegistrationForm extends Component {
                     </label>
                   </div>
                   {isValidLastName && (
-                    <span className="far fa-check-circle" style={styles.iconForNames} />
+                    <FontAwesomeIcon style={styles.iconForNames} icon={faCheckCircle} />
                   )}
                   <input
                     aria-label={LOCALIZE.authentication.createAccount.content.inputs.lastNameTitle}
@@ -245,7 +247,7 @@ class RegistrationForm extends Component {
                   </label>
                 </div>
                 {isValidEmail && (
-                  <span className="far fa-check-circle" style={styles.iconForOtherFields} />
+                  <FontAwesomeIcon style={styles.iconForOtherFields} icon={faCheckCircle} />
                 )}
                 <input
                   aria-label={LOCALIZE.authentication.createAccount.content.inputs.emailTitle}
@@ -272,7 +274,7 @@ class RegistrationForm extends Component {
                   </label>
                 </div>
                 {isValidPassword && (
-                  <span className="far fa-check-circle" style={styles.iconForOtherFields} />
+                  <FontAwesomeIcon style={styles.iconForOtherFields} icon={faCheckCircle} />
                 )}
                 <input
                   aria-label={LOCALIZE.authentication.createAccount.content.inputs.passwordTitle}
@@ -330,7 +332,7 @@ class RegistrationForm extends Component {
                   </label>
                 </div>
                 {isValidPasswordConfirmation && (
-                  <span className="far fa-check-circle" style={styles.iconForOtherFields} />
+                  <FontAwesomeIcon style={styles.iconForOtherFields} icon={faCheckCircle} />
                 )}
                 <input
                   aria-label={

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -45,11 +45,11 @@ const styles = {
     margin: "24px auto"
   },
   validationError: {
-    color: "red",
+    color: "#923534",
     marginTop: 6
   },
   errorMessage: {
-    color: "red",
+    color: "#923534",
     fontWeight: "bold",
     padding: 0,
     marginTop: 12

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -207,6 +207,7 @@ class RegistrationForm extends Component {
                     className={
                       isValidFirstName || isFirstLoad ? validFieldClass : invalidFieldClass
                     }
+                    aria-invalid={!this.state.isValidFirstName}
                     id="first-name-field"
                     type="text"
                     placeholder={
@@ -229,6 +230,7 @@ class RegistrationForm extends Component {
                   <input
                     aria-label={LOCALIZE.authentication.createAccount.content.inputs.lastNameTitle}
                     className={isValidLastName || isFirstLoad ? validFieldClass : invalidFieldClass}
+                    aria-invalid={!this.state.isValidLastName}
                     id="last-name-field"
                     type="text"
                     placeholder={
@@ -252,6 +254,7 @@ class RegistrationForm extends Component {
                 <input
                   aria-label={LOCALIZE.authentication.createAccount.content.inputs.emailTitle}
                   className={isValidEmail || isFirstLoad ? validFieldClass : invalidFieldClass}
+                  aria-invalid={!this.state.isValidEmail}
                   id="email-address-field"
                   type="text"
                   placeholder={
@@ -279,6 +282,7 @@ class RegistrationForm extends Component {
                 <input
                   aria-label={LOCALIZE.authentication.createAccount.content.inputs.passwordTitle}
                   className={isValidPassword || isFirstLoad ? validFieldClass : invalidFieldClass}
+                  aria-invalid={!this.state.isValidPassword}
                   id="password-field"
                   type="password"
                   placeholder={
@@ -341,6 +345,7 @@ class RegistrationForm extends Component {
                   className={
                     isValidPasswordConfirmation || isFirstLoad ? validFieldClass : invalidFieldClass
                   }
+                  aria-invalid={!this.state.isValidPasswordConfirmation}
                   id="password-confirmation-field"
                   type="password"
                   placeholder={

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -210,9 +210,6 @@ class RegistrationForm extends Component {
                     aria-invalid={!this.state.isValidFirstName}
                     id="first-name-field"
                     type="text"
-                    placeholder={
-                      LOCALIZE.authentication.createAccount.content.inputs.firstNamePlaceholder
-                    }
                     value={firstNameContent}
                     style={styles.inputForNames}
                     onChange={this.firstNameValidation}
@@ -233,9 +230,6 @@ class RegistrationForm extends Component {
                     aria-invalid={!this.state.isValidLastName}
                     id="last-name-field"
                     type="text"
-                    placeholder={
-                      LOCALIZE.authentication.createAccount.content.inputs.lastNamePlaceholder
-                    }
                     value={lastNameContent}
                     style={styles.inputForNames}
                     onChange={this.lastNameValidation}
@@ -257,9 +251,6 @@ class RegistrationForm extends Component {
                   aria-invalid={!this.state.isValidEmail}
                   id="email-address-field"
                   type="text"
-                  placeholder={
-                    LOCALIZE.authentication.createAccount.content.inputs.emailPlaceholder
-                  }
                   value={emailContent}
                   style={styles.inputs}
                   onChange={this.emailValidation}
@@ -285,9 +276,6 @@ class RegistrationForm extends Component {
                   aria-invalid={!this.state.isValidPassword}
                   id="password-field"
                   type="password"
-                  placeholder={
-                    LOCALIZE.authentication.createAccount.content.inputs.passwordPlaceholder
-                  }
                   value={passwordContent}
                   style={styles.inputs}
                   onChange={this.passwordValidation}
@@ -348,10 +336,6 @@ class RegistrationForm extends Component {
                   aria-invalid={!this.state.isValidPasswordConfirmation}
                   id="password-confirmation-field"
                   type="password"
-                  placeholder={
-                    LOCALIZE.authentication.createAccount.content.inputs
-                      .passwordConfirmationPlaceholder
-                  }
                   value={passwordConfirmationContent}
                   style={styles.inputs}
                   onChange={this.passwordConfirmationValidation}

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -150,6 +150,8 @@ class RegistrationForm extends Component {
         // account already exists
         if (response.username[0] === "A user with that username already exists.") {
           this.setState({ accountExistsError: true });
+          // focus on password field
+          document.getElementById("email-address-field").focus();
           // account successfully created
         } else {
           this.setState({ showDialog: true, accountExistsError: false });
@@ -172,7 +174,8 @@ class RegistrationForm extends Component {
       isValidPassword,
       isFirstPasswordLoad,
       passwordConfirmationContent,
-      isValidPasswordConfirmation
+      isValidPasswordConfirmation,
+      accountExistsError
     } = this.state;
 
     const validFieldClass = "valid-field";
@@ -248,7 +251,12 @@ class RegistrationForm extends Component {
                   <FontAwesomeIcon style={styles.iconForOtherFields} icon={faCheckCircle} />
                 )}
                 <input
-                  aria-label={LOCALIZE.authentication.createAccount.content.inputs.emailTitle}
+                  aria-label={
+                    accountExistsError
+                      ? LOCALIZE.authentication.createAccount.content.inputs.emailTitle +
+                        LOCALIZE.authentication.createAccount.accountAlreadyExistsError
+                      : LOCALIZE.authentication.createAccount.content.inputs.emailTitle
+                  }
                   className={isValidEmail || isFirstLoad ? validFieldClass : invalidFieldClass}
                   aria-invalid={!this.state.isValidEmail}
                   aria-required={"true"}

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -274,7 +274,7 @@ class RegistrationForm extends Component {
                   <FontAwesomeIcon style={styles.iconForOtherFields} icon={faCheckCircle} />
                 )}
                 <input
-                  aria-label={LOCALIZE.authentication.createAccount.content.inputs.passwordTitle}
+                  aria-label={LOCALIZE.ariaLabel.passwordCreationRequirements}
                   className={isValidPassword || isFirstLoad ? validFieldClass : invalidFieldClass}
                   aria-invalid={!this.state.isValidPassword}
                   aria-required={"true"}
@@ -285,7 +285,7 @@ class RegistrationForm extends Component {
                   onChange={this.passwordValidation}
                 />
                 {!isValidPassword && !isFirstPasswordLoad && (
-                  <div>
+                  <label htmlFor={"password-field"}>
                     <p style={styles.validationError}>
                       {
                         LOCALIZE.authentication.createAccount.content.inputs.passwordErrors
@@ -318,7 +318,7 @@ class RegistrationForm extends Component {
                         {LOCALIZE.authentication.createAccount.content.inputs.passwordErrors.length}
                       </li>
                     </ul>
-                  </div>
+                  </label>
                 )}
               </div>
               <div>

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -332,7 +332,12 @@ class RegistrationForm extends Component {
                 )}
                 <input
                   aria-label={
-                    LOCALIZE.authentication.createAccount.content.inputs.passwordConfirmationTitle
+                    isValidPasswordConfirmation
+                      ? LOCALIZE.authentication.createAccount.content.inputs
+                          .passwordConfirmationTitle
+                      : LOCALIZE.authentication.createAccount.content.inputs
+                          .passwordConfirmationTitle +
+                        LOCALIZE.ariaLabel.passwordConfirmationRequirements
                   }
                   className={
                     isValidPasswordConfirmation || isFirstLoad ? validFieldClass : invalidFieldClass
@@ -346,9 +351,9 @@ class RegistrationForm extends Component {
                   onChange={this.passwordConfirmationValidation}
                 />
                 {!isValidPasswordConfirmation && !isFirstPasswordLoad && (
-                  <p style={styles.validationError}>
+                  <label htmlFor={"password-confirmation-field"} style={styles.validationError}>
                     {LOCALIZE.authentication.createAccount.content.inputs.passwordConfirmationError}
-                  </p>
+                  </label>
                 )}
               </div>
               <button

--- a/frontend/src/css/registration-form.css
+++ b/frontend/src/css/registration-form.css
@@ -23,7 +23,7 @@ registration-form.css is used for the RegistrationForm.jsx styles that cannot be
 }
 
 .invalid-field {
-  border: 3px solid red;
+  border: 3px solid #923534;
 }
 
 /* this removes the 'clear field (X)' button in IE */

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -32,9 +32,7 @@ let LOCALIZE = new LocalizedStrings({
             "An account is required to proceed further. To log in, enter your credentials below.",
           inputs: {
             emailTitle: "Email Address:",
-            emailPlaceholder: "john.smith@outlook.ca",
             passwordTitle: "Password:",
-            passwordPlaceholder: "Password"
           }
         },
         button: "Login",
@@ -563,9 +561,7 @@ let LOCALIZE = new LocalizedStrings({
             "FR An account is required to proceed further. To log in, enter your credentials below.",
           inputs: {
             emailTitle: "Adresse courriel :",
-            emailPlaceholder: "john.smith@outlook.ca",
             passwordTitle: "Mot de passe :",
-            passwordPlaceholder: "Mot de passe"
           }
         },
         button: "Connexion",

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -38,7 +38,8 @@ let LOCALIZE = new LocalizedStrings({
           }
         },
         button: "Login",
-        invalidCredentials: "Invalid credentials!"
+        invalidCredentials: "Invalid credentials!",
+        passwordFieldSelected: "Password field selected."
       },
       createAccount: {
         title: "CREATE AN ACCOUNT",
@@ -573,7 +574,8 @@ let LOCALIZE = new LocalizedStrings({
           }
         },
         button: "Connexion",
-        invalidCredentials: "FR Invalid credentials!"
+        invalidCredentials: "FR Invalid credentials!",
+        passwordFieldSelected: "FR Password field selected."
       },
       createAccount: {
         title: "CRÉER UN COMPTE",

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -49,13 +49,9 @@ let LOCALIZE = new LocalizedStrings({
             "An account is required to proceed further. To create an account, fill out the following.",
           inputs: {
             firstNameTitle: "First Name:",
-            firstNamePlaceholder: "John",
             lastNameTitle: "Last Name:",
-            lastNamePlaceholder: "Smith",
             emailTitle: "Email Address:",
-            emailPlaceholder: "john.smith@outlook.ca",
             passwordTitle: "Password (must be between 5-15 characters):",
-            passwordPlaceholder: "Password",
             passwordErrors: {
               description: "Your password must satisfy the following:",
               upperCase: "At least one upper case",
@@ -65,7 +61,6 @@ let LOCALIZE = new LocalizedStrings({
               length: "Minimum of 5 characters and maximum of 15"
             },
             passwordConfirmationTitle: "Confirm Password:",
-            passwordConfirmationPlaceholder: "Password",
             passwordConfirmationError: "Must match the Password"
           }
         },
@@ -585,13 +580,9 @@ let LOCALIZE = new LocalizedStrings({
             "FR An account is required to proceed further. To create an account, fill out the following.",
           inputs: {
             firstNameTitle: "Prénom :",
-            firstNamePlaceholder: "John",
             lastNameTitle: "Nom de famille :",
-            lastNamePlaceholder: "Smith",
             emailTitle: "Adresse courriel :",
-            emailPlaceholder: "john.smith@outlook.ca",
             passwordTitle: "Mot de passe (doit contenir entre 5-15 caractères) :",
-            passwordPlaceholder: "Mot de passe",
             passwordErrors: {
               description: "Votre mot de passe doit satisfaire les critères suivants :",
               upperCase: "Au moins une majuscule",
@@ -601,7 +592,6 @@ let LOCALIZE = new LocalizedStrings({
               length: "Au moins 5 caractères et maximum 15"
             },
             passwordConfirmationTitle: "Confirmer le mot de passe :",
-            passwordConfirmationPlaceholder: "Mot de passe",
             passwordConfirmationError: "Doit correspondre au mot de passe"
           }
         },

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -491,7 +491,8 @@ let LOCALIZE = new LocalizedStrings({
       taskTooltip: "task tooltip",
       reasonsForActionTooltip: "reasons for action tooltip",
       passwordCreationRequirements:
-        "Password (your password must satisfy the following: At least one upper case, at least one lower case, at least one digit, at least one special character, minimum of 5 characters and maximum of 15)"
+        "Password (your password must satisfy the following: At least one upper case, at least one lower case, at least one digit, at least one special character, minimum of 5 characters and maximum of 15)",
+      passwordConfirmationRequirements: "It must match your password"
     },
 
     //Commons
@@ -1027,7 +1028,8 @@ let LOCALIZE = new LocalizedStrings({
       taskTooltip: "infobulle de tâche",
       reasonsForActionTooltip: "infobulle des motifs de l'action",
       passwordCreationRequirements:
-        "FR Password (your password must satisfy the following: At least one upper case, at least one lower case, at least one digit, at least one special character, minimum of 5 characters and maximum of 15)"
+        "FR Password (your password must satisfy the following: At least one upper case, at least one lower case, at least one digit, at least one special character, minimum of 5 characters and maximum of 15)",
+      passwordConfirmationRequirements: "FR It must match your password"
     },
 
     //Commons

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -32,7 +32,7 @@ let LOCALIZE = new LocalizedStrings({
             "An account is required to proceed further. To log in, enter your credentials below.",
           inputs: {
             emailTitle: "Email Address:",
-            passwordTitle: "Password:",
+            passwordTitle: "Password:"
           }
         },
         button: "Login",
@@ -489,7 +489,9 @@ let LOCALIZE = new LocalizedStrings({
       emailOptions: "email options",
       taskOptions: "task options",
       taskTooltip: "task tooltip",
-      reasonsForActionTooltip: "reasons for action tooltip"
+      reasonsForActionTooltip: "reasons for action tooltip",
+      passwordCreationRequirements:
+        "Password (your password must satisfy the following: At least one upper case, at least one lower case, at least one digit, at least one special character, minimum of 5 characters and maximum of 15)"
     },
 
     //Commons
@@ -561,7 +563,7 @@ let LOCALIZE = new LocalizedStrings({
             "FR An account is required to proceed further. To log in, enter your credentials below.",
           inputs: {
             emailTitle: "Adresse courriel :",
-            passwordTitle: "Mot de passe :",
+            passwordTitle: "Mot de passe :"
           }
         },
         button: "Connexion",
@@ -1023,7 +1025,9 @@ let LOCALIZE = new LocalizedStrings({
       emailOptions: "options de messagerie",
       taskOptions: "options de tâche",
       taskTooltip: "infobulle de tâche",
-      reasonsForActionTooltip: "infobulle des motifs de l'action"
+      reasonsForActionTooltip: "infobulle des motifs de l'action",
+      passwordCreationRequirements:
+        "FR Password (your password must satisfy the following: At least one upper case, at least one lower case, at least one digit, at least one special character, minimum of 5 characters and maximum of 15)"
     },
 
     //Commons


### PR DESCRIPTION
# Description

This PR is linking all the Login and Registration form errors to their respective fields. I also updated the aria-labels, so that screen reader users get a description of the fields requirements.

## Type of change

- Code cleanliness or refactor

## Screenshot

**Login Form (without error):**

![image](https://user-images.githubusercontent.com/23021242/58875928-be75fd80-869a-11e9-82ef-3bdf1cb47c21.png)

**Login Form (with errors):**

![image](https://user-images.githubusercontent.com/23021242/58875972-d3529100-869a-11e9-8a44-d2b4a3129e14.png)

**Registration form (without error):**

![image](https://user-images.githubusercontent.com/23021242/58875998-e6656100-869a-11e9-90cc-17b37c2a2148.png)

**Registration form (with errors):**

![image](https://user-images.githubusercontent.com/23021242/58876068-08f77a00-869b-11e9-975f-24dc89d6cdeb.png)

# Testing

Manual steps to reproduce this functionality:

1.  Start NVDA.
2.  Navigate in the Login and Registration forms using the keyboard and make sure that you get all the needed information (invalid fields, required fields, etc.) from the screen reader.

# Checklist

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
