### PR TITLE
[Postman Tests] Adding postman tests for new content APIs

### DIFF
--- a/backend/tests/postman/ThunderCAT.postman_collection.json
+++ b/backend/tests/postman/ThunderCAT.postman_collection.json
@@ -685,6 +685,260 @@
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "get sample test meta data (public test) - /api/test-meta-data/?test_name=emibSampleTest",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "5d85a30b-ed4a-4972-93ce-63c0b960c9f0",
+						"exec": [
+							"// successful request\r",
+							"pm.test(\"Successful request\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"// getting test internal name\r",
+							"pm.test(\"Getting test internal name\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"test_internal_name\":\"emibSampleTest\"');\r",
+							"});\r",
+							"\r",
+							"// getting test english name\r",
+							"pm.test(\"Getting test english name\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"test_en_name\":\"eMiB Sample Test\"');\r",
+							"});\r",
+							"\r",
+							"// getting test french name\r",
+							"pm.test(\"Getting test french name\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"test_fr_name\":\"FR eMiB Sample Test\"');\r",
+							"});\r",
+							"\r",
+							"// getting is_public flag (expected: true)\r",
+							"pm.test(\"Getting is_public flag\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"is_public\":true');\r",
+							"});\r",
+							"\r",
+							"// getting default_time  (expected: null)\r",
+							"pm.test(\"Getting default_time\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"default_time\":null');\r",
+							"});\r",
+							"\r",
+							"// getting test type\r",
+							"pm.test(\"Getting test type\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"test_type\":\"emib\"');\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{THUNDERCAT_URL}}/api/test-meta-data/?test_name=emibSampleTest",
+					"host": [
+						"{{THUNDERCAT_URL}}"
+					],
+					"path": [
+						"api",
+						"test-meta-data",
+						""
+					],
+					"query": [
+						{
+							"key": "test_name",
+							"value": "emibSampleTest"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "get pizza test meta data (non-public test + unauthenticated) - /api/test-meta-data/?test_name=emibPizzaTest",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "5d85a30b-ed4a-4972-93ce-63c0b960c9f0",
+						"exec": [
+							"// fail request (expected: status 403)\r",
+							"pm.test(\"Fail request\", function () {\r",
+							"    pm.response.to.have.status(403);\r",
+							"});\r",
+							"\r",
+							"// getting authentication message\r",
+							"pm.test(\"Getting 'Authentication credentials were not provided' message\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"detail\":\"Authentication credentials were not provided.\"');\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{THUNDERCAT_URL}}/api/test-meta-data/?test_name=emibPizzaTest",
+					"host": [
+						"{{THUNDERCAT_URL}}"
+					],
+					"path": [
+						"api",
+						"test-meta-data",
+						""
+					],
+					"query": [
+						{
+							"key": "test_name",
+							"value": "emibPizzaTest"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "get pizza test meta data (non-public test + authenticated with default user) - /api/test-meta-data/?test_name=emibPizzaTest",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "5d85a30b-ed4a-4972-93ce-63c0b960c9f0",
+						"exec": [
+							"// fail request (expected: status 403)\r",
+							"pm.test(\"Fail reques\", function () {\r",
+							"    pm.response.to.have.status(403);\r",
+							"});\r",
+							"\r",
+							"// getting missing permission message\r",
+							"pm.test(\"Getting 'You do not have permission to perform this action' message\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"detail\":\"You do not have permission to perform this action.\"');\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "basic YXBpLXRlc3QxQGVtYWlsLmNhOlF3ZXJ0eTEyMzQh",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{THUNDERCAT_URL}}/api/test-meta-data/?test_name=emibPizzaTest",
+					"host": [
+						"{{THUNDERCAT_URL}}"
+					],
+					"path": [
+						"api",
+						"test-meta-data",
+						""
+					],
+					"query": [
+						{
+							"key": "test_name",
+							"value": "emibPizzaTest"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "get pizza test meta data (non-public test + authenticated with admin user) - /api/test-meta-data/?test_name=emibPizzaTest",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "5d85a30b-ed4a-4972-93ce-63c0b960c9f0",
+						"exec": [
+							"// successful request\r",
+							"pm.test(\"Successful request\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"// getting test internal name\r",
+							"pm.test(\"Getting test internal name\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"test_internal_name\":\"emibPizzaTest\"');\r",
+							"});\r",
+							"\r",
+							"// getting test english name\r",
+							"pm.test(\"Getting test english name\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"test_en_name\":\"Pizza Test\"');\r",
+							"});\r",
+							"\r",
+							"// getting test french name\r",
+							"pm.test(\"Getting test french name\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"test_fr_name\":\"FR Pizza Test\"');\r",
+							"});\r",
+							"\r",
+							"// getting is_public flag (expected: false)\r",
+							"pm.test(\"Getting is_public flag\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"is_public\":false');\r",
+							"});\r",
+							"\r",
+							"// getting default_time  (expected: null)\r",
+							"pm.test(\"Getting default_time\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"default_time\":null');\r",
+							"});\r",
+							"\r",
+							"// getting test type\r",
+							"pm.test(\"Getting test type\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"test_type\":\"emib\"');\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"type": "text",
+						"value": "basic YWRtaW46QWRtaW4xMjM0IQ=="
+					}
+				],
+				"url": {
+					"raw": "{{THUNDERCAT_URL}}/api/test-meta-data/?test_name=emibPizzaTest",
+					"host": [
+						"{{THUNDERCAT_URL}}"
+					],
+					"path": [
+						"api",
+						"test-meta-data",
+						""
+					],
+					"query": [
+						{
+							"key": "test_name",
+							"value": "emibPizzaTest"
+						}
+					]
+				}
+			},
+			"response": []
 		}
 	]
 }

--- a/backend/tests/postman/ThunderCAT.postman_collection.json
+++ b/backend/tests/postman/ThunderCAT.postman_collection.json
@@ -838,6 +838,7 @@
 					{
 						"key": "Authorization",
 						"value": "basic YXBpLXRlc3QxQGVtYWlsLmNhOlF3ZXJ0eTEyMzQh",
+						"description": "api-test1 credentials",
 						"type": "text"
 					}
 				],
@@ -929,6 +930,212 @@
 					"path": [
 						"api",
 						"test-meta-data",
+						""
+					],
+					"query": [
+						{
+							"key": "test_name",
+							"value": "emibPizzaTest"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "get sample instructions data (public test) - /api/test-instructions/?test_name=emibSampleTest",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "5d85a30b-ed4a-4972-93ce-63c0b960c9f0",
+						"exec": [
+							"// successful request\r",
+							"pm.test(\"Successful request\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"// getting test internal name\r",
+							"pm.test(\"Getting test internal name\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"test_internal_name\":\"emibSampleTest\"');\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{THUNDERCAT_URL}}/api/test-instructions/?test_name=emibSampleTest",
+					"host": [
+						"{{THUNDERCAT_URL}}"
+					],
+					"path": [
+						"api",
+						"test-instructions",
+						""
+					],
+					"query": [
+						{
+							"key": "test_name",
+							"value": "emibSampleTest"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "get pizza test instructions data (non-public test + unauthenticated) - /api/test-instructions/?test_name=emibPizzaTest",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "5d85a30b-ed4a-4972-93ce-63c0b960c9f0",
+						"exec": [
+							"// fail request (expected: status 403)\r",
+							"pm.test(\"Fail request\", function () {\r",
+							"    pm.response.to.have.status(403);\r",
+							"});\r",
+							"\r",
+							"// getting authentication message\r",
+							"pm.test(\"Getting 'Authentication credentials were not provided' message\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"detail\":\"Authentication credentials were not provided.\"');\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{THUNDERCAT_URL}}/api/test-instructions/?test_name=emibPizzaTest",
+					"host": [
+						"{{THUNDERCAT_URL}}"
+					],
+					"path": [
+						"api",
+						"test-instructions",
+						""
+					],
+					"query": [
+						{
+							"key": "test_name",
+							"value": "emibPizzaTest"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "get pizza test instructions data (non-public test + authenticated with default user) - /api/test-instructions/?test_name=emibPizzaTest Copy",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "5d85a30b-ed4a-4972-93ce-63c0b960c9f0",
+						"exec": [
+							"// fail request (expected: status 403)\r",
+							"pm.test(\"Fail reques\", function () {\r",
+							"    pm.response.to.have.status(403);\r",
+							"});\r",
+							"\r",
+							"// getting missing permission message\r",
+							"pm.test(\"Getting 'You do not have permission to perform this action' message\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"detail\":\"You do not have permission to perform this action.\"');\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "basic YXBpLXRlc3QxQGVtYWlsLmNhOlF3ZXJ0eTEyMzQh",
+						"description": "api-test1 credentials",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{THUNDERCAT_URL}}/api/test-instructions/?test_name=emibPizzaTest",
+					"host": [
+						"{{THUNDERCAT_URL}}"
+					],
+					"path": [
+						"api",
+						"test-instructions",
+						""
+					],
+					"query": [
+						{
+							"key": "test_name",
+							"value": "emibPizzaTest"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "get pizza test instructions data (non-public test + authenticated with admin user) - /api/test-instructions/?test_name=emibPizzaTest Copy Copy",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "5d85a30b-ed4a-4972-93ce-63c0b960c9f0",
+						"exec": [
+							"// successful request\r",
+							"pm.test(\"Successful request\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"// getting test internal name\r",
+							"pm.test(\"Getting test internal name\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"test_internal_name\":\"emibPizzaTest\"');\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [
+					{
+						"description": "superuser credentials",
+						"key": "Authorization",
+						"type": "text",
+						"value": "basic YWRtaW46QWRtaW4xMjM0IQ=="
+					}
+				],
+				"url": {
+					"raw": "{{THUNDERCAT_URL}}/api/test-instructions/?test_name=emibPizzaTest",
+					"host": [
+						"{{THUNDERCAT_URL}}"
+					],
+					"path": [
+						"api",
+						"test-instructions",
 						""
 					],
 					"query": [

--- a/backend/tests/postman/ThunderCAT.postman_collection.json
+++ b/backend/tests/postman/ThunderCAT.postman_collection.json
@@ -671,7 +671,7 @@
 					"raw": "{\r\n  \"first_name\": \"Delete\",\r\n  \"last_name\": \"Delete\",\r\n  \"birth_date\": \"1/2/---3\",\r\n  \"email\": \"Delete@email.ca\",\r\n  \"pri_or_military_nbr\": \"Delete\",\r\n  \"username\": \"Delete\",\r\n  \"password\": \"Delete\"\r\n}"
 				},
 				"url": {
-					"raw": "{{THUNDERCAT_URL}}/api/auth/users/1/",
+					"raw": "{{THUNDERCAT_URL}}/api/auth/users/3/",
 					"host": [
 						"{{THUNDERCAT_URL}}"
 					],
@@ -679,7 +679,7 @@
 						"api",
 						"auth",
 						"users",
-						"1",
+						"3",
 						""
 					]
 				}
@@ -915,6 +915,7 @@
 				"method": "GET",
 				"header": [
 					{
+						"description": "superuser credentials",
 						"key": "Authorization",
 						"type": "text",
 						"value": "basic YWRtaW46QWRtaW4xMjM0IQ=="

--- a/backend/tests/postman/ThunderCAT.postman_collection.json
+++ b/backend/tests/postman/ThunderCAT.postman_collection.json
@@ -1329,7 +1329,7 @@
 							"\r",
 							"// getting test internal name\r",
 							"pm.test(\"Getting test internal name\", function () {\r",
-							"    pm.expect(pm.response.text()).to.include('\"test_internal_name\":\"emibSampleTest\"');\r",
+							"    pm.expect(pm.response.text()).to.include('\"test_internal_name\":\"emibPizzaTest\"');\r",
 							"});\r",
 							"\r",
 							"// getting test questions attribute\r",

--- a/backend/tests/postman/ThunderCAT.postman_collection.json
+++ b/backend/tests/postman/ThunderCAT.postman_collection.json
@@ -958,6 +958,11 @@
 							"// getting test internal name\r",
 							"pm.test(\"Getting test internal name\", function () {\r",
 							"    pm.expect(pm.response.text()).to.include('\"test_internal_name\":\"emibSampleTest\"');\r",
+							"});\r",
+							"\r",
+							"// getting test instructions attribute\r",
+							"pm.test(\"Getting test test instructions attribute\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"instructions\":[');\r",
 							"});"
 						],
 						"type": "text/javascript"
@@ -1039,7 +1044,7 @@
 			"response": []
 		},
 		{
-			"name": "get pizza test instructions data (non-public test + authenticated with default user) - /api/test-instructions/?test_name=emibPizzaTest Copy",
+			"name": "get pizza test instructions data (non-public test + authenticated with default user) - /api/test-instructions/?test_name=emibPizzaTest",
 			"event": [
 				{
 					"listen": "test",
@@ -1094,7 +1099,7 @@
 			"response": []
 		},
 		{
-			"name": "get pizza test instructions data (non-public test + authenticated with admin user) - /api/test-instructions/?test_name=emibPizzaTest Copy Copy",
+			"name": "get pizza test instructions data (non-public test + authenticated with admin user) - /api/test-instructions/?test_name=emibPizzaTest",
 			"event": [
 				{
 					"listen": "test",
@@ -1109,6 +1114,11 @@
 							"// getting test internal name\r",
 							"pm.test(\"Getting test internal name\", function () {\r",
 							"    pm.expect(pm.response.text()).to.include('\"test_internal_name\":\"emibPizzaTest\"');\r",
+							"});\r",
+							"\r",
+							"// getting test instructions attribute\r",
+							"pm.test(\"Getting test test instructions attribute\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"instructions\":[');\r",
 							"});"
 						],
 						"type": "text/javascript"
@@ -1136,6 +1146,222 @@
 					"path": [
 						"api",
 						"test-instructions",
+						""
+					],
+					"query": [
+						{
+							"key": "test_name",
+							"value": "emibPizzaTest"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "get sample questions data (public test) - /api/test-questions/?test_name=emibSampleTest",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "5d85a30b-ed4a-4972-93ce-63c0b960c9f0",
+						"exec": [
+							"// successful request\r",
+							"pm.test(\"Successful request\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"// getting test internal name\r",
+							"pm.test(\"Getting test internal name\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"test_internal_name\":\"emibSampleTest\"');\r",
+							"});\r",
+							"\r",
+							"// getting test questions attribute\r",
+							"pm.test(\"Getting test test questions attribute\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"questions\":[');\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{THUNDERCAT_URL}}/api/test-questions/?test_name=emibSampleTest",
+					"host": [
+						"{{THUNDERCAT_URL}}"
+					],
+					"path": [
+						"api",
+						"test-questions",
+						""
+					],
+					"query": [
+						{
+							"key": "test_name",
+							"value": "emibSampleTest"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "get pizza test questions data (non-public test + unauthenticated) - /api/test-questions/?test_name=emibPizzaTest",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "5d85a30b-ed4a-4972-93ce-63c0b960c9f0",
+						"exec": [
+							"// fail request (expected: status 403)\r",
+							"pm.test(\"Fail request\", function () {\r",
+							"    pm.response.to.have.status(403);\r",
+							"});\r",
+							"\r",
+							"// getting authentication message\r",
+							"pm.test(\"Getting 'Authentication credentials were not provided' message\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"detail\":\"Authentication credentials were not provided.\"');\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{THUNDERCAT_URL}}/api/test-questions/?test_name=emibPizzaTest",
+					"host": [
+						"{{THUNDERCAT_URL}}"
+					],
+					"path": [
+						"api",
+						"test-questions",
+						""
+					],
+					"query": [
+						{
+							"key": "test_name",
+							"value": "emibPizzaTest"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "get pizza test questions data (non-public test + authenticated with default user) - /api/test-questions/?test_name=emibPizzaTest",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "5d85a30b-ed4a-4972-93ce-63c0b960c9f0",
+						"exec": [
+							"// fail request (expected: status 403)\r",
+							"pm.test(\"Fail reques\", function () {\r",
+							"    pm.response.to.have.status(403);\r",
+							"});\r",
+							"\r",
+							"// getting missing permission message\r",
+							"pm.test(\"Getting 'You do not have permission to perform this action' message\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"detail\":\"You do not have permission to perform this action.\"');\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "basic YXBpLXRlc3QxQGVtYWlsLmNhOlF3ZXJ0eTEyMzQh",
+						"description": "api-test1 credentials",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{THUNDERCAT_URL}}/api/test-questions/?test_name=emibPizzaTest",
+					"host": [
+						"{{THUNDERCAT_URL}}"
+					],
+					"path": [
+						"api",
+						"test-questions",
+						""
+					],
+					"query": [
+						{
+							"key": "test_name",
+							"value": "emibPizzaTest"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "get pizza test questions data (non-public test + authenticated with admin user) - /api/test-questions/?test_name=emibPizzaTest",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "5d85a30b-ed4a-4972-93ce-63c0b960c9f0",
+						"exec": [
+							"// successful request\r",
+							"pm.test(\"Successful request\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"// getting test internal name\r",
+							"pm.test(\"Getting test internal name\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"test_internal_name\":\"emibSampleTest\"');\r",
+							"});\r",
+							"\r",
+							"// getting test questions attribute\r",
+							"pm.test(\"Getting test test questions attribute\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include('\"questions\":[');\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [
+					{
+						"description": "superuser credentials",
+						"key": "Authorization",
+						"type": "text",
+						"value": "basic YWRtaW46QWRtaW4xMjM0IQ=="
+					}
+				],
+				"url": {
+					"raw": "{{THUNDERCAT_URL}}/api/test-questions/?test_name=emibPizzaTest",
+					"host": [
+						"{{THUNDERCAT_URL}}"
+					],
+					"path": [
+						"api",
+						"test-questions",
 						""
 					],
 					"query": [


### PR DESCRIPTION
# Description

This PR is introducing new postman tests related to the following APIs:

- test meta data APIs (sample and pizza tests)
- test instructions APIs (sample and pizza tests)
- test questions APIs (sample and pizza tests)

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

![image](https://user-images.githubusercontent.com/23021242/59347587-0f14d880-8ce3-11e9-9753-05a8fe0f0694.png)

![image](https://user-images.githubusercontent.com/23021242/59347623-218f1200-8ce3-11e9-8570-702a287c262f.png)

# Testing

Manual steps to reproduce this functionality:

- This is not really testable. However, you can take a look at _travis_ console logs to see the new added tests.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [ ] ~~My changes look good on IE 11+ and Chrome~~
