### PR TITLE
[Accessibility] Adding password requirements inside a tool tip

### DIFF
--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -754,6 +754,62 @@ class RegistrationForm extends Component {
                     {LOCALIZE.authentication.createAccount.content.inputs.passwordTitle}
                   </label>
                   <span style={styles.mandatoryMark}>{MANDATORY_MARK}</span>
+                  <OverlayTrigger
+                    trigger="focus"
+                    placement="right"
+                    overlay={
+                      <Popover>
+                        <div>
+                          <p>
+                            {
+                              LOCALIZE.authentication.createAccount.content.inputs.passwordErrors
+                                .description
+                            }
+                          </p>
+                          <ul>
+                            <li>
+                              {
+                                LOCALIZE.authentication.createAccount.content.inputs.passwordErrors
+                                  .upperCase
+                              }
+                            </li>
+
+                            <li>
+                              {
+                                LOCALIZE.authentication.createAccount.content.inputs.passwordErrors
+                                  .lowerCase
+                              }
+                            </li>
+
+                            <li>
+                              {
+                                LOCALIZE.authentication.createAccount.content.inputs.passwordErrors
+                                  .digit
+                              }
+                            </li>
+
+                            <li>
+                              {
+                                LOCALIZE.authentication.createAccount.content.inputs.passwordErrors
+                                  .specialCharacter
+                              }
+                            </li>
+
+                            <li>
+                              {
+                                LOCALIZE.authentication.createAccount.content.inputs.passwordErrors
+                                  .length
+                              }
+                            </li>
+                          </ul>
+                        </div>
+                      </Popover>
+                    }
+                  >
+                    <Button tabIndex="-1" style={styles.tooltipButton} variant="link">
+                      ?
+                    </Button>
+                  </OverlayTrigger>
                 </div>
                 {isValidPassword && (
                   <FontAwesomeIcon style={styles.iconForOtherFields} icon={faCheckCircle} />


### PR DESCRIPTION
# Description

This PR is introducing the a new tool tip for the password. This tool tip is displaying the password requirements.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**Password Tool Tip:**

![image](https://user-images.githubusercontent.com/23021242/59778832-393b3d00-9285-11e9-8850-11c168848326.png)

# Testing

Manual steps to reproduce this functionality:

1.  Open the registration form.
2.  Make sure that you are able to see the password's tool tip when you click on '?'.

# Checklist

Applicable for all code changes.

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 11+ and Chrome
