### PR TITLE
[Accessibility] Registration form dob fields update to respect all the accessibility aspects

### DIFF
--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -43,8 +43,7 @@ const styles = {
     marginRight: 12
   },
   tooltipButton: {
-    padding: 0,
-    marginLeft: 6
+    padding: 8
   },
   iconForNames: {
     color: "#278400",

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -254,14 +254,10 @@ class RegistrationForm extends Component {
     // DOB Day field is valid OR this is the first page load
     if (this.state.isValidDobDay || this.state.isFirstLoad) {
       // returns the DOB field title and the field selected
-      return (
-        LOCALIZE.authentication.createAccount.content.inputs.dobDayTitle +
-        LOCALIZE.ariaLabel.dobMonthField
-      );
+      return LOCALIZE.ariaLabel.dobMonthField;
     } else {
       // returns the DOB field title, the DOB error and the field selected
       return (
-        LOCALIZE.authentication.createAccount.content.inputs.dobDayTitle +
         LOCALIZE.authentication.createAccount.content.inputs.dobError +
         LOCALIZE.ariaLabel.dobMonthField
       );
@@ -274,14 +270,12 @@ class RegistrationForm extends Component {
     if (this.state.isValidDobDay || this.state.isFirstLoad) {
       // returns the DOB field title and the field selected
       return (
-        LOCALIZE.authentication.createAccount.content.inputs.dobDayTitle +
         LOCALIZE.authentication.createAccount.content.inputs.dobTooltip +
         LOCALIZE.ariaLabel.dobYearField
       );
     } else {
       // returns the DOB field title, the DOB error and the field selected
       return (
-        LOCALIZE.authentication.createAccount.content.inputs.dobDayTitle +
         LOCALIZE.authentication.createAccount.content.inputs.dobError +
         LOCALIZE.authentication.createAccount.content.inputs.dobTooltip +
         LOCALIZE.ariaLabel.dobYearField

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -283,6 +283,11 @@ class RegistrationForm extends Component {
     }
   };
 
+  // triggers DOB tooltip button click in order to show/hide the tooltip window
+  triggerDobTooltipClick = () => {
+    document.getElementById("dob-tooltip-button").click();
+  };
+
   // screen reader will read specific content depending on the following field conditions
   privacyNoticeAriaLabelCondition = () => {
     // Privacy Notice field is valid OR this is the first page load
@@ -620,7 +625,7 @@ class RegistrationForm extends Component {
                   <label>{LOCALIZE.authentication.createAccount.content.inputs.dobDayTitle}</label>
                   <span style={styles.mandatoryMark}>{MANDATORY_MARK}</span>
                   <OverlayTrigger
-                    trigger="focus"
+                    trigger="click"
                     placement="right"
                     overlay={
                       <Popover>
@@ -630,7 +635,13 @@ class RegistrationForm extends Component {
                       </Popover>
                     }
                   >
-                    <Button tabIndex="-1" style={styles.tooltipButton} variant="link">
+                    <Button
+                      id="dob-tooltip-button"
+                      tabIndex="-1"
+                      style={styles.tooltipButton}
+                      variant="link"
+                      onBlur={this.triggerDobTooltipClick}
+                    >
                       ?
                     </Button>
                   </OverlayTrigger>
@@ -664,6 +675,8 @@ class RegistrationForm extends Component {
                   value={dobYearContent}
                   style={styles.dobFields}
                   onChange={this.getDobYearContent}
+                  onFocus={this.triggerDobTooltipClick}
+                  onBlur={this.triggerDobTooltipClick}
                 />
                 {!(isValidDobDay && isValidDobMonth && isValidDobYear) && !isFirstLoad && (
                   <div>


### PR DESCRIPTION
# Description

This PR is introducing new DOB fields updates. These changes are related to David's comments. Here is a summary of the changes:

- Removed the DOB label from the aria-label of the month and year fields
- Updated tool tip display conditions (displayed on focus or on year field focus)
- Updated tool tip button style

## Type of change

- New feature (non-breaking change which adds functionality)
- Code cleanliness or refactor

## Screenshot

**Displays the tool tip on year field focus:**

![image](https://user-images.githubusercontent.com/23021242/59776733-4c4c0e00-9281-11e9-8c52-32e268fada4f.png)

**Hides the tool tip on year field blur:**

![image](https://user-images.githubusercontent.com/23021242/59776812-7271ae00-9281-11e9-963f-8d184eb245d3.png)

**Tool tip is also displayed on '?' focus (the same way it was before):**

![image](https://user-images.githubusercontent.com/23021242/59776886-93d29a00-9281-11e9-91e7-0ed27473dccb.png)

# Testing

Manual steps to reproduce this functionality:

1.  Open the registration form.
2.  Navigate using the keyboard and make sure that the tool tip is displayed on year field focus and hidden on year field blur.
3. Make also sure that the tool tip is displayed on '?' focus.
4. Launch NVDA and make sure that you can navigate easily around DOB fields using the keyboard and the screen reader.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
