### PR TITLE
[Travis Configs] Creating Django superuser via commands for Travis tests (for future API tests)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
       before_script:
         - docker-compose up -d --build
         - npm install frontend/
+        - docker exec -it project-thundercat_backend_1 shell -c "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(username='admin', first_name='Admin', last_name='Account', birth_date='01/01/---1', pri_or_military_nbr='', email='admin@email.ca', password='Admin1234!');"
       script:
         - newman run backend/tests/postman/ThunderCAT.postman_collection.json -e backend/tests/postman/environments/local/ThunderCAT.local.postman_environment.json
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ matrix:
         - npm install newman
       before_script:
         - docker-compose up -d --build
-        - docker ps
         - npm install frontend/
         # creating a superuser
         - docker exec -it projectthundercat_backend_1 python manage.py shell -c "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(username='admin', first_name='Admin', last_name='Account', birth_date='01/01/---1', pri_or_military_nbr='', email='admin@email.ca', password='Admin1234!');"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
         - docker-compose up -d --build
         - docker ps
         - npm install frontend/
-        - docker exec -it project-thundercat_backend python manage.py shell -c "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(username='admin', first_name='Admin', last_name='Account', birth_date='01/01/---1', pri_or_military_nbr='', email='admin@email.ca', password='Admin1234!');"
+        - docker exec -it projectthundercat_backend python manage.py shell -c "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(username='admin', first_name='Admin', last_name='Account', birth_date='01/01/---1', pri_or_military_nbr='', email='admin@email.ca', password='Admin1234!');"
       script:
         - newman run backend/tests/postman/ThunderCAT.postman_collection.json -e backend/tests/postman/environments/local/ThunderCAT.local.postman_environment.json
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,9 @@ matrix:
         - npm install newman
       before_script:
         - docker-compose up -d --build
+        - docker ps
         - npm install frontend/
-        - docker exec -it project-thundercat_backend_1 shell -c "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(username='admin', first_name='Admin', last_name='Account', birth_date='01/01/---1', pri_or_military_nbr='', email='admin@email.ca', password='Admin1234!');"
+        - docker exec -it project-thundercat_backend python manage.py shell -c "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(username='admin', first_name='Admin', last_name='Account', birth_date='01/01/---1', pri_or_military_nbr='', email='admin@email.ca', password='Admin1234!');"
       script:
         - newman run backend/tests/postman/ThunderCAT.postman_collection.json -e backend/tests/postman/environments/local/ThunderCAT.local.postman_environment.json
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
         - docker-compose up -d --build
         - docker ps
         - npm install frontend/
-        - docker exec -it projectthundercat_backend python manage.py shell -c "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(username='admin', first_name='Admin', last_name='Account', birth_date='01/01/---1', pri_or_military_nbr='', email='admin@email.ca', password='Admin1234!');"
+        - docker exec -it projectthundercat_backend_1 python manage.py shell -c "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(username='admin', first_name='Admin', last_name='Account', birth_date='01/01/---1', pri_or_military_nbr='', email='admin@email.ca', password='Admin1234!');"
       script:
         - newman run backend/tests/postman/ThunderCAT.postman_collection.json -e backend/tests/postman/environments/local/ThunderCAT.local.postman_environment.json
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
         - docker-compose up -d --build
         - docker ps
         - npm install frontend/
+        # creating a superuser
         - docker exec -it projectthundercat_backend_1 python manage.py shell -c "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(username='admin', first_name='Admin', last_name='Account', birth_date='01/01/---1', pri_or_military_nbr='', email='admin@email.ca', password='Admin1234!');"
       script:
         - newman run backend/tests/postman/ThunderCAT.postman_collection.json -e backend/tests/postman/environments/local/ThunderCAT.local.postman_environment.json

--- a/backend/tests/postman/ThunderCAT.postman_collection.json
+++ b/backend/tests/postman/ThunderCAT.postman_collection.json
@@ -268,9 +268,9 @@
 					"script": {
 						"id": "9b149cd8-ca54-4559-a5cb-86798cd9077f",
 						"exec": [
-							"// request fails (expected status code: 403)\r",
-							"pm.test(\"Request fails, since default users shouldn't be able to access the users list\", function () {\r",
-							"    pm.response.to.have.status(403);\r",
+							"// successful request\r",
+							"pm.test(\"Successful request\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
 							"});"
 						],
 						"type": "text/javascript"
@@ -295,7 +295,8 @@
 				"header": [
 					{
 						"key": "Authorization",
-						"value": "basic YXBpLXRlc3QxOlF3ZXJ0eTEyMzQh",
+						"value": "basic YWRtaW46QWRtaW4xMjM0IQ==",
+						"description": "superuser credentials",
 						"type": "text"
 					},
 					{
@@ -636,16 +637,11 @@
 					"script": {
 						"id": "aef27e12-f010-43f8-958f-d8d3a0e71397",
 						"exec": [
-							"// TODO: find a way to create a superuser in travis config file and use this superuser to delete an account\r",
-							"/* making sure that the api-test2 account has been deleted (expects status code: 204)\r",
+							"// making sure that the api-test2 account has been deleted (expects status code: 204)\r",
 							"pm.test(\"api-test2 account has been deleted successfully\", function () {\r",
 							"    pm.response.to.have.status(204);\r",
-							"});*/\r",
-							"\r",
-							"// request fails (expected status code: 403)\r",
-							"pm.test(\"Request fails (delete api-test2 account), since a default user shouldn't be able to delete other accounts\", function () {\r",
-							"    pm.response.to.have.status(403);\r",
-							"});"
+							"});\r",
+							""
 						],
 						"type": "text/javascript"
 					}
@@ -659,7 +655,8 @@
 				"header": [
 					{
 						"key": "Authorization",
-						"value": "basic YXBpLXRlc3QxQGVtYWlsLmNhOlF3ZXJ0eTEyMzQh",
+						"value": "basic YWRtaW46QWRtaW4xMjM0IQ==",
+						"description": "superuser credentials",
 						"type": "text"
 					}
 				],

--- a/backend/tests/postman/ThunderCAT.postman_collection.json
+++ b/backend/tests/postman/ThunderCAT.postman_collection.json
@@ -658,8 +658,18 @@
 						"value": "basic YWRtaW46QWRtaW4xMjM0IQ==",
 						"description": "superuser credentials",
 						"type": "text"
+					},
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
 					}
 				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"first_name\": \"Delete\",\r\n  \"last_name\": \"Delete\",\r\n  \"birth_date\": \"1/2/---3\",\r\n  \"email\": \"Delete@email.ca\",\r\n  \"pri_or_military_nbr\": \"Delete\",\r\n  \"username\": \"Delete\",\r\n  \"password\": \"Delete\"\r\n}"
+				},
 				"url": {
 					"raw": "{{THUNDERCAT_URL}}/api/auth/users/1/",
 					"host": [


### PR DESCRIPTION
# Description

This PR is introducing new travis configurations. These new settings are creating a superuser using command line, so we we are now able test APIs that need admin rights. I also updated the postman tests that needed these rights to succeed.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

(N/A)

# Testing

- It's not really testable. You can take a look at the travis console log to see how it works.

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [ ] ~~My changes look good on IE 11+ and Chrome~~
