### PR TITLE
[Accessibility] Registration form accessibility updates

### DIFF
--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -66,6 +66,9 @@ const styles = {
     marginTop: 6,
     fontWeight: "bold"
   },
+  passwordRequirementsForScreenReader: {
+    display: "none"
+  },
   errorMessage: {
     color: "#923534",
     fontWeight: "bold",
@@ -300,6 +303,21 @@ class RegistrationForm extends Component {
         LOCALIZE.authentication.createAccount.privacyNoticeError +
         LOCALIZE.authentication.createAccount.privacyNotice +
         LOCALIZE.authentication.createAccount.privacyNoticeLink
+      );
+    }
+  };
+
+  getPasswordRequirements = () => {
+    if (this.state.isFirstLoad) {
+      return (
+        <span id="password-requirements" style={styles.passwordRequirementsForScreenReader}>
+          {LOCALIZE.authentication.createAccount.content.inputs.passwordErrors.description +
+            LOCALIZE.authentication.createAccount.content.inputs.passwordErrors.upperCase +
+            LOCALIZE.authentication.createAccount.content.inputs.passwordErrors.lowerCase +
+            LOCALIZE.authentication.createAccount.content.inputs.passwordErrors.digit +
+            LOCALIZE.authentication.createAccount.content.inputs.passwordErrors.specialCharacter +
+            LOCALIZE.authentication.createAccount.content.inputs.passwordErrors.length}
+        </span>
       );
     }
   };
@@ -730,6 +748,7 @@ class RegistrationForm extends Component {
                 <input
                   className={isValidPassword || isFirstLoad ? validFieldClass : invalidFieldClass}
                   aria-live="polite"
+                  aria-describedby={"password-requirements"}
                   aria-invalid={!isValidPassword && !isFirstLoad}
                   aria-required={"true"}
                   id="password-field"
@@ -738,6 +757,7 @@ class RegistrationForm extends Component {
                   style={styles.inputs}
                   onChange={this.getPasswordContent}
                 />
+                {this.getPasswordRequirements()}
                 {!isValidPassword && !isFirstPasswordLoad && (
                   <label htmlFor={"password-field"}>
                     <p style={styles.errorMessage}>

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -604,6 +604,7 @@ class RegistrationForm extends Component {
                     }
                   >
                     <Button
+                      tabIndex="-1"
                       aria-label={
                         LOCALIZE.authentication.createAccount.content.inputs.dobDayTitle +
                         LOCALIZE.authentication.createAccount.content.inputs.dobTooltip

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -271,6 +271,7 @@ class RegistrationForm extends Component {
       // returns the DOB field title and the field selected
       return (
         LOCALIZE.authentication.createAccount.content.inputs.dobDayTitle +
+        LOCALIZE.authentication.createAccount.content.inputs.dobTooltip +
         LOCALIZE.ariaLabel.dobYearField
       );
     } else {
@@ -278,6 +279,7 @@ class RegistrationForm extends Component {
       return (
         LOCALIZE.authentication.createAccount.content.inputs.dobDayTitle +
         LOCALIZE.authentication.createAccount.content.inputs.dobError +
+        LOCALIZE.authentication.createAccount.content.inputs.dobTooltip +
         LOCALIZE.ariaLabel.dobYearField
       );
     }
@@ -603,15 +605,7 @@ class RegistrationForm extends Component {
                       </Popover>
                     }
                   >
-                    <Button
-                      tabIndex="-1"
-                      aria-label={
-                        LOCALIZE.authentication.createAccount.content.inputs.dobDayTitle +
-                        LOCALIZE.authentication.createAccount.content.inputs.dobTooltip
-                      }
-                      style={styles.tooltipButton}
-                      variant="link"
-                    >
+                    <Button tabIndex="-1" style={styles.tooltipButton} variant="link">
                       ?
                     </Button>
                   </OverlayTrigger>

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -307,7 +307,9 @@ class RegistrationForm extends Component {
     }
   };
 
+  // returns password requirements on password field selection for the screen reader users
   getPasswordRequirements = () => {
+    // only on first load, since the dynamic password requirements are handling that after the first page load
     if (this.state.isFirstLoad) {
       return (
         <span id="password-requirements" style={styles.passwordRequirementsForScreenReader}>


### PR DESCRIPTION
# Description

This PR is introducing some accessibility fixes after David's feedback on the registration form. The following updates have been done:

- remove tooltip tab selection
- make the screen reader read the tooltip content on year field selection
- add aria-describedby to password field, so it reads the password requirements on password field selection

## Type of change

- New feature (non-breaking change which adds functionality)
- Code cleanliness or refactor

## Screenshot

(N/A)

# Testing

Manual steps to reproduce this functionality:

1.  Start NVDA.
2.  Open the registration form.
3.  Make sure that the tooltip content is read by the screen reader when you select the _year_ DOB field.
4.  Also, make sure that you get the password requirements from the screen reader on password field selection.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
