### PR TITLE
[Inbox] Add tooltips to action dialogs

### DIFF
--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -8,6 +8,7 @@ import { transformAddressBook } from "../../helpers/transformations";
 import { contactShape } from "./constants";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faReply, faReplyAll, faShareSquare } from "@fortawesome/free-solid-svg-icons";
+import { OverlayTrigger, Popover, Button } from "react-bootstrap";
 
 // These two consts limit the number of characters
 // that can be entered into two text areas
@@ -305,6 +306,25 @@ class EditEmail extends Component {
               <label htmlFor="your-response-text-area">
                 {LOCALIZE.emibTest.inboxPage.addEmailResponse.response}
               </label>
+              <OverlayTrigger
+                trigger="focus"
+                placement="right"
+                overlay={
+                  <Popover id="reasons-for-action-tooltip">
+                    <div>
+                      <p>{LOCALIZE.emibTest.inboxPage.addEmailResponse.emailResponseTooltip}</p>
+                    </div>
+                  </Popover>
+                }
+              >
+                <Button
+                  aria-label={LOCALIZE.ariaLabel.emailResponseTooltip}
+                  style={styles.tooltipButton}
+                  variant="link"
+                >
+                  ?
+                </Button>
+              </OverlayTrigger>
               <div>
                 <textarea
                   id="your-response-text-area"
@@ -326,6 +346,25 @@ class EditEmail extends Component {
               <label htmlFor="reasons-for-action-text-area">
                 {LOCALIZE.emibTest.inboxPage.addEmailResponse.reasonsForAction}
               </label>
+              <OverlayTrigger
+                trigger="focus"
+                placement="right"
+                overlay={
+                  <Popover id="reasons-for-action-tooltip">
+                    <div>
+                      <p>{LOCALIZE.emibTest.inboxPage.addEmailResponse.reasonsForActionTooltip}</p>
+                    </div>
+                  </Popover>
+                }
+              >
+                <Button
+                  aria-label={LOCALIZE.ariaLabel.reasonsForActionTooltip}
+                  style={styles.tooltipButton}
+                  variant="link"
+                >
+                  ?
+                </Button>
+              </OverlayTrigger>
               <div>
                 <textarea
                   id="reasons-for-action-text-area"

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -43,16 +43,6 @@ const styles = {
       width: 15,
       cursor: "pointer"
     },
-    tooltipContainer: {
-      marginLeft: 6,
-      padding: 6,
-      maxWidth: 550,
-      borderColor: "#00565E"
-    },
-    tooltipContent: {
-      color: "#00565E",
-      margin: 0
-    },
     textArea: {
       padding: "6px 12px",
       border: "1px solid #00565E",
@@ -71,16 +61,6 @@ const styles = {
       color: "#00565E",
       marginTop: "4px",
       cursor: "pointer"
-    },
-    tooltipContainer: {
-      marginLeft: 6,
-      padding: 8,
-      maxWidth: 360,
-      borderColor: "#00565E"
-    },
-    tooltipContent: {
-      color: "#00565E",
-      margin: 0
     },
     textArea: {
       padding: "6px 12px",
@@ -132,14 +112,10 @@ class EditTask extends Component {
                 trigger="focus"
                 placement="right"
                 overlay={
-                  <Popover style={styles.tasks.tooltipContainer}>
+                  <Popover>
                     <div>
-                      <p style={styles.tasks.tooltipContent}>
-                        {LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart1}
-                      </p>
-                      <p style={styles.tasks.tooltipContent}>
-                        {LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart2}
-                      </p>
+                      <p>{LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart1}</p>
+                      <p>{LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart2}</p>
                     </div>
                   </Popover>
                 }
@@ -172,14 +148,9 @@ class EditTask extends Component {
                 trigger="focus"
                 placement="right"
                 overlay={
-                  <Popover
-                    id="reasons-for-action-tooltip"
-                    style={styles.reasonsForAction.tooltipContainer}
-                  >
+                  <Popover id="reasons-for-action-tooltip">
                     <div>
-                      <p style={styles.reasonsForAction.tooltipContent}>
-                        {LOCALIZE.emibTest.inboxPage.taskContent.reasonsForActionTooltip}
-                      </p>
+                      <p>{LOCALIZE.emibTest.inboxPage.taskContent.reasonsForActionTooltip}</p>
                     </div>
                   </Popover>
                 }

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -120,7 +120,11 @@ class EditTask extends Component {
                   </Popover>
                 }
               >
-                <Button style={styles.tooltipButton} variant="link">
+                <Button
+                  aria-label={LOCALIZE.ariaLabel.taskTooltip}
+                  style={styles.tooltipButton}
+                  variant="link"
+                >
                   ?
                 </Button>
               </OverlayTrigger>
@@ -155,7 +159,11 @@ class EditTask extends Component {
                   </Popover>
                 }
               >
-                <Button style={styles.tooltipButton} variant="link">
+                <Button
+                  aria-label={LOCALIZE.ariaLabel.reasonsForActionTooltip}
+                  style={styles.tooltipButton}
+                  variant="link"
+                >
                   ?
                 </Button>
               </OverlayTrigger>

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { OverlayTrigger, Popover } from "react-bootstrap";
+import { OverlayTrigger, Popover, Button } from "react-bootstrap";
 import LOCALIZE from "../../text_resources";
 import { actionShape } from "./constants";
 import "../../css/inbox.css";
@@ -13,6 +13,9 @@ const MAX_TASK = "650";
 const MAX_REASON = "650";
 
 const styles = {
+  tooltipButton: {
+    padding: 0
+  },
   header: {
     color: "#00565E",
     paddingTop: 12
@@ -93,9 +96,7 @@ const styles = {
 class EditTask extends Component {
   state = {
     task: !this.props.action ? "" : this.props.action.task,
-    taskTooltipIcon: "far fa-question-circle",
-    reasonsForAction: !this.props.action ? "" : this.props.action.reasonsForAction,
-    reasonsForActionTooltipIcon: "far fa-question-circle"
+    reasonsForAction: !this.props.action ? "" : this.props.action.reasonsForAction
   };
 
   static propTypes = {
@@ -115,24 +116,8 @@ class EditTask extends Component {
     this.props.onChange({ ...this.state, reasonsForAction: newReasonForAction });
   };
 
-  onTaskTooltipFocus = () => {
-    this.setState({ taskTooltipIcon: "fas fa-question-circle" });
-  };
-
-  onTaskTooltipBlur = () => {
-    this.setState({ taskTooltipIcon: "far fa-question-circle" });
-  };
-
-  onReasonsForActionTooltipFocus = () => {
-    this.setState({ reasonsForActionTooltipIcon: "fas fa-question-circle" });
-  };
-
-  onReasonsForActionTooltipBlur = () => {
-    this.setState({ reasonsForActionTooltipIcon: "far fa-question-circle" });
-  };
-
   render() {
-    const { task, taskTooltipIcon, reasonsForAction, reasonsForActionTooltipIcon } = this.state;
+    const { task, reasonsForAction } = this.state;
 
     return (
       <div style={styles.container}>
@@ -147,7 +132,7 @@ class EditTask extends Component {
                 trigger="focus"
                 placement="right"
                 overlay={
-                  <Popover id="task-tooltip" style={styles.tasks.tooltipContainer}>
+                  <Popover style={styles.tasks.tooltipContainer}>
                     <div>
                       <p style={styles.tasks.tooltipContent}>
                         {LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart1}
@@ -159,14 +144,9 @@ class EditTask extends Component {
                   </Popover>
                 }
               >
-                <i
-                  id="task-tooltip"
-                  aria-label={LOCALIZE.ariaLabel.taskTooltip}
-                  className={taskTooltipIcon}
-                  style={styles.tasks.icon}
-                  onFocus={this.onTaskTooltipFocus}
-                  onBlur={this.onTaskTooltipBlur}
-                />
+                <Button style={styles.tooltipButton} variant="link">
+                  ?
+                </Button>
               </OverlayTrigger>
               <div>
                 <textarea
@@ -204,14 +184,9 @@ class EditTask extends Component {
                   </Popover>
                 }
               >
-                <i
-                  id="reasons-for-action-tooltip"
-                  aria-label={LOCALIZE.ariaLabel.reasonsForActionTooltip}
-                  className={reasonsForActionTooltipIcon}
-                  style={styles.reasonsForAction.icon}
-                  onFocus={this.onReasonsForActionTooltipFocus}
-                  onBlur={this.onReasonsForActionTooltipBlur}
-                />
+                <Button style={styles.tooltipButton} variant="link">
+                  ?
+                </Button>
               </OverlayTrigger>
               <div>
                 <textarea

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -394,7 +394,10 @@ let LOCALIZE = new LocalizedStrings({
           selectResponseType: "Please select how you would like to respond to the original email:",
           headerFieldPlaceholder: "JohnSmith",
           response: "Your response:",
-          reasonsForAction: "Add reasons for actions here (optional)"
+          reasonsForAction: "Add reasons for actions here (optional)",
+          emailResponseTooltip: "Write a response to the email you recieved.",
+          reasonsForActionTooltip:
+            "Here, you can explain why you took a specific action in response to a situation if you feel you need to provide additional information"
         },
         emailResponse: {
           description: "For this response, you've chosen to:",
@@ -492,6 +495,7 @@ let LOCALIZE = new LocalizedStrings({
       emailOptions: "email options",
       taskOptions: "task options",
       taskTooltip: "task tooltip",
+      emailResponseTooltip: "email response tooltip",
       reasonsForActionTooltip: "reasons for action tooltip",
       passwordCreationRequirements:
         "Password (your password must satisfy the following: At least one upper case, at least one lower case, at least one digit, at least one special character, minimum of 5 characters and maximum of 15)",
@@ -933,7 +937,10 @@ let LOCALIZE = new LocalizedStrings({
             "FR Please select how you would like to respond to the original email:",
           headerFieldPlaceholder: "JohnSmith",
           response: "FR Your response:",
-          reasonsForAction: "FR Add reasons for actions here (optional)"
+          reasonsForAction: "FR Add reasons for actions here (optional)",
+          emailResponseTooltip: "FR Write a response to the email you recieved.",
+          reasonsForActionTooltip:
+            "FR Here, you can explain why you took a specific action in response to a situation if you feel you need to provide additional information"
         },
         emailResponse: {
           description: "FR For this response, you've chosen to:",

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -1039,6 +1039,7 @@ let LOCALIZE = new LocalizedStrings({
       emailOptions: "options de messagerie",
       taskOptions: "options de tâche",
       taskTooltip: "infobulle de tâche",
+      emailResponseTooltip: "FR email response tooltip",
       reasonsForActionTooltip: "infobulle des motifs de l'action",
       passwordCreationRequirements:
         "FR Password (your password must satisfy the following: At least one upper case, at least one lower case, at least one digit, at least one special character, minimum of 5 characters and maximum of 15)",


### PR DESCRIPTION
# Description

Add tooltips to the add email and add task dialogs. (We had something similar before, but I broke them with the icon change.)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Screenshot

<img width="468" alt="Screen Shot 2019-06-05 at 6 33 58 PM" src="https://user-images.githubusercontent.com/4640747/58995027-8b2d8e80-87c0-11e9-88ce-4a276e96b850.png">
<img width="616" alt="Screen Shot 2019-06-05 at 6 34 04 PM" src="https://user-images.githubusercontent.com/4640747/58995028-8b2d8e80-87c0-11e9-88e1-ff859d038a25.png">

# Testing

Manual steps to reproduce this functionality:

1.  Go to the inbox.
2.  Add an email and add a task. Click on the "?" to see tooltips.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [ ] My changes look good on IE 11+ and Chrome
