### PR TITLE
Make collapsing component accessible

### DIFF
--- a/frontend/src/components/eMIB/CollapsingItemContainer.jsx
+++ b/frontend/src/components/eMIB/CollapsingItemContainer.jsx
@@ -70,7 +70,12 @@ class CollapsingItemContainer extends Component {
 
     return (
       <div className={`${containerClass} collapsing-item-container`} style={styles.container}>
-        <button className={buttonClass} style={styles.button} onClick={this.expandItem}>
+        <button
+          className={buttonClass}
+          style={styles.button}
+          onClick={this.expandItem}
+          aria-expanded={!this.state.isCollapsed}
+        >
           <FontAwesomeIcon icon={iconType} style={styles.emailAndTaskIcon} />
           <span style={styles.title}>{title}</span>
         </button>
@@ -78,6 +83,8 @@ class CollapsingItemContainer extends Component {
           id="white-expand-icon-on-hover"
           icon={iconClass}
           style={styles.expandIcon}
+          aria-hidden="true"
+          focusable="false"
         />
         {!isCollapsed && <div style={styles.contentContainer}>{body}</div>}
       </div>


### PR DESCRIPTION
# Description

Make collapsing component accessible. 
Guide I used: https://inclusive-components.design/collapsible-sections/ 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Testing

Manual steps to reproduce this functionality:

1.  Go to the inbox with a screen reader.
2.  Click add a task and navigate to the original email expanding section.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
