### PR TITLE
Setting dialog content

### DIFF
--- a/frontend/src/components/commons/Settings.jsx
+++ b/frontend/src/components/commons/Settings.jsx
@@ -86,7 +86,7 @@ class Settings extends Component {
             </div>
           }
           rightButtonType={BUTTON_TYPE.primary}
-          rightButtonTitle={LOCALIZE.settings.okay}
+          rightButtonTitle={LOCALIZE.commons.ok}
           rightButtonAction={this.toggleDialog}
         />
       </div>

--- a/frontend/src/components/commons/Settings.jsx
+++ b/frontend/src/components/commons/Settings.jsx
@@ -43,13 +43,58 @@ class Settings extends Component {
           description={
             <div>
               <h3>Zoom (+/-)</h3>
-              <p>Info</p>
+              <ol>
+                <li>Select the View button at the top left bar in Internet Explorer</li>
+                <li>Select Zoom.</li>
+                <li>
+                  You can select a predefined zoom level, or a custom level by selecting Custom and
+                  entering a zoom value.
+                </li>
+                <li>
+                  Alternatively, you can hold down CTRL and the + / - keys on your keyboard to zoom
+                  in or out.
+                </li>
+              </ol>
               <h3>Text size</h3>
-              <p>Info</p>
+              <ol>
+                <li>Select the View button at the top left bar in Internet Explorer</li>
+                <li>Select Text size.</li>
+                <li>Choose to make text larger or smaller than the size on the screen.</li>
+              </ol>
+              If the text size has not changed:
+              <ol>
+                <li>
+                  Select the Tools button, and select General tab, and then, under Appearance,
+                  select Accessibility.
+                </li>
+                <li>Select the Ignore font sizes specified on webpages on the check box.</li>
+                <li>Select OK, and then select OK again.</li>
+              </ol>
               <h3>Font style</h3>
-              <p>Info</p>
+              <ol>
+                <li>Select the Tools button at the top left bar in Internet Explorer.</li>
+                <li>Select Internet options.</li>
+                <li>In the General tab, under Appearance, select Accessibility. </li>
+                <li>Select the Ignore font styles specified on webpages on the check box. </li>
+                <li>Select OK.</li>
+                <li>In the General tab, under Appearance, select Fonts.</li>
+                <li>Select the fonts you want to use.</li>
+                <li>Select OK, and then select OK again.</li>
+              </ol>
               <h3>Text and background colour</h3>
-              <p>Info</p>
+              <ol>
+                <li>Select the Tools button and select Internet options.</li>
+                <li>In the General tab, under Appearance, select Accessibility. </li>
+                <li>Select the Ignore colors specified on webpages on the check box. </li>
+                <li>Select OK.</li>
+                <li>In the General tab, under Appearance, select Colors.</li>
+                <li>Uncheck the Use Windows colors check box.</li>
+                <li>
+                  For each color that you want to change, select the color box, select a new color,
+                  and then select OK.
+                </li>
+                <li>Select OK, and then select OK again.</li>
+              </ol>
             </div>
           }
           rightButtonType={BUTTON_TYPE.primary}

--- a/frontend/src/components/commons/Settings.jsx
+++ b/frontend/src/components/commons/Settings.jsx
@@ -42,58 +42,46 @@ class Settings extends Component {
           title={LOCALIZE.settings.systemSettings}
           description={
             <div>
-              <h3>Zoom (+/-)</h3>
+              <h3>{LOCALIZE.settings.zoom.title}</h3>
               <ol>
-                <li>Select the View button at the top left bar in Internet Explorer</li>
-                <li>Select Zoom.</li>
-                <li>
-                  You can select a predefined zoom level, or a custom level by selecting Custom and
-                  entering a zoom value.
-                </li>
-                <li>
-                  Alternatively, you can hold down CTRL and the + / - keys on your keyboard to zoom
-                  in or out.
-                </li>
+                <li>{LOCALIZE.settings.zoom.instructionsListItem1}</li>
+                <li>{LOCALIZE.settings.zoom.instructionsListItem2}</li>
+                <li>{LOCALIZE.settings.zoom.instructionsListItem3}</li>
+                <li>{LOCALIZE.settings.zoom.instructionsListItem4}</li>
               </ol>
-              <h3>Text size</h3>
+              <h3>{LOCALIZE.settings.textSize.title}</h3>
               <ol>
-                <li>Select the View button at the top left bar in Internet Explorer</li>
-                <li>Select Text size.</li>
-                <li>Choose to make text larger or smaller than the size on the screen.</li>
+                <li>{LOCALIZE.settings.textSize.instructionsListItem1}</li>
+                <li>{LOCALIZE.settings.textSize.instructionsListItem2}</li>
+                <li>{LOCALIZE.settings.textSize.instructionsListItem3}</li>
               </ol>
-              If the text size has not changed:
+              {LOCALIZE.settings.textSize.notChanged}
               <ol>
-                <li>
-                  Select the Tools button, and select General tab, and then, under Appearance,
-                  select Accessibility.
-                </li>
-                <li>Select the Ignore font sizes specified on webpages on the check box.</li>
-                <li>Select OK, and then select OK again.</li>
+                <li>{LOCALIZE.settings.textSize.instructionsListItem4}</li>
+                <li>{LOCALIZE.settings.textSize.instructionsListItem5}</li>
+                <li>{LOCALIZE.settings.textSize.instructionsListItem6}</li>
               </ol>
-              <h3>Font style</h3>
+              <h3>{LOCALIZE.settings.fontStyle.title}</h3>
               <ol>
-                <li>Select the Tools button at the top left bar in Internet Explorer.</li>
-                <li>Select Internet options.</li>
-                <li>In the General tab, under Appearance, select Accessibility. </li>
-                <li>Select the Ignore font styles specified on webpages on the check box. </li>
-                <li>Select OK.</li>
-                <li>In the General tab, under Appearance, select Fonts.</li>
-                <li>Select the fonts you want to use.</li>
-                <li>Select OK, and then select OK again.</li>
+                <li>{LOCALIZE.settings.fontStyle.instructionsListItem1}</li>
+                <li>{LOCALIZE.settings.fontStyle.instructionsListItem2}</li>
+                <li>{LOCALIZE.settings.fontStyle.instructionsListItem3}</li>
+                <li>{LOCALIZE.settings.fontStyle.instructionsListItem4}</li>
+                <li>{LOCALIZE.settings.fontStyle.instructionsListItem5}</li>
+                <li>{LOCALIZE.settings.fontStyle.instructionsListItem6}</li>
+                <li>{LOCALIZE.settings.fontStyle.instructionsListItem7}</li>
+                <li>{LOCALIZE.settings.fontStyle.instructionsListItem8}</li>
               </ol>
-              <h3>Text and background colour</h3>
+              <h3>{LOCALIZE.settings.color.title}</h3>
               <ol>
-                <li>Select the Tools button and select Internet options.</li>
-                <li>In the General tab, under Appearance, select Accessibility. </li>
-                <li>Select the Ignore colors specified on webpages on the check box. </li>
-                <li>Select OK.</li>
-                <li>In the General tab, under Appearance, select Colors.</li>
-                <li>Uncheck the Use Windows colors check box.</li>
-                <li>
-                  For each color that you want to change, select the color box, select a new color,
-                  and then select OK.
-                </li>
-                <li>Select OK, and then select OK again.</li>
+                <li>{LOCALIZE.settings.color.instructionsListItem1}</li>
+                <li>{LOCALIZE.settings.color.instructionsListItem2}</li>
+                <li>{LOCALIZE.settings.color.instructionsListItem3}</li>
+                <li>{LOCALIZE.settings.color.instructionsListItem4}</li>
+                <li>{LOCALIZE.settings.color.instructionsListItem5}</li>
+                <li>{LOCALIZE.settings.color.instructionsListItem6}</li>
+                <li>{LOCALIZE.settings.color.instructionsListItem7}</li>
+                <li>{LOCALIZE.settings.color.instructionsListItem8}</li>
               </ol>
             </div>
           }

--- a/frontend/src/components/commons/Settings.jsx
+++ b/frontend/src/components/commons/Settings.jsx
@@ -4,6 +4,7 @@ import { Button } from "react-bootstrap";
 import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCog } from "@fortawesome/free-solid-svg-icons";
+import LOCALIZE from "../../text_resources";
 
 const styles = {
   button: {
@@ -25,24 +26,34 @@ class Settings extends Component {
   };
 
   render() {
-    // TODO(caleybrock) - Fill in context and localize.
     return (
       <div>
         <Button
           style={styles.button}
           variant={this.props.variant}
           onClick={this.toggleDialog}
-          aria-label="System settings"
+          aria-label={LOCALIZE.settings.systemSettings}
         >
           <FontAwesomeIcon icon={faCog} />
         </Button>
         <PopupBox
           show={this.state.isDialogOpen}
           handleClose={this.toggleDialog}
-          title={"System settings"}
-          description={<div>TODO: Information about system settings will go here.</div>}
+          title={LOCALIZE.settings.systemSettings}
+          description={
+            <div>
+              <h3>Zoom (+/-)</h3>
+              <p>Info</p>
+              <h3>Text size</h3>
+              <p>Info</p>
+              <h3>Font style</h3>
+              <p>Info</p>
+              <h3>Text and background colour</h3>
+              <p>Info</p>
+            </div>
+          }
           rightButtonType={BUTTON_TYPE.primary}
-          rightButtonTitle={"Okay"}
+          rightButtonTitle={LOCALIZE.settings.okay}
           rightButtonAction={this.toggleDialog}
         />
       </div>

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -113,7 +113,52 @@ let LOCALIZE = new LocalizedStrings({
     // Settings Dialog
     settings: {
       systemSettings: "System settings",
-      okay: "Okay"
+      okay: "Okay",
+      zoom: {
+        title: "Zoom (+/-)",
+        instructionsListItem1: "Select the View button at the top left bar in Internet Explorer.",
+        instructionsListItem2: "Select Zoom.",
+        instructionsListItem3:
+          "You can select a predefined zoom level, or a custom level by selecting Custom and entering a zoom value.",
+        instructionsListItem4:
+          "Alternatively, you can hold down CTRL and the + / - keys on your keyboard to zoom in or out."
+      },
+      textSize: {
+        title: "Text size",
+        instructionsListItem1: "Select the View button at the top left bar in Internet Explorer.",
+        instructionsListItem2: "Select Text size.",
+        instructionsListItem3: "Choose to make text larger or smaller than the size on the screen.",
+        instructionsListItem4:
+          "Select the Tools button, and select General tab, and then, under Appearance, select Accessibility.",
+        instructionsListItem5:
+          "Select the Ignore font sizes specified on webpages on the check box.",
+        instructionsListItem6: "Select OK, and then select OK again.",
+        notChanged: "If the text size has not changed:"
+      },
+      fontStyle: {
+        title: "Font style",
+        instructionsListItem1: "Select the Tools button at the top left bar in Internet Explorer.",
+        instructionsListItem2: "Select Internet options.",
+        instructionsListItem3: "In the General tab, under Appearance, select Accessibility.",
+        instructionsListItem4:
+          "Select the Ignore font styles specified on webpages on the check box.",
+        instructionsListItem5: "Select OK.",
+        instructionsListItem6: "In the General tab, under Appearance, select Fonts.",
+        instructionsListItem7: "Select the fonts you want to use.",
+        instructionsListItem8: "Select OK, and then select OK again."
+      },
+      color: {
+        title: "Text and background colour",
+        instructionsListItem1: "Select the Tools button and select Internet options.",
+        instructionsListItem2: "In the General tab, under Appearance, select Accessibility.",
+        instructionsListItem3: "Select the Ignore colors specified on webpages on the check box.",
+        instructionsListItem4: "Select OK.",
+        instructionsListItem5: "In the General tab, under Appearance, select Colors.",
+        instructionsListItem6: "Uncheck the Use Windows colors check box.",
+        instructionsListItem7:
+          "For each color that you want to change, select the color box, select a new color, and then select OK.",
+        instructionsListItem8: "Select OK, and then select OK again."
+      }
     },
 
     //eMIB Test
@@ -648,7 +693,57 @@ let LOCALIZE = new LocalizedStrings({
     // Settings Dialog
     settings: {
       systemSettings: "FR System settings",
-      okay: "FR Okay"
+      okay: "FR Okay",
+      zoom: {
+        title: "FR Zoom (+/-)",
+        instructionsListItem1:
+          "FR Select the View button at the top left bar in Internet Explorer.",
+        instructionsListItem2: "FR Select Zoom.",
+        instructionsListItem3:
+          "FR You can select a predefined zoom level, or a custom level by selecting Custom and entering a zoom value.",
+        instructionsListItem4:
+          "FR Alternatively, you can hold down CTRL and the + / - keys on your keyboard to zoom in or out."
+      },
+      textSize: {
+        title: "FR Text size",
+        instructionsListItem1:
+          "FR Select the View button at the top left bar in Internet Explorer.",
+        instructionsListItem2: "FR Select Text size.",
+        instructionsListItem3:
+          "FR Choose to make text larger or smaller than the size on the screen.",
+        instructionsListItem4:
+          "FR Select the Tools button, and select General tab, and then, under Appearance, select Accessibility.",
+        instructionsListItem5:
+          "FR Select the Ignore font sizes specified on webpages on the check box.",
+        instructionsListItem6: "FR Select OK, and then select OK again.",
+        notChanged: "FR If the text size has not changed:"
+      },
+      fontStyle: {
+        title: "FR Font style",
+        instructionsListItem1:
+          "FR Select the Tools button at the top left bar in Internet Explorer.",
+        instructionsListItem2: "FR Select Internet options.",
+        instructionsListItem3: "FR In the General tab, under Appearance, select Accessibility.",
+        instructionsListItem4:
+          "FR Select the Ignore font styles specified on webpages on the check box.",
+        instructionsListItem5: "FR Select OK.",
+        instructionsListItem6: "FR In the General tab, under Appearance, select Fonts.",
+        instructionsListItem7: "FR Select the fonts you want to use.",
+        instructionsListItem8: "FR Select OK, and then select OK again."
+      },
+      color: {
+        title: "FR Text and background colour",
+        instructionsListItem1: "FR Select the Tools button and select Internet options.",
+        instructionsListItem2: "FR In the General tab, under Appearance, select Accessibility.",
+        instructionsListItem3:
+          "FR Select the Ignore colors specified on webpages on the check box.",
+        instructionsListItem4: "FR Select OK.",
+        instructionsListItem5: "FR In the General tab, under Appearance, select Colors.",
+        instructionsListItem6: "FR Uncheck the Use Windows colors check box.",
+        instructionsListItem7:
+          "FR For each color that you want to change, select the color box, select a new color, and then select OK.",
+        instructionsListItem8: "FR Select OK, and then select OK again."
+      }
     },
 
     //eMIB Test

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -113,7 +113,6 @@ let LOCALIZE = new LocalizedStrings({
     // Settings Dialog
     settings: {
       systemSettings: "System settings",
-      okay: "Okay",
       zoom: {
         title: "Zoom (+/-)",
         instructionsListItem1: "Select the View button at the top left bar in Internet Explorer.",
@@ -693,7 +692,6 @@ let LOCALIZE = new LocalizedStrings({
     // Settings Dialog
     settings: {
       systemSettings: "FR System settings",
-      okay: "FR Okay",
       zoom: {
         title: "FR Zoom (+/-)",
         instructionsListItem1:

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -89,13 +89,6 @@ let LOCALIZE = new LocalizedStrings({
       description: "Here is your dashboard..."
     },
 
-    //Prototype Page
-    prototypePage: {
-      title: "Prototype",
-      welcomeMsg: "This page will be used to test out experimental UIs.",
-      startEmibSampleTest: "Start eMIB Sample Test"
-    },
-
     //Status Page
     statusPage: {
       title: "CAT Status",
@@ -623,13 +616,6 @@ let LOCALIZE = new LocalizedStrings({
     dashboard: {
       title: "FR Welcome to your dashboard",
       description: "FR Here is your dashboard..."
-    },
-
-    //Prototype Page
-    prototypePage: {
-      title: "Prototype",
-      welcomeMsg: "Cette page sera utilisée pour tester des interfaces utilisateur expérimentales.",
-      startEmibSampleTest: "Démarrer le test pratique eMIB"
     },
 
     //Status Page

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -110,6 +110,12 @@ let LOCALIZE = new LocalizedStrings({
       }
     },
 
+    // Settings Dialog
+    settings: {
+      systemSettings: "System settings",
+      okay: "Okay"
+    },
+
     //eMIB Test
     emibTest: {
       //Home Page
@@ -637,6 +643,12 @@ let LOCALIZE = new LocalizedStrings({
         browsers: "IE 9+, Firefox, Chrome",
         screenResolution: "Résolution d'écran minimum de 800 x 600"
       }
+    },
+
+    // Settings Dialog
+    settings: {
+      systemSettings: "FR System settings",
+      okay: "FR Okay"
     },
 
     //eMIB Test


### PR DESCRIPTION
# Description

Added content for the settings dialog. French will come once it's finalized and translated.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

<img width="733" alt="Screen Shot 2019-06-05 at 4 40 59 PM" src="https://user-images.githubusercontent.com/4640747/58988979-e6f01b80-87b0-11e9-81a4-c1222b9b2213.png">

# Testing

Manual steps to reproduce this functionality:

1.  Click on the settings button in the nav.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
