### PR TITLE
[Registration Flow] Candidate registration flow updates

### DIFF
--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -442,6 +442,9 @@ class RegistrationForm extends Component {
         .then(response => {
           // response returns email and username
           if (
+            response.first_name === this.state.firstNameContent &&
+            response.last_name === this.state.lastNameContent &&
+            response.birth_date.length > 0 &&
             response.email === this.state.emailContent &&
             response.username === this.state.emailContent
           ) {

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -452,6 +452,7 @@ class RegistrationForm extends Component {
           ) {
             // account successfully created
             this.setState({ accountExistsError: false });
+            // login the user by using its credentials
             this.props
               .loginAction({
                 username: this.state.emailContent,

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -8,13 +8,13 @@ import validateName, {
   PASSWORD_REQUIREMENTS
 } from "../../helpers/regexValidator";
 import "../../css/registration-form.css";
-import { registerAction } from "../../modules/LoginRedux";
-import { bindActionCreators } from "redux";
+import { registerAction, handleAuthResponseAndState, loginAction } from "../../modules/LoginRedux";
 import { connect } from "react-redux";
 import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCheckCircle } from "@fortawesome/free-solid-svg-icons";
 import { OverlayTrigger, Popover, Button } from "react-bootstrap";
+import history from "./history";
 
 const styles = {
   createAccountContent: {
@@ -98,7 +98,9 @@ const MANDATORY_MARK = " *";
 class RegistrationForm extends Component {
   static propTypes = {
     // Props from Redux
-    registerAction: PropTypes.func
+    registerAction: PropTypes.func,
+    handleAuthResponseAndState: PropTypes.func,
+    loginAction: PropTypes.func
   };
 
   state = {
@@ -450,6 +452,19 @@ class RegistrationForm extends Component {
           ) {
             // account successfully created
             this.setState({ accountExistsError: false });
+            this.props
+              .loginAction({
+                username: this.state.emailContent,
+                password: this.state.passwordContent
+              })
+              .then(response => {
+                this.props.handleAuthResponseAndState(
+                  response,
+                  this.props.dispatch,
+                  window.location.pathname,
+                  history.push
+                );
+              });
           }
           // response gets username error(s)
           if (typeof response.username !== "undefined") {
@@ -890,13 +905,13 @@ class RegistrationForm extends Component {
   }
 }
 
-const mapDispatchToProps = dispatch =>
-  bindActionCreators(
-    {
-      registerAction
-    },
-    dispatch
-  );
+const mapDispatchToProps = dispatch => ({
+  registerAction: data => dispatch(registerAction(data)),
+  loginAction: data => dispatch(loginAction(data)),
+  handleAuthResponseAndState: (userData, dispatch, location, push) =>
+    dispatch(handleAuthResponseAndState(userData, dispatch, location, push)),
+  dispatch
+});
 
 export default connect(
   null,

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -138,7 +138,6 @@ class RegistrationForm extends Component {
     betweenMinAndMaxChar: false,
 
     // PopupBox States
-    showCreatedAccountDialog: false,
     showPrivacyNoticeDialog: false,
 
     // API Errors Handler States
@@ -423,13 +422,6 @@ class RegistrationForm extends Component {
     );
   };
 
-  redirectToLoginPage = () => {
-    // refresh the page in order to show the login form
-    window.location.reload();
-    // close dialog
-    this.setState({ showCreatedAccountDialog: false });
-  };
-
   handleSubmit = event => {
     const validForm = this.isFormValid();
     // if all fields are valid, execute API errors validation
@@ -454,7 +446,7 @@ class RegistrationForm extends Component {
             response.username === this.state.emailContent
           ) {
             // account successfully created
-            this.setState({ showCreatedAccountDialog: true, accountExistsError: false });
+            this.setState({ accountExistsError: false });
           }
           // response gets username error(s)
           if (typeof response.username !== "undefined") {
@@ -889,21 +881,6 @@ class RegistrationForm extends Component {
           rightButtonType={BUTTON_TYPE.primary}
           rightButtonTitle={LOCALIZE.commons.ok}
           rightButtonAction={this.closePrivacyNoticePopup}
-        />
-        <PopupBox
-          isCloseButtonVisible={false}
-          isBackdropStatic={true}
-          show={this.state.showCreatedAccountDialog}
-          handleClose={this.redirectToLoginPage}
-          title={LOCALIZE.authentication.createAccount.popupBox.title}
-          description={
-            <div>
-              <p>{LOCALIZE.authentication.createAccount.popupBox.description}</p>
-            </div>
-          }
-          rightButtonType={BUTTON_TYPE.primary}
-          rightButtonTitle={LOCALIZE.commons.ok}
-          rightButtonAction={this.redirectToLoginPage}
         />
       </div>
     );

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -74,11 +74,6 @@ let LOCALIZE = new LocalizedStrings({
           "I have read and agreed to how the Public Service Commission collects, uses and discloses personnel information, as set out in the ",
         privacyNoticeLink: "privacy notice",
         privacyNoticeError: "You must accept the privacy notice by clicking on the checkbox",
-        //temporary
-        popupBox: {
-          title: "Account Created",
-          description: "You have just created a new account!"
-        },
         button: "Create account",
         accountAlreadyExistsError: "An account is already associated to this email address",
         passwordTooCommonError: "This password is too common",
@@ -670,11 +665,6 @@ let LOCALIZE = new LocalizedStrings({
           "FR I have read and agreed to how the Public Service Commission collects, uses and discloses personnel information, as set out in the ",
         privacyNoticeLink: "FR privacy notice",
         privacyNoticeError: "FR You must accept the privacy notice by clicking on the checkbox",
-        //temporary
-        popupBox: {
-          title: "FR Account Created",
-          description: "FR You have just created a new account!"
-        },
         button: "Créer compte",
         accountAlreadyExistsError: "FR An account is already associated to this email address",
         passwordTooCommonError: "FR This password is too common",


### PR DESCRIPTION
# Description

This PR is introducing part of the new candidate registration flow. It means that when a new user creates an account, he gets redirected to the dashboard page logged in.

## Type of change

- New feature (non-breaking change which adds functionality)
- Code cleanliness or refactor

## Screenshot

**Creating a new account:**

![image](https://user-images.githubusercontent.com/23021242/59379796-89fee300-8d25-11e9-962d-acf67c7177ed.png)

**After clicking on _Create account_ button:**

![image](https://user-images.githubusercontent.com/23021242/59379826-a438c100-8d25-11e9-8dda-67011a5a2e64.png)

# Testing

Manual steps to reproduce this functionality:

1.  Create a new account with the registration form.
2.  Make sure that you are logged in and you get to the dashboard page when clicking on _Create account_ button.

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 11+ and Chrome
