### PR TITLE
[Bug Fix] Fixing password is too similar to username bug

### DIFF
--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -140,7 +140,8 @@ class RegistrationForm extends Component {
 
     // API Errors Handler States
     accountExistsError: false,
-    passwordTooCommonError: false
+    passwordTooCommonError: false,
+    passwordTooSimilarToUsernameError: false
   };
 
   getFirstNameContent = event => {
@@ -306,12 +307,23 @@ class RegistrationForm extends Component {
     }
   };
 
-  handlePasswordTooCommonError = response => {
-    if (response.password[0] === "This password is too common.") {
+  handlePasswordErrors = response => {
+    const passwordTooCommonIndex = response.password.indexOf("This password is too common.");
+    const passwordTooSimilarToUsernameIndex = response.password.indexOf(
+      "The password is too similar to the username."
+    );
+
+    // password too common error
+    if (passwordTooCommonIndex >= 0) {
       this.setState({ passwordTooCommonError: true });
-      // focus on password field
-      document.getElementById("password-field").focus();
     }
+
+    // password too similar to username error
+    if (passwordTooSimilarToUsernameIndex >= 0) {
+      this.setState({ passwordTooSimilarToUsernameError: true });
+    }
+    // focus on password field
+    document.getElementById("password-field").focus();
   };
 
   validateForm = () => {
@@ -342,6 +354,7 @@ class RegistrationForm extends Component {
       isFirstPasswordLoad: false,
       accountExistsError: false,
       passwordTooCommonError: false,
+      passwordTooSimilarToUsernameError: false,
       isValidFirstName: isValidFirstName,
       isValidLastName: isValidLastName,
       isValidDobDay: isValidDobDay,
@@ -442,7 +455,7 @@ class RegistrationForm extends Component {
           // response gets password error(s)
           if (typeof response.password !== "undefined") {
             // password too common error
-            this.handlePasswordTooCommonError(response);
+            this.handlePasswordErrors(response);
           }
         });
     }
@@ -495,7 +508,8 @@ class RegistrationForm extends Component {
       atLeastOneSpecialChar,
       betweenMinAndMaxChar,
       accountExistsError,
-      passwordTooCommonError
+      passwordTooCommonError,
+      passwordTooSimilarToUsernameError
     } = this.state;
 
     const validFieldClass = "valid-field";
@@ -775,6 +789,11 @@ class RegistrationForm extends Component {
                 {passwordTooCommonError && (
                   <label htmlFor={"password-field"} style={styles.errorMessage}>
                     {LOCALIZE.authentication.createAccount.passwordTooCommonError}
+                  </label>
+                )}
+                {passwordTooSimilarToUsernameError && (
+                  <label htmlFor={"password-field"} style={styles.errorMessage}>
+                    {LOCALIZE.authentication.createAccount.passwordTooSimilarToUsernameError}
                   </label>
                 )}
               </div>

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -81,7 +81,8 @@ let LOCALIZE = new LocalizedStrings({
         },
         button: "Create account",
         accountAlreadyExistsError: "An account is already associated to this email address",
-        passwordTooCommonError: "This password is too common"
+        passwordTooCommonError: "This password is too common",
+        passwordTooSimilarToUsernameError: "The password is too similar to the username"
       }
     },
 
@@ -676,7 +677,8 @@ let LOCALIZE = new LocalizedStrings({
         },
         button: "Créer compte",
         accountAlreadyExistsError: "FR An account is already associated to this email address",
-        passwordTooCommonError: "FR This password is too common"
+        passwordTooCommonError: "FR This password is too common",
+        passwordTooSimilarToUsernameError: "FR The password is too similar to the username"
       }
     },
 


### PR DESCRIPTION
# Description

This PR is introducing a fix for the "password is too similar to username" error.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Code cleanliness or refactor


## Screenshot

**Initial form view:**

![image](https://user-images.githubusercontent.com/23021242/59113956-208d6780-8914-11e9-9f11-c4bff403c6f1.png)

**Trying to create a new account with a password similar to the username (username: password.normand@email.ca, password: Password1!):**

![image](https://user-images.githubusercontent.com/23021242/59114052-529ec980-8914-11e9-8ee3-a151b8d2d3c9.png)

# Testing

Manual steps to reproduce this functionality:

1.  Open the registration form.
2.  Try to create a new account with a password similar to the username and make sure that you get the right error(s).

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
