### PR TITLE
[Home Link] Updated the wording of the Home link

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -107,10 +107,14 @@ class App extends Component {
                 <Navbar bg="light" variant="light" style={styles.nav}>
                   <Nav>
                     {!this.props.authenticated && (
-                      <Nav.Link href={PATH.login}>{LOCALIZE.mainTabs.homeTabTitle}</Nav.Link>
+                      <Nav.Link href={PATH.login}>
+                        {LOCALIZE.mainTabs.homeTabTitleUnauthenticated}
+                      </Nav.Link>
                     )}
                     {this.props.authenticated && (
-                      <Nav.Link href={PATH.dashboard}>{LOCALIZE.mainTabs.homeTabTitle}</Nav.Link>
+                      <Nav.Link href={PATH.dashboard}>
+                        {LOCALIZE.mainTabs.homeTabTitleAuthenticated}
+                      </Nav.Link>
                     )}
                     <Nav.Link href="/emib-sample">{LOCALIZE.mainTabs.sampleTest}</Nav.Link>
                   </Nav>

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -4,7 +4,8 @@ let LOCALIZE = new LocalizedStrings({
   en: {
     //Main Tabs
     mainTabs: {
-      homeTabTitle: "Home",
+      homeTabTitleUnauthenticated: "Home",
+      homeTabTitleAuthenticated: "Your tests",
       dashboardTabTitle: "Dashboard",
       sampleTest: "Sample eMIB",
       statusTabTitle: "Status",
@@ -601,7 +602,8 @@ let LOCALIZE = new LocalizedStrings({
   fr: {
     //Main Tabs
     mainTabs: {
-      homeTabTitle: "Accueil",
+      homeTabTitleUnauthenticated: "Accueil",
+      homeTabTitleAuthenticated: "FR Your tests",
       dashboardTabTitle: "Tableau de bord",
       sampleTest: "FR eMIB Sample",
       statusTabTitle: "Statut",


### PR DESCRIPTION
# Description

Updated the wording of the _Home_ link:

- When not authenticated, the name of this link is: Home
- When authenticated, the name of this link becomes: Your tests

## Type of change

- Code cleanliness or refactor

## Screenshot

**When not authenticated:**

![image](https://user-images.githubusercontent.com/23021242/59526544-27cdeb80-8ea7-11e9-99bd-66417aa1f783.png)

**When authenticated:**

![image](https://user-images.githubusercontent.com/23021242/59526569-387e6180-8ea7-11e9-962d-98d880702f5e.png)

# Testing

Manual steps to reproduce this functionality:

1.  First, make sure that this link is displayed as _Home_.
2.  Login to the system.
3.  Then, make sure that this link is displayed as _Your tests_.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 11+ and Chrome
