### PR TITLE
[Accessibility] Added a descriptive message in the registration form

### DIFF
--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -39,10 +39,13 @@ const styles = {
     position: "absolute",
     margin: "8px 0 0 484px"
   },
-  loginBtn: {
+  createAccountBtn: {
     width: 150,
     display: "block",
     margin: "24px auto"
+  },
+  enableButtonDesc: {
+    marginBottom: 24
   },
   validationError: {
     color: "#923534",
@@ -370,12 +373,17 @@ class RegistrationForm extends Component {
               </div>
               <button
                 disabled={!submitButtonEnabled}
-                style={styles.loginBtn}
+                style={styles.createAccountBtn}
                 className="btn btn-primary"
                 type="submit"
               >
                 {LOCALIZE.authentication.createAccount.button}
               </button>
+              {!submitButtonEnabled && (
+                <div tabIndex="0" style={styles.enableButtonDesc}>
+                  <p>{LOCALIZE.authentication.createAccount.enableButtonDescription}</p>
+                </div>
+              )}
             </form>
           </div>
         </div>

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -68,6 +68,8 @@ let LOCALIZE = new LocalizedStrings({
           description: "You have just created a new account!"
         },
         button: "Create account",
+        enableButtonDescription:
+          'The "Create account" button will be enabled when all the required fields will be valid.',
         accountAlreadyExistsError: "An account is already associated to this email address."
       }
     },
@@ -600,6 +602,8 @@ let LOCALIZE = new LocalizedStrings({
           description: "FR You have just created a new account!"
         },
         button: "Créer compte",
+        enableButtonDescription:
+          "FR The « Create account » button will be enabled when all the required fields will be valid.",
         accountAlreadyExistsError: "FR An account is already associated to this email address."
       }
     },


### PR DESCRIPTION
**These changes are subject to change, depending on Joey's comments related to the design.**

# Description

This PR is introducing a new descriptive message below the _Create account_ button in the registration form, so that the users will know how to enabled this button. This message will disappear once all the fields will be valid, meaning when the _Create account_ button will be enabled.

## Type of change

- New feature (non-breaking change which adds functionality)
- Code cleanliness or refactor

## Screenshot

**Initial Form View:**

![image](https://user-images.githubusercontent.com/23021242/58898312-51795c80-86c8-11e9-9c9a-5124eab0a295.png)

**Form with invalid fields:**

![image](https://user-images.githubusercontent.com/23021242/58898260-327aca80-86c8-11e9-9877-9ece1b3d536a.png)

**Form with all valid fields:**

![image](https://user-images.githubusercontent.com/23021242/58898276-41617d00-86c8-11e9-83d4-07dfd7d07d3f.png)

# Testing

Manual steps to reproduce this functionality:

- Fill out the registration form and make sure that the descriptive message is displayed at the right time.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
