### PR TITLE
[Test Structure] Update json emails to match db

### DIFF
--- a/frontend/src/modules/EmibInboxRedux.js
+++ b/frontend/src/modules/EmibInboxRedux.js
@@ -75,11 +75,11 @@ const changeCurrentEmail = emailIndex => ({
 // addressBook - repesents an array of contactShape objects in the currently selected language
 const initialState = {
   // Loads emails from a static JSON file until an API exists.
-  emails: emailsJson.emailsEN,
-  emailsEN: emailsJson.emailsEN,
-  emailsFR: emailsJson.emailsFR,
-  emailSummaries: initializeEmailSummaries(emailsJson.emailsEN.length),
-  emailActions: initializeEmailActions(emailsJson.emailsEN.length),
+  emails: emailsJson.questions.en.email,
+  emailsEN: emailsJson.questions.en.email,
+  emailsFR: emailsJson.questions.fr.email,
+  emailSummaries: initializeEmailSummaries(emailsJson.questions.en.email.length),
+  emailActions: initializeEmailActions(emailsJson.questions.en.email.length),
   addressBook: addressBookJson.addressBookEN,
   currentEmail: 0
 };

--- a/frontend/src/modules/sampleEmibJson.js
+++ b/frontend/src/modules/sampleEmibJson.js
@@ -1,65 +1,72 @@
 export const emailsJson = {
-  emailsEN: [
-    {
-      id: 0,
-      to: "Claude Huard (Manager, Quality Assurance Team)",
-      from: "Serge Duplessis (Quality Control Analyst, Quality Assurance Team)",
-      subject: "Bad experience with Serv",
-      date: "Thursday, November 3",
-      body:
-        "Hello Claude,\n\nAs you are settling into this position, I was hoping to share with you some of my thoughts about the proposed changes to our service requests and documentation practices.\n\nI have been working on the Quality Assurance team for over 12 years. I feel that, overall, we are quite successful in understanding and processing service requests. Switching to an automated, computerized system would take a very long time to adapt to and could jeopardize the quality of our service. For example, having a face-to-face or telephone conversation with a client can help us better understand the client’s issues in more depth because it allows us to ask probing questions and receive important information related to each case. By buying into this new technology, we risk having more IT problems and unexpected delays in the long-run.\n\nI have voiced my opinion in previous meetings but I do not feel that my opinions matter. Everyone else has been on the team for less than two years and I feel ignored because I’m the oldest member on the team. I urge you to consider my opinion so that we do not make a costly mistake.\n\nSerge"
+  test_internal_name: "emibSampleTest",
+  questions: {
+    en: {
+      email: [
+        {
+          subject: "Bad experience with Serv",
+          from: "Serge Duplessis (Quality Control Analyst, Quality Assurance Team)",
+          to: "Claude Huard (Manager, Quality Assurance Team)",
+          date: "Thursday, November 3",
+          body:
+            "Hello Claude,\n\nAs you are settling into this position, I was hoping to share with you some of my thoughts about the proposed changes to our service requests and documentation practices.\n\nI have been working on the Quality Assurance team for over 12 years. I feel that, overall, we are quite successful in understanding and processing service requests. Switching to an automated, computerized system would take a very long time to adapt to and could jeopardize the quality of our service. For example, having a face-to-face or telephone conversation with a client can help us better understand the client’s issues in more depth because it allows us to ask probing questions and receive important information related to each case. By buying into this new technology, we risk having more IT problems and unexpected delays in the long-run.\n\nI have voiced my opinion in previous meetings but I do not feel that my opinions matter. Everyone else has been on the team for less than two years and I feel ignored because I’m the oldest member on the team. I urge you to consider my opinion so that we do not make a costly mistake.\n\nSerge",
+          id: 0
+        },
+        {
+          subject: "Informal Training on Serv",
+          from: "Marina Richter (Quality Control Analyst, Quality Assurance Team)",
+          to: "Claude Huard (Manager, Quality Assurance Team)",
+          date: "Friday, November 4",
+          body:
+            "Hello Claude,\n\nDuring our last meeting, Danny had mentioned that he learned a lot about the Serv system during the pilot testing exercise with the IT unit.  While talking to other team members, some mentioned they were trained on and worked with an older version of Serv in previous jobs. However, there are a few of us who have never used it. I would like to know if there would be opportunities to be trained on Serv?\n\nMarina",
+          id: 1
+        },
+        {
+          subject: "Report deadline",
+          from: "Charlie Wang (Quality Control Analyst, Quality Assurance Team)",
+          to: "Claude Huard (Manager, Quality Assurance Team)",
+          date: "Friday, November 4",
+          body:
+            "Hello Claude,\n\nI am working with Clara Farewell from the Research and Innovations unit on evaluating the quality of a training approach and I am having a hard time getting a hold of her. I am starting to be concerned because I have been waiting on her part of the work to complete the evaluation report.\nFor the past three weeks, we had scheduled working meetings on Friday afternoons and although she did cancel the first one, she was absent the past two, without notice. She did not answer my attempts to contact her by phone or email. I am worried that I will not be able to complete the report by the end of next Friday without her content.\n\nOn another note, I was told by one of my colleagues from the Program Development unit that his director, Bartosz Greco, would invite employees from other units to help them develop a new training program. They want to take a multiple perspectives approach. I’m very much interested in participating in this process. As usual, manager permission is required for participation. I am wondering what you think?\n\nThank you,\nCharlie",
+          id: 2
+        }
+      ]
     },
-    {
-      id: 1,
-      to: "Claude Huard (Manager, Quality Assurance Team)",
-      from: "Marina Richter (Quality Control Analyst, Quality Assurance Team)",
-      subject: "Informal Training on Serv",
-      date: "Friday, November 4",
-      body:
-        "Hello Claude,\n\nDuring our last meeting, Danny had mentioned that he learned a lot about the Serv system during the pilot testing exercise with the IT unit.  While talking to other team members, some mentioned they were trained on and worked with an older version of Serv in previous jobs. However, there are a few of us who have never used it. I would like to know if there would be opportunities to be trained on Serv?\n\nMarina"
-    },
-    {
-      id: 2,
-      to: "Claude Huard (Manager, Quality Assurance Team)",
-      from: "Charlie Wang (Quality Control Analyst, Quality Assurance Team)",
-      subject: "Report deadline",
-      date: "Friday, November 4",
-      body:
-        "Hello Claude,\n\nI am working with Clara Farewell from the Research and Innovations unit on evaluating the quality of a training approach and I am having a hard time getting a hold of her. I am starting to be concerned because I have been waiting on her part of the work to complete the evaluation report.\nFor the past three weeks, we had scheduled working meetings on Friday afternoons and although she did cancel the first one, she was absent the past two, without notice. She did not answer my attempts to contact her by phone or email. I am worried that I will not be able to complete the report by the end of next Friday without her content.\n\nOn another note, I was told by one of my colleagues from the Program Development unit that his director, Bartosz Greco, would invite employees from other units to help them develop a new training program. They want to take a multiple perspectives approach. I’m very much interested in participating in this process. As usual, manager permission is required for participation. I am wondering what you think?\n\nThank you,\nCharlie"
+    fr: {
+      email: [
+        {
+          subject: "Mauvaise expérience avec Serv",
+          from:
+            "Serge Duplessis (analyste de l’assurance de la qualité, Équipe de l’assurance de la qualité)",
+          to: "Claude Huard (gestionnaire, Équipe de l’assurance de la qualité)",
+          date: "Le jeudi 3 novembre",
+          body:
+            "Bonjour Claude.Alors que vous vous familiarisez avec vos nouvelles fonctions, j’aimerais vous faire part de certaines de mes opinions concernant les changements que l’on propose d’apporter à notre système de demandes de services et à nos pratiques en matière de documentation.\n\nJe travaille au sein de l’Équipe de l’assurance de la qualité depuis plus de 12 ans. J’estime que, dans l’ensemble, nous avons bien réussi à comprendre et à traiter les demandes de service. Le passage à un système automatisé et informatisé prendrait beaucoup de temps avant qu’on s’y adapte et pourrait compromettre la qualité de notre service. Par exemple, une conversation en personne ou par téléphone avec un client peut nous aider à mieux comprendre ses problèmes, car cela nous permet de poser des questions d’approfondissement et d’obtenir des renseignements importants sur chaque cas. En adoptant cette nouvelle technologie, nous risquons d’avoir plus de problèmes de TI et des retards imprévus à long terme.\n\nJ’ai déjà exprimé mon opinion lors de réunions précédentes, mais je n’ai pas l’impression que mes opinions comptent. Tous les autres sont dans l’équipe depuis moins de deux ans et je me sens ignoré parce que je suis le plus âgé de l’équipe. Je vous encourage à tenir compte de mon opinion afin que nous ne commettions pas une erreur coûteuse. \n\nSerge",
+          id: 0
+        },
+        {
+          subject: "Formation informelle sur Serv",
+          from:
+            "Marina Richter (analyste de l’assurance de la qualité, Équipe de l’assurance de la qualité)",
+          to: "Claude Huard (gestionnaire, Équipe de l’assurance de la qualité)",
+          date: "Le vendredi 4 novembre",
+          body:
+            "Bonjour Claude.\nLors de notre dernière réunion, Danny a indiqué qu’il avait beaucoup appris sur le système Serv  pendant l’exercice d’essai pilote avec l’Équipe des TI. En discutant avec d’autres membres de notre équipe, certains ont mentionné qu’ils avaient reçu une formation et avaient travaillé avec une ancienne version de Serv dans des emplois antérieurs. Cependant, certains d’entre nous ne l’ont jamais utilisée. J’aimerais savoir s’il y aurait des possibilités d’être formé sur Serv ?\nMarina",
+          id: 1
+        },
+        {
+          subject: "Date limite de dépôt du rapport",
+          from:
+            "Charlie Wang (analyste de l’assurance de la qualité, Équipe de l’assurance de la qualité)",
+          to: "Claude Huard (gestionnaire, Équipe de l’assurance de la qualité)",
+          date: "Le vendredi 4 novembre",
+          body:
+            "Bonjour Claude.\nJe travaille avec Clara Farewell de l’Unité de recherche et innovations sur l’évaluation de la qualité d’une approche de formation et j’ai de la difficulté à la joindre. Je commence à m’inquiéter parce que j’attendais qu’elle termine sa partie du travail pour achever le rapport d’évaluation.\nAu cours des trois dernières semaines, nous avions prévu des rencontres de travail les vendredis après-midi et, après avoir annulé la première rencontre, elle était absente aux deux dernières, sans donner un préavis. Elle n’a pas non plus répondu à mes tentatives de communiquer avec elle par téléphone ou par courriel. Je m’inquiète de ne pas pouvoir terminer le rapport d’ici vendredi prochain sans sa part du travail.\nDans un autre ordre d’idées, un de mes collègues de l’Unité de développement des programmes m’a dit que son directeur, Bartosz Greco, inviterait des employés d’autres unités à les aider à créer un nouveau programme de formation. Ils veulent adopter une approche qui inclut des perspectives multiples. J’aimerais bien participer à ce processus. Comme d’habitude, la permission du gestionnaire est requise pour y participer. Je me demande ce que tu en penses.\nMerci,\nCharlie",
+          id: 2
+        }
+      ]
     }
-  ],
-  emailsFR: [
-    {
-      id: 0,
-      to: "Claude Huard (gestionnaire, Équipe de l’assurance de la qualité)",
-      from:
-        "Serge Duplessis (analyste de l’assurance de la qualité, Équipe de l’assurance de la qualité)",
-      subject: "Mauvaise expérience avec Serv",
-      date: "Le jeudi 3 novembre",
-      body:
-        "Bonjour Claude.Alors que vous vous familiarisez avec vos nouvelles fonctions, j’aimerais vous faire part de certaines de mes opinions concernant les changements que l’on propose d’apporter à notre système de demandes de services et à nos pratiques en matière de documentation.\n\nJe travaille au sein de l’Équipe de l’assurance de la qualité depuis plus de 12 ans. J’estime que, dans l’ensemble, nous avons bien réussi à comprendre et à traiter les demandes de service. Le passage à un système automatisé et informatisé prendrait beaucoup de temps avant qu’on s’y adapte et pourrait compromettre la qualité de notre service. Par exemple, une conversation en personne ou par téléphone avec un client peut nous aider à mieux comprendre ses problèmes, car cela nous permet de poser des questions d’approfondissement et d’obtenir des renseignements importants sur chaque cas. En adoptant cette nouvelle technologie, nous risquons d’avoir plus de problèmes de TI et des retards imprévus à long terme.\n\nJ’ai déjà exprimé mon opinion lors de réunions précédentes, mais je n’ai pas l’impression que mes opinions comptent. Tous les autres sont dans l’équipe depuis moins de deux ans et je me sens ignoré parce que je suis le plus âgé de l’équipe. Je vous encourage à tenir compte de mon opinion afin que nous ne commettions pas une erreur coûteuse. \n\nSerge"
-    },
-    {
-      id: 1,
-      to: "Claude Huard (gestionnaire, Équipe de l’assurance de la qualité)",
-      from:
-        "Marina Richter (analyste de l’assurance de la qualité, Équipe de l’assurance de la qualité)",
-      subject: "Formation informelle sur Serv",
-      date: "Le vendredi 4 novembre",
-      body:
-        "Bonjour Claude.\nLors de notre dernière réunion, Danny a indiqué qu’il avait beaucoup appris sur le système Serv  pendant l’exercice d’essai pilote avec l’Équipe des TI. En discutant avec d’autres membres de notre équipe, certains ont mentionné qu’ils avaient reçu une formation et avaient travaillé avec une ancienne version de Serv dans des emplois antérieurs. Cependant, certains d’entre nous ne l’ont jamais utilisée. J’aimerais savoir s’il y aurait des possibilités d’être formé sur Serv ?\nMarina"
-    },
-    {
-      id: 2,
-      to: "Claude Huard (gestionnaire, Équipe de l’assurance de la qualité)",
-      from:
-        "Charlie Wang (analyste de l’assurance de la qualité, Équipe de l’assurance de la qualité)",
-      subject: "Date limite de dépôt du rapport",
-      date: "Le vendredi 4 novembre ",
-      body:
-        "Bonjour Claude.\nJe travaille avec Clara Farewell de l’Unité de recherche et innovations sur l’évaluation de la qualité d’une approche de formation et j’ai de la difficulté à la joindre. Je commence à m’inquiéter parce que j’attendais qu’elle termine sa partie du travail pour achever le rapport d’évaluation.\nAu cours des trois dernières semaines, nous avions prévu des rencontres de travail les vendredis après-midi et, après avoir annulé la première rencontre, elle était absente aux deux dernières, sans donner un préavis. Elle n’a pas non plus répondu à mes tentatives de communiquer avec elle par téléphone ou par courriel. Je m’inquiète de ne pas pouvoir terminer le rapport d’ici vendredi prochain sans sa part du travail.\nDans un autre ordre d’idées, un de mes collègues de l’Unité de développement des programmes m’a dit que son directeur, Bartosz Greco, inviterait des employés d’autres unités à les aider à créer un nouveau programme de formation. Ils veulent adopter une approche qui inclut des perspectives multiples. J’aimerais bien participer à ce processus. Comme d’habitude, la permission du gestionnaire est requise pour y participer. Je me demande ce que tu en penses.\nMerci,\nCharlie"
-    }
-  ]
+  }
 };
 
 export const addressBookJson = {

--- a/frontend/src/tests/components/eMIB/Inbox.test.js
+++ b/frontend/src/tests/components/eMIB/Inbox.test.js
@@ -5,7 +5,7 @@ import { emailsJson } from "../../../modules/sampleEmibJson";
 import EmailPreview from "../../../components/eMIB/EmailPreview";
 import Email from "../../../components/eMIB/Email";
 
-const INBOX_SPECS = emailsJson.emailsEN;
+const INBOX_SPECS = emailsJson.questions.en.email;
 
 it("Displays 3 email previews when there are 3 emails", () => {
   const wrapper = shallow(

--- a/frontend/src/tests/modules/EmibInboxRedux.test.js
+++ b/frontend/src/tests/modules/EmibInboxRedux.test.js
@@ -17,10 +17,10 @@ describe("EmibInboxRedux", () => {
   let stubbedInitialState;
   beforeEach(() => {
     stubbedInitialState = {
-      emails: emailsJson.emailsEN,
-      emailsEN: emailsJson.emailsEN,
-      emailsFR: emailsJson.emailsFR,
-      emailSummaries: initializeEmailSummaries(emailsJson.emailsEN.length),
+      emails: emailsJson.questions.en.email,
+      emailsEN: emailsJson.questions.en.email,
+      emailsFR: emailsJson.questions.fr.email,
+      emailSummaries: initializeEmailSummaries(emailsJson.questions.en.email.length),
       emailActions: [[], [], []],
       currentEmail: 0
     };
@@ -33,9 +33,9 @@ describe("EmibInboxRedux", () => {
   describe("setLanguage action", () => {
     it("should update emails to french or english", () => {
       const action1 = setLanguage("fr");
-      expect(emibInbox(stubbedInitialState, action1).emails).toEqual(emailsJson.emailsFR);
+      expect(emibInbox(stubbedInitialState, action1).emails).toEqual(emailsJson.questions.fr.email);
       const action2 = setLanguage("en");
-      expect(emibInbox(stubbedInitialState, action2).emails).toEqual(emailsJson.emailsEN);
+      expect(emibInbox(stubbedInitialState, action2).emails).toEqual(emailsJson.questions.en.email);
     });
   });
 


### PR DESCRIPTION
# Description

This PR simply restructures the json to match the return for #359. When both of these are merged in, we can simply swap out the json for the DB without needing to change the rest of the code or the tests (as those changes are in this PR)

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

This results in no visible changes

# Testing

Interact with the test, namely the inbox, and make sure it acts as expected. There should be no change in functionality

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 11+ and Chrome
