### PR TITLE
[Test Meta Data] Getting test meta data from the back end

### DIFF
--- a/frontend/src/modules/LoadTestContentRedux.js
+++ b/frontend/src/modules/LoadTestContentRedux.js
@@ -1,0 +1,39 @@
+// Action Types
+const UPDATE_TEST_META_DATA = "emibInbox/UPDATE_TEST_META_DATA";
+
+// Action Creators
+const updateTestMetaDataState = testMetaData => ({ type: UPDATE_TEST_META_DATA, testMetaData });
+
+const getTestMetaData = testName => {
+  return async function() {
+    let metaDataContent = await fetch(`/api/test-meta-data/?test_name=${testName}`, {
+      method: "GET",
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      cache: "default"
+    });
+    return await metaDataContent.json();
+  };
+};
+
+// Initial State
+const initialState = {
+  testMetaData: ""
+};
+
+// Reducer
+const loadTestContent = (state = initialState, action) => {
+  switch (action.type) {
+    case UPDATE_TEST_META_DATA:
+      return {
+        ...state,
+        testMetaData: action.testMetaData
+      };
+
+    default:
+      return state;
+  }
+};
+
+export default loadTestContent;
+export { initialState, updateTestMetaDataState, getTestMetaData };

--- a/frontend/src/modules/LoadTestContentRedux.js
+++ b/frontend/src/modules/LoadTestContentRedux.js
@@ -18,7 +18,7 @@ const getTestMetaData = testName => {
 
 // Initial State
 const initialState = {
-  testMetaData: ""
+  testMetaData: {}
 };
 
 // Reducer

--- a/frontend/src/modules/index.js
+++ b/frontend/src/modules/index.js
@@ -3,5 +3,6 @@ import localize from "./LocalizeRedux";
 import login from "./LoginRedux";
 import testStatus from "./TestStatusRedux";
 import emibInbox from "./EmibInboxRedux";
+import loadTestContent from "./LoadTestContentRedux";
 
-export default combineReducers({ localize, login, emibInbox, testStatus });
+export default combineReducers({ localize, login, emibInbox, testStatus, loadTestContent });

--- a/frontend/src/testDefinition.js
+++ b/frontend/src/testDefinition.js
@@ -1,0 +1,9 @@
+// definition of tests
+export const TEST_DEFINITION = {
+  emib: {
+    // public test
+    sampleTest: "emibSampleTest",
+    // non-public test
+    pizzaTest: "emibPizzaTest"
+  }
+};


### PR DESCRIPTION
# Description

This PR is introducing a new Redux Module called _LoadTestContentRedux_. This module will be useful to get the test content using the new APIs created in the previous PRs.

This PR is only introducing the actions to get the test meta data and update the redux state.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**How to use these new actions:**
![image](https://user-images.githubusercontent.com/23021242/59372131-d5f55c00-8d14-11e9-8e3c-2a6552669fb5.png)

**Then if we print the redux state called 'testMetaData':**
![image](https://user-images.githubusercontent.com/23021242/59372219-fde4bf80-8d14-11e9-89c1-4f600b0d9a5a.png)

**We get that result:**
![image](https://user-images.githubusercontent.com/23021242/59372287-28cf1380-8d15-11e9-99af-7d17786a3732.png)

# Testing

Manual steps to reproduce this functionality:

- you can test these new actions using the code shown above in any desired file of the project. You'll just need to assure the redux connection with this selected file.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [ ] ~~My changes look good on IE 11+ and Chrome~~
