### PR TITLE
[Bug Fix] Fixing IE login form bug

### DIFF
--- a/frontend/src/components/authentication/AuthenticationTabs.jsx
+++ b/frontend/src/components/authentication/AuthenticationTabs.jsx
@@ -7,14 +7,16 @@ import { Tabs, Tab, Container, Row, Col } from "react-bootstrap";
 const styles = {
   loginComponent: {
     maxWidth: 600,
-    marginBottom: 32,
+    margin: "0 auto",
     position: "absolute",
-    margin: "auto auto 32px auto",
     left: 0,
     right: 0
   },
   row: {
     position: "relative"
+  },
+  bottomMargin: {
+    marginBottom: 32
   }
 };
 
@@ -37,15 +39,17 @@ class AuthenticationTabs extends Component {
         <Container>
           <Row style={styles.row}>
             <Col style={styles.loginComponent}>
-              <Tabs defaultActiveKey="login" id="login-tabs">
-                {TABS.map((tab, index) => {
-                  return (
-                    <Tab key={index} eventKey={tab.key} title={tab.tabName}>
-                      {tab.body}
-                    </Tab>
-                  );
-                })}
-              </Tabs>
+              <div style={styles.bottomMargin}>
+                <Tabs defaultActiveKey="login" id="login-tabs">
+                  {TABS.map((tab, index) => {
+                    return (
+                      <Tab key={index} eventKey={tab.key} title={tab.tabName}>
+                        {tab.body}
+                      </Tab>
+                    );
+                  })}
+                </Tabs>
+              </div>
             </Col>
           </Row>
         </Container>

--- a/frontend/src/components/authentication/AuthenticationTabs.jsx
+++ b/frontend/src/components/authentication/AuthenticationTabs.jsx
@@ -6,8 +6,11 @@ import { Tabs, Tab, Container, Row, Col } from "react-bootstrap";
 
 const styles = {
   loginComponent: {
-    maxWidth: 600,
-    marginBottom: 32
+    maxWidth: 600
+  },
+  row: {
+    display: "table",
+    margin: "0 auto"
   }
 };
 
@@ -28,7 +31,7 @@ class AuthenticationTabs extends Component {
     return (
       <div>
         <Container>
-          <Row className="justify-content-md-center">
+          <Row style={styles.row}>
             <Col style={styles.loginComponent}>
               <Tabs defaultActiveKey="login" id="login-tabs">
                 {TABS.map((tab, index) => {

--- a/frontend/src/components/authentication/AuthenticationTabs.jsx
+++ b/frontend/src/components/authentication/AuthenticationTabs.jsx
@@ -6,7 +6,8 @@ import { Tabs, Tab, Container, Row, Col } from "react-bootstrap";
 
 const styles = {
   loginComponent: {
-    maxWidth: 600
+    maxWidth: 600,
+    marginBottom: 32
   },
   row: {
     display: "table",

--- a/frontend/src/components/authentication/AuthenticationTabs.jsx
+++ b/frontend/src/components/authentication/AuthenticationTabs.jsx
@@ -7,11 +7,14 @@ import { Tabs, Tab, Container, Row, Col } from "react-bootstrap";
 const styles = {
   loginComponent: {
     maxWidth: 600,
-    marginBottom: 32
+    marginBottom: 32,
+    position: "absolute",
+    margin: "auto auto 32px auto",
+    left: 0,
+    right: 0
   },
   row: {
-    display: "table",
-    margin: "0 auto"
+    position: "relative"
   }
 };
 


### PR DESCRIPTION
# Description

This PR is fixing the IE login/registration forms bug. Before the forms were not centered. Now they are.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

**Before:**

![image](https://user-images.githubusercontent.com/23021242/59624943-16cee580-9106-11e9-9de9-8bf2efb62023.png)

**After:**

![image](https://user-images.githubusercontent.com/23021242/59624887-f43ccc80-9105-11e9-8a30-bf8158de096b.png)

# Testing

Manual steps to reproduce this functionality:

1.  Open the login and/or the registration form.
2.  Make sure that the forms are centered.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 11+ and Chrome
