### PR TITLE
[Accessibility] Hide login button if current page is login page

### DIFF
--- a/frontend/src/components/commons/LoginButton.jsx
+++ b/frontend/src/components/commons/LoginButton.jsx
@@ -4,8 +4,8 @@ import LOCALIZE from "../../text_resources";
 import { logoutAction } from "../../modules/LoginRedux";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
-import { NavLink } from "react-router-dom";
 import { PATH } from "../../App";
+import { Nav } from "react-bootstrap";
 
 const styles = {
   button: {
@@ -31,14 +31,16 @@ class LoginButton extends Component {
     return (
       <div>
         {!this.props.authenticated && (
-          <NavLink tabIndex="-1" style={styles.navlink} to={PATH.login}>
-            <button className="btn btn-primary" style={styles.button}>
-              {LOCALIZE.commons.login}
-            </button>
-          </NavLink>
+          <Nav.Link tabIndex="-1" href={PATH.login} style={styles.navlink}>
+            {window.location.pathname !== PATH.login && (
+              <button className="btn btn-primary" style={styles.button}>
+                {LOCALIZE.commons.login}
+              </button>
+            )}
+          </Nav.Link>
         )}
         {this.props.authenticated && (
-          <NavLink tabIndex="-1" style={styles.navlink} to={PATH.login}>
+          <Nav.Link tabIndex="-1" href={PATH.login} style={styles.navlink}>
             <button
               type="button"
               className="btn btn-primary"
@@ -47,7 +49,7 @@ class LoginButton extends Component {
             >
               {LOCALIZE.commons.logout}
             </button>
-          </NavLink>
+          </Nav.Link>
         )}
       </div>
     );

--- a/frontend/src/components/commons/LoginButton.jsx
+++ b/frontend/src/components/commons/LoginButton.jsx
@@ -5,14 +5,10 @@ import { logoutAction } from "../../modules/LoginRedux";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { PATH } from "../../App";
-import { Nav } from "react-bootstrap";
 
 const styles = {
-  button: {
-    marginRight: 15
-  },
   navlink: {
-    all: "unset"
+    marginRight: 15
   }
 };
 
@@ -31,25 +27,27 @@ class LoginButton extends Component {
     return (
       <div>
         {!this.props.authenticated && (
-          <Nav.Link tabIndex="-1" href={PATH.login} style={styles.navlink}>
+          <div>
             {window.location.pathname !== PATH.login && (
-              <button className="btn btn-primary" style={styles.button}>
-                {LOCALIZE.commons.login}
-              </button>
+              <a tabIndex="-1" href={PATH.login}>
+                <button style={styles.navlink} className="btn btn-primary">
+                  {LOCALIZE.commons.login}
+                </button>
+              </a>
             )}
-          </Nav.Link>
+          </div>
         )}
         {this.props.authenticated && (
-          <Nav.Link tabIndex="-1" href={PATH.login} style={styles.navlink}>
+          <a tabIndex="-1" href={PATH.login}>
             <button
               type="button"
               className="btn btn-primary"
-              style={styles.button}
+              style={styles.navlink}
               onClick={this.handleLogout}
             >
               {LOCALIZE.commons.logout}
             </button>
-          </Nav.Link>
+          </a>
         )}
       </div>
     );


### PR DESCRIPTION
# Description

Hiding the _Login_ button (top right corner button) if the current page is login page, in order to avoid confusion.

## Type of change

- Code cleanliness or refactor

## Screenshot

**If not logged in - Home/Login Page:**

![image](https://user-images.githubusercontent.com/23021242/58879408-a060cb00-86a3-11e9-98df-79d0aee78214.png)

**If not logged in - eMIB Sample Test Page:**

![image](https://user-images.githubusercontent.com/23021242/58879494-ca19f200-86a3-11e9-93a9-94570a3906e4.png)

**If logged in - Home/Dashboard Page:**

![image](https://user-images.githubusercontent.com/23021242/58879554-ecac0b00-86a3-11e9-9bff-c46069617fe9.png)

**If logged in - eMIB Sample Test Page:**

![image](https://user-images.githubusercontent.com/23021242/58879597-02b9cb80-86a4-11e9-8200-2bfb92af0c57.png)

# Testing

Manual steps to reproduce this functionality:

- Navigate in the application and make sure that the Login/Logout button is displayed at the right time.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 11+ and Chrome
