### PR TITLE
[Test API] Adding meta-data-api view

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -4,7 +4,7 @@ from django.urls import path, include
 from django.contrib import admin
 from rest_framework import routers
 from rest_framework_swagger.views import get_swagger_view
-from views import views, database_check_view, test_meta_data_view
+from views import views, database_check_view, test_meta_data_view, test_instructions_view, test_questions_view
 from rest_framework_jwt.views import (
     obtain_jwt_token,
     refresh_jwt_token,
@@ -30,6 +30,10 @@ urlpatterns = [
     url(r"^api/auth/jwt/verify_token/", verify_jwt_token),
     url(r"^api/test-meta-data",
         test_meta_data_view.TestMetaDataSet.as_view()),
+    url(r"^api/test-instructions",
+        test_instructions_view.TestInstructionsSet.as_view()),
+    url(r"^api/test-questions",
+        test_questions_view.TestQuestionsSet.as_view()),
 ]
 
 if settings.DEBUG:

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -4,7 +4,7 @@ from django.urls import path, include
 from django.contrib import admin
 from rest_framework import routers
 from rest_framework_swagger.views import get_swagger_view
-from views import views, database_check_view
+from views import views, database_check_view, test_meta_data_view
 from rest_framework_jwt.views import (
     obtain_jwt_token,
     refresh_jwt_token,
@@ -28,6 +28,8 @@ urlpatterns = [
     url(r"^api/auth/jwt/create_token/", obtain_jwt_token),
     url(r"^api/auth/jwt/refresh_token/", refresh_jwt_token),
     url(r"^api/auth/jwt/verify_token/", verify_jwt_token),
+    url(r"^api/test-meta-data",
+        test_meta_data_view.TestMetaDataSet.as_view()),
 ]
 
 if settings.DEBUG:

--- a/backend/views/test_instructions_view.py
+++ b/backend/views/test_instructions_view.py
@@ -1,0 +1,19 @@
+from rest_framework.views import APIView
+from rest_framework import permissions
+from views.retrieve_test_view import TEST_INSTRUCTIONS, retrieve_test_data, is_test_public
+
+
+class TestInstructionsSet(APIView):
+    def get(self, request):
+        return retrieve_test_data(request, TEST_INSTRUCTIONS)
+
+    # assign the permissions depending on if the test is public or not
+    def get_permissions(self):
+        # is_public = true
+        if is_test_public(self.request.query_params.get("test_name", None)):
+            return [permissions.IsAuthenticatedOrReadOnly()]
+        # is_public = false
+        else:
+            return [permissions.IsAdminUser()]
+
+# http://localhost/api/test-instructions/?test_name=emibSampleTest

--- a/backend/views/test_meta_data_view.py
+++ b/backend/views/test_meta_data_view.py
@@ -1,0 +1,22 @@
+from rest_framework.views import APIView
+from rest_framework import permissions
+from views.retrieve_test_view import TEST_META_DATA, retrieve_test_data, is_test_public
+
+
+class TestMetaDataSet(APIView):
+    def get(self, request):
+        return retrieve_test_data(request, TEST_META_DATA)
+
+    # assign the permissions depending on if the test is public or not
+    def get_permissions(self):
+        # is_public = true
+        if is_test_public(self.request.query_params.get("test_name", None)):
+            return [permissions.IsAuthenticatedOrReadOnly()]
+        # is_public = false
+        else:
+            return [permissions.IsAdminUser()]
+
+
+# Tests List:
+# eMIB Sample Test: http://localhost/api/test-meta-data/?test_name=emibSampleTest
+# eMIB Pizza Test: http://http://localhost/api/test-meta-data/?test_name=emibPizzaTest

--- a/backend/views/test_questions_view.py
+++ b/backend/views/test_questions_view.py
@@ -1,0 +1,19 @@
+from rest_framework.views import APIView
+from rest_framework import permissions
+from views.retrieve_test_view import TEST_QUESTIONS, retrieve_test_data, is_test_public
+
+
+class TestQuestionsSet(APIView):
+    def get(self, request):
+        return retrieve_test_data(request, TEST_QUESTIONS)
+
+    # assign the permissions depending on if the test is public or not
+    def get_permissions(self):
+        # is_public = true
+        if is_test_public(self.request.query_params.get("test_name", None)):
+            return [permissions.IsAuthenticatedOrReadOnly()]
+        # is_public = false
+        else:
+            return [permissions.IsAdminUser()]
+
+# http://localhost/api/test-questions/?test_name=emibSampleTest


### PR DESCRIPTION
# Description

Adding view and url registration of test-meta-data API

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

Accessing `http://localhost/api/test-meta-data/?test_name=emibSampleTest` when logged in
![image](https://user-images.githubusercontent.com/2746350/59277283-eda5e500-8c2d-11e9-89c5-90df82ff5383.png)

Accessing `http://localhost/api/test-meta-data/?test_name=emibPizzaTest` when logged in as admin
![image](https://user-images.githubusercontent.com/2746350/59277256-dbc44200-8c2d-11e9-8205-730e8cb4e19b.png)

Accessing `http://localhost/api/test-meta-data/?test_name=emibPizzaTest` when not logged in
![image](https://user-images.githubusercontent.com/2746350/59277217-ca7b3580-8c2d-11e9-8015-491feef878f2.png)



# Testing

See screenshots

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
~~- [ ] My changes generate no new accessibility errors and/or warnings~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
~~- [ ] My changes look good on IE 11+ and Chrome~~
