### PR TITLE
[Status Page] Added status page as allowed url without authentication

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -60,7 +60,11 @@ class App extends Component {
         this.props.authenticateAction(true);
       }
       // if not valid and not the eMIB sample url, logout and redirect to login page
-      if (response.status !== 200 && window.location.pathname !== PATH.emibSampleTest) {
+      if (
+        response.status !== 200 &&
+        window.location.pathname !== PATH.emibSampleTest &&
+        window.location.pathname !== PATH.status
+      ) {
         this.props.authenticateAction(false);
         this.props.logoutAction();
         history.push(PATH.login);


### PR DESCRIPTION
# Description

This PR is only adding the status page as allowed url without any authentication. So any users have now access to status page (http://localhost/status), even if they are not authenticated.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

(N/A)

# Testing

Manual steps to reproduce this functionality:

1.  Use the following url to access to status page: http://localhost/status.
2.  Make sure that you have access, even if you are not authenticated.

# Checklist

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 11+ and Chrome
