### PR TITLE
[Accessibility] Removing unneeded aria-label from login form

### DIFF
--- a/frontend/src/components/authentication/LoginForm.jsx
+++ b/frontend/src/components/authentication/LoginForm.jsx
@@ -101,7 +101,6 @@ class LoginForm extends Component {
                     </label>
                   </div>
                   <input
-                    aria-label={LOCALIZE.authentication.login.content.inputs.emailTitle}
                     aria-required={"true"}
                     type="text"
                     id="username"


### PR DESCRIPTION
# Description

I simply removed the unneeded aria-label from the login form.

## Type of change

- Code cleanliness or refactor

## Screenshot

(N/A)

# Testing

Manual steps to reproduce this functionality:

1.  Open the login form from the home page.
2.  Navigate using the screen reader and make sure that you get the expected behavior when you enter valid and invalid credentials.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
