### PR TITLE
Update styles for CAT dialogs

### DIFF
--- a/frontend/src/components/commons/PopupBox.jsx
+++ b/frontend/src/components/commons/PopupBox.jsx
@@ -21,7 +21,9 @@ const customStyles = {
     right: "auto",
     bottom: "auto",
     marginRight: "-50%",
-    transform: "translate(-50%, -50%)"
+    transform: "translate(-50%, -50%)",
+    backgroundColor: "#F5FAFB",
+    padding: 0
   },
   overlay: {
     backgroundColor: "rgba(0, 0, 0, 0.7)"
@@ -29,11 +31,23 @@ const customStyles = {
 };
 
 const styles = {
+  contentPadding: {
+    padding: "10px 15px",
+    overflow: "scroll",
+    maxHeight: "calc(100vh - 300px)"
+  },
+  headerPadding: {
+    padding: "15px 15px 5px 15px"
+  },
+  footerPadding: {
+    padding: 15,
+    height: 70
+  },
   rightButton: {
     float: "right"
   },
-  description: {
-    padding: "16px 0px"
+  hr: {
+    margin: 0
   }
 };
 
@@ -111,31 +125,41 @@ class PopupBox extends Component {
         }}
         ariaHideApp={ariaHideApp}
       >
-        <h2 id="modal-heading">{title}</h2>
-        <div id="modal-description" style={styles.description}>
+        <div style={styles.headerPadding}>
+          <h2 id="modal-heading">{title}</h2>
+        </div>
+
+        <hr style={styles.hr} />
+
+        <div id="modal-description" style={styles.contentPadding}>
           {description}
         </div>
-        {leftButtonTitle && leftButtonType && (
-          <button
-            className={leftButtonType}
-            onClick={this.leftButtonCloseAndAction}
-            disabled={leftButtonState}
-            id="unit-test-left-btn"
-          >
-            {leftButtonTitle}
-          </button>
-        )}
-        {rightButtonTitle && rightButtonType && (
-          <button
-            style={styles.rightButton}
-            className={rightButtonType}
-            onClick={this.rightButtonCloseAndAction}
-            disabled={rightButtonState}
-            id="unit-test-right-btn"
-          >
-            {rightButtonTitle}
-          </button>
-        )}
+
+        <hr style={styles.hr} />
+
+        <div style={styles.footerPadding}>
+          {leftButtonTitle && leftButtonType && (
+            <button
+              className={leftButtonType}
+              onClick={this.leftButtonCloseAndAction}
+              disabled={leftButtonState}
+              id="unit-test-left-btn"
+            >
+              {leftButtonTitle}
+            </button>
+          )}
+          {rightButtonTitle && rightButtonType && (
+            <button
+              style={styles.rightButton}
+              className={rightButtonType}
+              onClick={this.rightButtonCloseAndAction}
+              disabled={rightButtonState}
+              id="unit-test-right-btn"
+            >
+              {rightButtonTitle}
+            </button>
+          )}
+        </div>
       </Modal>
     );
   }


### PR DESCRIPTION
# Description

Update of styles for CAT dialogs.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

Before
<img width="751" alt="Screen Shot 2019-06-05 at 2 23 01 PM" src="https://user-images.githubusercontent.com/4640747/58980056-7db2dd00-879d-11e9-907a-34f3ceec6513.png">


After
<img width="725" alt="Screen Shot 2019-06-05 at 11 48 13 AM" src="https://user-images.githubusercontent.com/4640747/58970656-d7101180-8787-11e9-9370-68796037cf70.png">


# Testing

Manual steps to reproduce this functionality:

1.  Try out the dialogs by starting the test, submitting, seeing settings, org chat, etc.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 11+ and Chrome
