### PR TITLE
[Inbox] Character limit should be accessible

### DIFF
--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -339,7 +339,10 @@ class EditEmail extends Component {
               </div>
               {this.state.emailBody.length >= MAX_RESPONSE && (
                 <p class="visually-hidden" aria-live="assertive" role="alert">
-                  {LOCALIZE.formatString(LOCALIZE.inboxPage.characterLimitReached, MAX_RESPONSE)}
+                  {LOCALIZE.formatString(
+                    LOCALIZE.emibTest.inboxPage.characterLimitReached,
+                    MAX_RESPONSE
+                  )}
                 </p>
               )}
               <div style={styles.textCounter}>
@@ -387,7 +390,10 @@ class EditEmail extends Component {
               </div>
               {this.state.reasonsForAction.length >= MAX_REASON && (
                 <p class="visually-hidden" aria-live="assertive" role="alert">
-                  {LOCALIZE.formatString(LOCALIZE.inboxPage.characterLimitReached, MAX_REASON)}
+                  {LOCALIZE.formatString(
+                    LOCALIZE.emibTest.inboxPage.characterLimitReached,
+                    MAX_REASON
+                  )}
                 </p>
               )}
               <div style={styles.textCounter}>

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -98,6 +98,10 @@ const styles = {
       height: 150,
       resize: "none"
     }
+  },
+  tooltipButton: {
+    float: "right",
+    textDecoration: "underline"
   }
 };
 
@@ -300,7 +304,10 @@ class EditEmail extends Component {
           <div>
             <div className="font-weight-bold form-group">
               <label htmlFor="your-response-text-area">
-                {LOCALIZE.emibTest.inboxPage.addEmailResponse.response}
+                {LOCALIZE.formatString(
+                  LOCALIZE.emibTest.inboxPage.addEmailResponse.response,
+                  MAX_RESPONSE
+                )}
               </label>
               <OverlayTrigger
                 trigger="focus"
@@ -340,7 +347,10 @@ class EditEmail extends Component {
           <div>
             <div className="font-weight-bold form-group">
               <label htmlFor="reasons-for-action-text-area">
-                {LOCALIZE.emibTest.inboxPage.addEmailResponse.reasonsForAction}
+                {LOCALIZE.formatString(
+                  LOCALIZE.emibTest.inboxPage.addEmailResponse.reasonsForAction,
+                  MAX_REASON
+                )}
               </label>
               <OverlayTrigger
                 trigger="focus"

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -337,6 +337,13 @@ class EditEmail extends Component {
                   onChange={this.onEmailBodyChange}
                 />
               </div>
+              {this.state.emailBody.length >= MAX_RESPONSE && (
+                <p
+                  class="visually-hidden"
+                  aria-live="assertive"
+                  role="alert"
+                >{`Limit reached. You can only use ${MAX_RESPONSE} characters in this field.`}</p>
+              )}
               <div style={styles.textCounter}>
                 {this.state.emailBody === undefined ? 0 : this.state.emailBody.length}/
                 {MAX_RESPONSE}
@@ -380,6 +387,13 @@ class EditEmail extends Component {
                   onChange={this.onReasonsForActionChange}
                 />
               </div>
+              {this.state.reasonsForAction.length >= MAX_REASON && (
+                <p
+                  class="visually-hidden"
+                  aria-live="assertive"
+                  role="alert"
+                >{`Limit reached. You can only use ${MAX_REASON} characters in this field.`}</p>
+              )}
               <div style={styles.textCounter}>
                 {this.state.reasonsForAction === undefined ? 0 : this.state.reasonsForAction.length}
                 /{MAX_REASON}

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -338,11 +338,9 @@ class EditEmail extends Component {
                 />
               </div>
               {this.state.emailBody.length >= MAX_RESPONSE && (
-                <p
-                  class="visually-hidden"
-                  aria-live="assertive"
-                  role="alert"
-                >{`Limit reached. You can only use ${MAX_RESPONSE} characters in this field.`}</p>
+                <p class="visually-hidden" aria-live="assertive" role="alert">
+                  {LOCALIZE.formatString(LOCALIZE.inboxPage.characterLimitReached, MAX_RESPONSE)}
+                </p>
               )}
               <div style={styles.textCounter}>
                 {this.state.emailBody === undefined ? 0 : this.state.emailBody.length}/
@@ -388,11 +386,9 @@ class EditEmail extends Component {
                 />
               </div>
               {this.state.reasonsForAction.length >= MAX_REASON && (
-                <p
-                  class="visually-hidden"
-                  aria-live="assertive"
-                  role="alert"
-                >{`Limit reached. You can only use ${MAX_REASON} characters in this field.`}</p>
+                <p class="visually-hidden" aria-live="assertive" role="alert">
+                  {LOCALIZE.formatString(LOCALIZE.inboxPage.characterLimitReached, MAX_REASON)}
+                </p>
               )}
               <div style={styles.textCounter}>
                 {this.state.reasonsForAction === undefined ? 0 : this.state.reasonsForAction.length}

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -338,7 +338,7 @@ class EditEmail extends Component {
                 />
               </div>
               {this.state.emailBody.length >= MAX_RESPONSE && (
-                <p class="visually-hidden" aria-live="assertive" role="alert">
+                <p className="visually-hidden" aria-live="assertive" role="alert">
                   {LOCALIZE.formatString(
                     LOCALIZE.emibTest.inboxPage.characterLimitReached,
                     MAX_RESPONSE
@@ -389,7 +389,7 @@ class EditEmail extends Component {
                 />
               </div>
               {this.state.reasonsForAction.length >= MAX_REASON && (
-                <p class="visually-hidden" aria-live="assertive" role="alert">
+                <p className="visually-hidden" aria-live="assertive" role="alert">
                   {LOCALIZE.formatString(
                     LOCALIZE.emibTest.inboxPage.characterLimitReached,
                     MAX_REASON

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -139,7 +139,7 @@ class EditTask extends Component {
                 />
               </div>
               {this.state.task.length >= MAX_TASK && (
-                <p class="visually-hidden" aria-live="assertive" role="alert">
+                <p className="visually-hidden" aria-live="assertive" role="alert">
                   {LOCALIZE.formatString(
                     LOCALIZE.emibTest.inboxPage.characterLimitReached,
                     MAX_TASK
@@ -189,7 +189,7 @@ class EditTask extends Component {
                 />
               </div>
               {this.state.reasonsForAction.length >= MAX_REASON && (
-                <p class="visually-hidden" aria-live="assertive" role="alert">
+                <p className="visually-hidden" aria-live="assertive" role="alert">
                   {LOCALIZE.formatString(
                     LOCALIZE.emibTest.inboxPage.characterLimitReached,
                     MAX_REASON

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -143,7 +143,10 @@ class EditTask extends Component {
               </div>
               {this.state.task.length >= MAX_TASK && (
                 <p class="visually-hidden" aria-live="assertive" role="alert">
-                  {LOCALIZE.formatString(LOCALIZE.inboxPage.characterLimitReached, MAX_TASK)}
+                  {LOCALIZE.formatString(
+                    LOCALIZE.emibTest.inboxPage.characterLimitReached,
+                    MAX_TASK
+                  )}
                 </p>
               )}
               <div style={styles.textCounter} id="unit-test-task-response">
@@ -190,7 +193,10 @@ class EditTask extends Component {
               </div>
               {this.state.reasonsForAction.length >= MAX_REASON && (
                 <p class="visually-hidden" aria-live="assertive" role="alert">
-                  {LOCALIZE.formatString(LOCALIZE.inboxPage.characterLimitReached, MAX_REASON)}
+                  {LOCALIZE.formatString(
+                    LOCALIZE.emibTest.inboxPage.characterLimitReached,
+                    MAX_REASON
+                  )}
                 </p>
               )}
               <div style={styles.textCounter} id="unit-test-task-rfa">

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -70,6 +70,10 @@ const styles = {
       height: 100,
       resize: "none"
     }
+  },
+  tooltipButton: {
+    float: "right",
+    textDecoration: "underline"
   }
 };
 
@@ -106,7 +110,7 @@ class EditTask extends Component {
           <div>
             <div className="font-weight-bold form-group">
               <label htmlFor="your-tasks-text-area" style={styles.tasks.title}>
-                {LOCALIZE.emibTest.inboxPage.addEmailTask.task}
+                {LOCALIZE.formatString(LOCALIZE.emibTest.inboxPage.addEmailTask.task, MAX_TASK)}
               </label>
               <OverlayTrigger
                 trigger="focus"
@@ -137,6 +141,13 @@ class EditTask extends Component {
                   onChange={this.onTaskContentChange}
                 />
               </div>
+              {this.state.task.length >= MAX_TASK && (
+                <p
+                  class="visually-hidden"
+                  aria-live="assertive"
+                  role="alert"
+                >{`Limit reached. You can only use ${MAX_TASK} characters in this field.`}</p>
+              )}
               <div style={styles.textCounter} id="unit-test-task-response">
                 {this.state.task === undefined ? 0 : this.state.task.length}/{MAX_TASK}
               </div>
@@ -146,7 +157,10 @@ class EditTask extends Component {
           <div>
             <div className="font-weight-bold form-group">
               <label htmlFor="reasons-for-action-text-area" style={styles.reasonsForAction.title}>
-                {LOCALIZE.emibTest.inboxPage.addEmailTask.reasonsForAction}
+                {LOCALIZE.formatString(
+                  LOCALIZE.emibTest.inboxPage.addEmailTask.reasonsForAction,
+                  MAX_REASON
+                )}
               </label>
               <OverlayTrigger
                 trigger="focus"
@@ -176,6 +190,13 @@ class EditTask extends Component {
                   onChange={this.onReasonsForActionChange}
                 />
               </div>
+              {this.state.reasonsForAction.length >= MAX_REASON && (
+                <p
+                  class="visually-hidden"
+                  aria-live="assertive"
+                  role="alert"
+                >{`Limit reached. You can only use ${MAX_REASON} characters in this field.`}</p>
+              )}
               <div style={styles.textCounter} id="unit-test-task-rfa">
                 {this.state.reasonsForAction === undefined ? 0 : this.state.reasonsForAction.length}
                 /{MAX_REASON}

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -13,9 +13,6 @@ const MAX_TASK = "650";
 const MAX_REASON = "650";
 
 const styles = {
-  tooltipButton: {
-    padding: 0
-  },
   header: {
     color: "#00565E",
     paddingTop: 12

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -142,11 +142,9 @@ class EditTask extends Component {
                 />
               </div>
               {this.state.task.length >= MAX_TASK && (
-                <p
-                  class="visually-hidden"
-                  aria-live="assertive"
-                  role="alert"
-                >{`Limit reached. You can only use ${MAX_TASK} characters in this field.`}</p>
+                <p class="visually-hidden" aria-live="assertive" role="alert">
+                  {LOCALIZE.formatString(LOCALIZE.inboxPage.characterLimitReached, MAX_TASK)}
+                </p>
               )}
               <div style={styles.textCounter} id="unit-test-task-response">
                 {this.state.task === undefined ? 0 : this.state.task.length}/{MAX_TASK}
@@ -191,11 +189,9 @@ class EditTask extends Component {
                 />
               </div>
               {this.state.reasonsForAction.length >= MAX_REASON && (
-                <p
-                  class="visually-hidden"
-                  aria-live="assertive"
-                  role="alert"
-                >{`Limit reached. You can only use ${MAX_REASON} characters in this field.`}</p>
+                <p class="visually-hidden" aria-live="assertive" role="alert">
+                  {LOCALIZE.formatString(LOCALIZE.inboxPage.characterLimitReached, MAX_REASON)}
+                </p>
               )}
               <div style={styles.textCounter} id="unit-test-task-rfa">
                 {this.state.reasonsForAction === undefined ? 0 : this.state.reasonsForAction.length}

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -257,25 +257,6 @@ it("clicking on the button only adds the email once", () => {
 });
 
 describe("edit action dialog helper file", () => {
-  // ============================== VARIABLES ==============================
-  // empty variables
-  const emptyEmailType = "";
-  const emptyEmailTo = "";
-  const emptyEmailCc = "";
-  const emptyEmailResponse = "";
-  const emptyReasonsForActionContent = "";
-  const emptyTaskContent = "";
-
-  // initial variables (for edit only)
-  const initialEmailType = EMAIL_TYPE.replyAll;
-  const initialEmailTo = ["to"];
-  const initialEmailCc = ["cc"];
-  const initialEmailResponse = "response";
-  const initialReasonsForActionContent = "reasons for action";
-  const initialTaskContent = "tasks";
-
-  // current variables
-  let stubbedCurrentVariables;
   beforeEach(() => {
     stubbedCurrentVariables = {
       emailType: EMAIL_TYPE.replyAll,

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -257,6 +257,8 @@ it("clicking on the button only adds the email once", () => {
 });
 
 describe("edit action dialog helper file", () => {
+  let stubbedCurrentVariables;
+
   beforeEach(() => {
     stubbedCurrentVariables = {
       emailType: EMAIL_TYPE.replyAll,

--- a/frontend/src/tests/components/eMIB/EditActionDialog.test.js
+++ b/frontend/src/tests/components/eMIB/EditActionDialog.test.js
@@ -315,7 +315,10 @@ const emptyActionMount = actionType => {
         actionType={actionType}
         editMode={EDIT_MODE.update}
         action={{
-          actionType: actionType
+          actionType: actionType,
+          emailBody: "",
+          task: "",
+          reasonsForAction: ""
         }}
       />
     </Provider>

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -1048,8 +1048,8 @@ let LOCALIZE = new LocalizedStrings({
           selectResponseType:
             "FR Please select how you would like to respond to the original email:",
           headerFieldPlaceholder: "JohnSmith",
-          response: "FR Your response:",
-          reasonsForAction: "FR Add reasons for actions here (optional)",
+          response: "FR Your response: {0} character limit",
+          reasonsForAction: "FR Your reasons for actions (optional): {0} character limit",
           emailResponseTooltip: "FR Write a response to the email you recieved.",
           reasonsForActionTooltip:
             "FR Here, you can explain why you took a specific action in response to a situation if you feel you need to provide additional information"
@@ -1061,8 +1061,8 @@ let LOCALIZE = new LocalizedStrings({
         },
         addEmailTask: {
           header: "FR Email ID #{0}: {1}",
-          task: "FR Your task(s):",
-          reasonsForAction: "FR Add reasons for actions here (optional)"
+          task: "FR Your task(s): {0} character limit",
+          reasonsForAction: "FR Reasons for actions (optional): {0} character limit"
         },
         taskContent: {
           task: "FR Your task(s):",

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -431,6 +431,7 @@ let LOCALIZE = new LocalizedStrings({
           editTask: "Edit task",
           save: "Save response"
         },
+        characterLimitReached: `Limit reached. You can only use {0} characters in this field.`,
         emailCommons: {
           to: "To:",
           cc: "Cc:",
@@ -1033,6 +1034,7 @@ let LOCALIZE = new LocalizedStrings({
           editTask: "FR Edit task",
           save: "FR Save response"
         },
+        characterLimitReached: `FR Limit reached. You can only use {0} characters in this field.`,
         emailCommons: {
           to: "À :",
           cc: "Cc :",

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -445,8 +445,8 @@ let LOCALIZE = new LocalizedStrings({
         addEmailResponse: {
           selectResponseType: "Please select how you would like to respond to the original email:",
           headerFieldPlaceholder: "JohnSmith",
-          response: "Your response:",
-          reasonsForAction: "Add reasons for actions here (optional)",
+          response: "Your response: {0} character limit",
+          reasonsForAction: "Your reasons for actions (optional): {0} character limit",
           emailResponseTooltip: "Write a response to the email you recieved.",
           reasonsForActionTooltip:
             "Here, you can explain why you took a specific action in response to a situation if you feel you need to provide additional information"
@@ -458,8 +458,8 @@ let LOCALIZE = new LocalizedStrings({
         },
         addEmailTask: {
           header: "Email ID #{0}: {1}",
-          task: "Your task(s):",
-          reasonsForAction: "Add reasons for actions here (optional)"
+          task: "Your task(s): {0} character limit",
+          reasonsForAction: "Your reasons for actions (optional): {0} character limit"
         },
         taskContent: {
           task: "Your task(s):",


### PR DESCRIPTION
# Description

Max character count on inputs should be accessible by:
 - providing the limit in the label
 - alerting the screen reader when the limit is reached

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

![image](https://user-images.githubusercontent.com/4640747/59118436-1cfede00-891e-11e9-80d7-53ebdb54f9cf.png)


# Testing

Manual steps to reproduce this functionality:

1.  Go to inbox with a screen reader.
2. Add an email or task and hit the max limit.
3. Listen for alert.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
