### PR TITLE
[Bug Fix] Fixing the 'privacy notice' popup access using the keyboard

### DIFF
--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -86,7 +86,10 @@ const styles = {
   privacyNoticeLink: {
     textDecoration: "underline",
     color: "#0278A4",
-    cursor: "pointer"
+    cursor: "pointer",
+    backgroundColor: "transparent",
+    border: "none",
+    padding: 0
   }
 };
 
@@ -845,13 +848,13 @@ class RegistrationForm extends Component {
                 <div className="privacy-notice-grid-description">
                   <label htmlFor="privacy-notice-checkbox">
                     {LOCALIZE.authentication.createAccount.privacyNotice}
-                    <span
+                    <button
                       tabIndex="0"
                       onClick={this.showPrivacyNoticePopup}
                       style={styles.privacyNoticeLink}
                     >
                       {LOCALIZE.authentication.createAccount.privacyNoticeLink}
-                    </span>
+                    </button>
                     .
                   </label>
                 </div>


### PR DESCRIPTION
# Description

Fixed a small bug related to the _privacy notice_ link that opens a popup box in registration form.
Before, we were not able to open the privacy notice popup with the keyboard, but now we can.

![image](https://user-images.githubusercontent.com/23021242/59269024-073e3100-8c1c-11e9-9750-b73be13def11.png)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

(N/A)

# Testing

Manual steps to reproduce this functionality:

1.  Open the registratinon form.
2.  Navigate using the keyboard and make sure that you can open the privacy notice popup box..

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
