### PR TITLE
[Accessibility] Focusing on highest registration form error field

### DIFF
--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -450,6 +450,7 @@ class RegistrationForm extends Component {
     );
   };
 
+  // analyses field by field and focus on the highest error field
   focusOnHighestErrorField = () => {
     if (!this.state.isValidFirstName) {
       document.getElementById("first-name-field").focus();

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -450,6 +450,30 @@ class RegistrationForm extends Component {
     );
   };
 
+  focusOnHighestErrorField = () => {
+    if (!this.state.isValidFirstName) {
+      document.getElementById("first-name-field").focus();
+    } else if (!this.state.isValidLastName) {
+      document.getElementById("last-name-field").focus();
+    } else if (!this.state.isValidDobDay) {
+      document.getElementById("dob-day-field").focus();
+    } else if (!this.state.isValidDobMonth) {
+      document.getElementById("dob-month-field").focus();
+    } else if (!this.state.isValidDobYear) {
+      document.getElementById("dob-year-field").focus();
+    } else if (!this.state.isValidEmail) {
+      document.getElementById("email-address-field").focus();
+    } else if (!this.state.isValidPriOrMilitaryNbr) {
+      document.getElementById("pri-or-military-nbr-field").focus();
+    } else if (!this.state.isValidPassword) {
+      document.getElementById("password-field").focus();
+    } else if (!this.state.isValidPasswordConfirmation) {
+      document.getElementById("password-confirmation-field").focus();
+    } else if (!this.state.isValidPrivacyNotice) {
+      document.getElementById("privacy-notice-checkbox").focus();
+    }
+  };
+
   handleSubmit = event => {
     const validForm = this.isFormValid();
     // if all fields are valid, execute API errors validation
@@ -509,6 +533,7 @@ class RegistrationForm extends Component {
         });
     } else {
       this.props.updateIsRegistrationFormValidState(false);
+      this.focusOnHighestErrorField();
     }
     event.preventDefault();
   };


### PR DESCRIPTION
# Description

This PR is introducing a new function called _focusOnHighestErrorField_. This function find the highest error field in registration form (if there is any) and focus on it.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**Initial View:**

![image](https://user-images.githubusercontent.com/23021242/59849540-ea011500-9335-11e9-88c4-7338100535bd.png)

**Error on _Last name_ and email fields:**

![image](https://user-images.githubusercontent.com/23021242/59849617-1f0d6780-9336-11e9-8101-07773b409ed6.png)

**As soon as I click on _Create account_ button, it focuses on the highest error field:**

![image](https://user-images.githubusercontent.com/23021242/59849651-3fd5bd00-9336-11e9-8ba3-4a1769ed20d6.png)

**Once fixed, if I click again on _Create account_ button, it focuses on the highest error field again:**

![image](https://user-images.githubusercontent.com/23021242/59849712-6dbb0180-9336-11e9-9f97-3ce4cb981586.png)

# Testing

Manual steps to reproduce this functionality:

1.  Open the registration form.
2.  Fill out the form, but put intentional errors.
3.  Click on _Create account_ button and make sure the it focuses on the highest error field.

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 11+ and Chrome
