### PR TITLE
[Test Structure] Load en/fr from state rather than json

### DIFF
--- a/frontend/src/modules/EmibInboxRedux.js
+++ b/frontend/src/modules/EmibInboxRedux.js
@@ -76,6 +76,8 @@ const changeCurrentEmail = emailIndex => ({
 const initialState = {
   // Loads emails from a static JSON file until an API exists.
   emails: emailsJson.emailsEN,
+  emailsEN: emailsJson.emailsEN,
+  emailsFR: emailsJson.emailsFR,
   emailSummaries: initializeEmailSummaries(emailsJson.emailsEN.length),
   emailActions: initializeEmailActions(emailsJson.emailsEN.length),
   addressBook: addressBookJson.addressBookEN,
@@ -88,7 +90,7 @@ const emibInbox = (state = initialState, action) => {
     case SET_LANGUAGE:
       return {
         ...state,
-        emails: action.language === "fr" ? emailsJson.emailsFR : emailsJson.emailsEN,
+        emails: action.language === "fr" ? state.emailsFR : state.emailsEN,
         addressBook:
           action.language === "fr" ? addressBookJson.addressBookFR : addressBookJson.addressBookEN
       };

--- a/frontend/src/tests/modules/EmibInboxRedux.test.js
+++ b/frontend/src/tests/modules/EmibInboxRedux.test.js
@@ -18,7 +18,7 @@ describe("EmibInboxRedux", () => {
   beforeEach(() => {
     stubbedInitialState = {
       emails: emailsJson.emailsEN,
-      emailEN: emailsJson.emailsEN,
+      emailsEN: emailsJson.emailsEN,
       emailsFR: emailsJson.emailsFR,
       emailSummaries: initializeEmailSummaries(emailsJson.emailsEN.length),
       emailActions: [[], [], []],

--- a/frontend/src/tests/modules/EmibInboxRedux.test.js
+++ b/frontend/src/tests/modules/EmibInboxRedux.test.js
@@ -18,6 +18,8 @@ describe("EmibInboxRedux", () => {
   beforeEach(() => {
     stubbedInitialState = {
       emails: emailsJson.emailsEN,
+      emailEN: emailsJson.emailsEN,
+      emailsFR: emailsJson.emailsFR,
       emailSummaries: initializeEmailSummaries(emailsJson.emailsEN.length),
       emailActions: [[], [], []],
       currentEmail: 0


### PR DESCRIPTION
# Description

Loading EN/FR from state of redux rather than the json file

This will be needed later when loading from DB rather than json so that we do not need to ping the DB every time we toggle language, just once when loading the test

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

No change in behavior

# Testing

Enter the Emib
Look at the questions
Ensure that the language toggles as expected

# Checklist

Applicable for all code changes.

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
~~- [ ] My changes look good on IE 11+ and Chrome~~
