### PR TITLE
[Accessibility] Use CSS instead of extra elements to space components

### DIFF
--- a/frontend/src/components/commons/PopupBox.jsx
+++ b/frontend/src/components/commons/PopupBox.jsx
@@ -33,7 +33,7 @@ const customStyles = {
 const styles = {
   contentPadding: {
     padding: "10px 15px",
-    overflow: "scroll",
+    overflow: "auto",
     maxHeight: "calc(100vh - 300px)"
   },
   headerPadding: {

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -45,13 +45,15 @@ const styles = {
     radioTextUnselected: {
       fontWeight: "normal",
       cursor: "pointer",
-      paddingRight: 20
+      paddingRight: 20,
+      color: "#00565E"
     },
     radioTextSelected: {
       fontWeight: "bold",
       textDecoration: "underline",
       cursor: "pointer",
-      paddingRight: 20
+      paddingRight: 20,
+      color: "#00565E"
     },
     fieldsetLegend: {
       fontSize: 16,
@@ -177,93 +179,87 @@ class EditEmail extends Component {
                 {LOCALIZE.emibTest.inboxPage.addEmailResponse.selectResponseType}
               </legend>
               <div style={styles.header.radioButtonZone} className="radio-button-hover">
-                <span style={styles.header.responseTypeRadio}>
-                  <input
-                    id="reply-radio"
-                    type="radio"
-                    name="responseTypeRadio"
-                    style={styles.header.radioPadding}
-                    onChange={this.onEmailTypeChange}
-                    value={EMAIL_TYPE.reply}
-                    checked={replyChecked}
-                    className="visually-hidden"
+                <input
+                  id="reply-radio"
+                  type="radio"
+                  name="responseTypeRadio"
+                  style={{ ...styles.header.radioPadding, ...styles.header.responseTypeRadio }}
+                  onChange={this.onEmailTypeChange}
+                  value={EMAIL_TYPE.reply}
+                  checked={replyChecked}
+                  className="visually-hidden"
+                />
+                <label
+                  htmlFor="reply-radio"
+                  style={
+                    replyChecked
+                      ? styles.header.radioTextSelected
+                      : styles.header.radioTextUnselected
+                  }
+                >
+                  <FontAwesomeIcon
+                    icon={faReply}
+                    style={{
+                      ...styles.header.responseTypeIcons,
+                      ...(replyChecked ? styles.header.responseTypeIconsSelected : {})
+                    }}
                   />
-                  <label
-                    htmlFor="reply-radio"
-                    style={
-                      replyChecked
-                        ? styles.header.radioTextSelected
-                        : styles.header.radioTextUnselected
-                    }
-                  >
-                    <FontAwesomeIcon
-                      icon={faReply}
-                      style={{
-                        ...styles.header.responseTypeIcons,
-                        ...(replyChecked ? styles.header.responseTypeIconsSelected : {})
-                      }}
-                    />
-                    {LOCALIZE.emibTest.inboxPage.emailCommons.reply}
-                  </label>
-                </span>
-                <span style={styles.header.responseTypeRadio}>
-                  <input
-                    id="reply-all-radio"
-                    type="radio"
-                    name="responseTypeRadio"
-                    style={styles.header.radioPadding}
-                    onChange={this.onEmailTypeChange}
-                    value={EMAIL_TYPE.replyAll}
-                    checked={replyAllChecked}
-                    className="visually-hidden"
+                  {LOCALIZE.emibTest.inboxPage.emailCommons.reply}
+                </label>
+                <input
+                  id="reply-all-radio"
+                  type="radio"
+                  name="responseTypeRadio"
+                  style={{ ...styles.header.radioPadding, ...styles.header.responseTypeRadio }}
+                  onChange={this.onEmailTypeChange}
+                  value={EMAIL_TYPE.replyAll}
+                  checked={replyAllChecked}
+                  className="visually-hidden"
+                />
+                <label
+                  htmlFor="reply-all-radio"
+                  style={
+                    replyAllChecked
+                      ? styles.header.radioTextSelected
+                      : styles.header.radioTextUnselected
+                  }
+                >
+                  <FontAwesomeIcon
+                    icon={faReplyAll}
+                    style={{
+                      ...styles.header.responseTypeIcons,
+                      ...(replyAllChecked ? styles.header.responseTypeIconsSelected : {})
+                    }}
                   />
-                  <label
-                    htmlFor="reply-all-radio"
-                    style={
-                      replyAllChecked
-                        ? styles.header.radioTextSelected
-                        : styles.header.radioTextUnselected
-                    }
-                  >
-                    <FontAwesomeIcon
-                      icon={faReplyAll}
-                      style={{
-                        ...styles.header.responseTypeIcons,
-                        ...(replyAllChecked ? styles.header.responseTypeIconsSelected : {})
-                      }}
-                    />
-                    {LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
-                  </label>
-                </span>
-                <span style={styles.header.responseTypeRadio}>
-                  <input
-                    id="forward-radio"
-                    type="radio"
-                    name="responseTypeRadio"
-                    style={styles.header.radioPadding}
-                    onChange={this.onEmailTypeChange}
-                    value={EMAIL_TYPE.forward}
-                    checked={forwardChecked}
-                    className="visually-hidden"
+                  {LOCALIZE.emibTest.inboxPage.emailCommons.replyAll}
+                </label>
+                <input
+                  id="forward-radio"
+                  type="radio"
+                  name="responseTypeRadio"
+                  style={{ ...styles.header.radioPadding, ...styles.header.responseTypeRadio }}
+                  onChange={this.onEmailTypeChange}
+                  value={EMAIL_TYPE.forward}
+                  checked={forwardChecked}
+                  className="visually-hidden"
+                />
+                <label
+                  htmlFor="forward-radio"
+                  style={
+                    forwardChecked
+                      ? styles.header.radioTextSelected
+                      : styles.header.radioTextUnselected
+                  }
+                >
+                  <FontAwesomeIcon
+                    icon={faShareSquare}
+                    style={{
+                      ...styles.header.responseTypeIcons,
+                      ...(forwardChecked ? styles.header.responseTypeIconsSelected : {})
+                    }}
                   />
-                  <label
-                    htmlFor="forward-radio"
-                    style={
-                      forwardChecked
-                        ? styles.header.radioTextSelected
-                        : styles.header.radioTextUnselected
-                    }
-                  >
-                    <FontAwesomeIcon
-                      icon={faShareSquare}
-                      style={{
-                        ...styles.header.responseTypeIcons,
-                        ...(forwardChecked ? styles.header.responseTypeIconsSelected : {})
-                      }}
-                    />
-                    {LOCALIZE.emibTest.inboxPage.emailCommons.forward}
-                  </label>
-                </span>
+                  {LOCALIZE.emibTest.inboxPage.emailCommons.forward}
+                </label>
               </div>
             </fieldset>
           </div>

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -39,6 +39,12 @@ const styles = {
     width: "100%",
     borderTop: "1px solid #00565E",
     margin: "16px 0 12px 0"
+  },
+  actionIcon: {
+    marginRight: 5
+  },
+  addEmailButton: {
+    marginRight: 20
   }
 };
 
@@ -109,20 +115,18 @@ class Email extends Component {
               type="button"
               className="btn btn-primary"
               onClick={this.showAddEmailDialog}
+              style={styles.addEmailButton}
             >
-              <FontAwesomeIcon icon={faEnvelope} />
-              &emsp;
+              <FontAwesomeIcon icon={faEnvelope} style={styles.actionIcon} />
               {LOCALIZE.emibTest.inboxPage.addReply}
             </button>
-            &emsp;
             <button
               id="unit-test-email-task-button"
               type="button"
               className="btn btn-primary"
               onClick={this.showAddTaskDialog}
             >
-              <FontAwesomeIcon icon={faTasks} />
-              &emsp;
+              <FontAwesomeIcon icon={faTasks} style={styles.actionIcon} />
               {LOCALIZE.emibTest.inboxPage.addTask}
             </button>
           </div>


### PR DESCRIPTION
# Description

When HTML elements are used for layout or formatting, the screen reader picks up on them in unexpected ways. This PR removes extra elements and uses CSS to handle styling and spacing.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

![image](https://user-images.githubusercontent.com/4640747/59047322-a5fc1380-8851-11e9-85d1-0243546a491a.png)
![image](https://user-images.githubusercontent.com/4640747/59047353-af857b80-8851-11e9-84c2-9fbd31b1dc24.png)


# Testing

Manual steps to reproduce this functionality:

1.  Go the the inbox with a screen reader.
2.  Add an email and select the radio buttons.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
