### PR TITLE
[Test Content Definition - Background] Using markdown files for Background Content (2) 

### DIFF
--- a/frontend/src/components/eMIB/OrganizationalInformation.jsx
+++ b/frontend/src/components/eMIB/OrganizationalInformation.jsx
@@ -1,46 +1,42 @@
 import React, { Component } from "react";
-import LOCALIZE from "../../text_resources";
+import { connect } from "react-redux";
+import ReactMarkdown from "react-markdown";
+import markdown_en from "./markdown_files/OrganizationalInformation_en.md";
+import markdown_fr from "./markdown_files/OrganizationalInformation_fr.md";
 
 class OrganizationalInformation extends Component {
+  state = {
+    markdown_en: "",
+    markdown_fr: ""
+  };
+
+  // loads the markdown files (english and french versions)
+  componentWillMount = () => {
+    fetch(markdown_en)
+      .then(response => response.text())
+      .then(text => this.setState({ markdown_en: text }));
+    fetch(markdown_fr)
+      .then(response => response.text())
+      .then(text => this.setState({ markdown_fr: text }));
+  };
+
   render() {
     return (
       <div>
-        <div>
-          <h2>{LOCALIZE.emibTest.background.organizationalInformation.title}</h2>
-          <div>
-            <p>{LOCALIZE.emibTest.background.organizationalInformation.description}</p>
-          </div>
-          <section aria-labelledby="info-about-odc-priorities">
-            <h3 id="info-about-odc-priorities">
-              {LOCALIZE.emibTest.background.organizationalInformation.prioritiesSection.title}
-            </h3>
-            <ul>
-              <li>
-                {LOCALIZE.emibTest.background.organizationalInformation.prioritiesSection.bullet1}
-              </li>
-              <li>
-                {LOCALIZE.emibTest.background.organizationalInformation.prioritiesSection.bullet2}
-              </li>
-              <li>
-                {LOCALIZE.emibTest.background.organizationalInformation.prioritiesSection.bullet3}
-              </li>
-              <li>
-                {LOCALIZE.emibTest.background.organizationalInformation.prioritiesSection.bullet4}
-              </li>
-            </ul>
-          </section>
-          <section aria-labelledby="info-about-odc-risks">
-            <h3 id="info-about-odc-risks">
-              {LOCALIZE.emibTest.background.organizationalInformation.risksSection.title}
-            </h3>
-            <ul>
-              <li>{LOCALIZE.emibTest.background.organizationalInformation.risksSection.bullet1}</li>
-            </ul>
-          </section>
-        </div>
+        {this.props.language === "en" && <ReactMarkdown source={this.state.markdown_en} />}
+        {this.props.language === "fr" && <ReactMarkdown source={this.state.markdown_fr} />}
       </div>
     );
   }
 }
 
-export default OrganizationalInformation;
+const mapStateToProps = (state, ownProps) => {
+  return {
+    language: state.localize.language
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  null
+)(OrganizationalInformation);

--- a/frontend/src/components/eMIB/OrganizationalInformation.jsx
+++ b/frontend/src/components/eMIB/OrganizationalInformation.jsx
@@ -3,6 +3,7 @@ import { connect } from "react-redux";
 import ReactMarkdown from "react-markdown";
 import markdown_en from "./markdown_files/OrganizationalInformation_en.md";
 import markdown_fr from "./markdown_files/OrganizationalInformation_fr.md";
+import { LANGUAGES } from "../commons/Translation";
 
 class OrganizationalInformation extends Component {
   state = {
@@ -23,8 +24,12 @@ class OrganizationalInformation extends Component {
   render() {
     return (
       <div>
-        {this.props.language === "en" && <ReactMarkdown source={this.state.markdown_en} />}
-        {this.props.language === "fr" && <ReactMarkdown source={this.state.markdown_fr} />}
+        {this.props.language === LANGUAGES.english && (
+          <ReactMarkdown source={this.state.markdown_en} />
+        )}
+        {this.props.language === LANGUAGES.french && (
+          <ReactMarkdown source={this.state.markdown_fr} />
+        )}
       </div>
     );
   }

--- a/frontend/src/components/eMIB/markdown_files/OrganizationalInformation_en.md
+++ b/frontend/src/components/eMIB/markdown_files/OrganizationalInformation_en.md
@@ -1,0 +1,14 @@
+## Information about the Organizational Development Council (ODC)
+
+The ODC is an independent government agency that promotes organizational development across the public service. The ODC’s mandate is to provide training to all public service employees to maintain a productive and commendable workforce. The organization is responsible for: (1) the creation and evaluation of training programs; (2) research and innovation in learning, transfer of training, and technology; and (3) conducting audits on workplace behaviors in adherence to the ethical and professional standards of public service. With its headquarters located in the National Capital Region, the ODC currently employs approximately 100 individuals.
+
+### Priorities
+
+- To ensure that the organization continues to enhance productive workplace behaviors through policies of ethical and professional conduct.
+- To continuously evaluate the effectiveness and utility of training programs across the public service.
+- To deliver high-quality training programs across the public service, supporting the Government of Canada’s priorities.
+- To manage the documentation and communication of client training activities.
+
+### Risks
+
+- The scope and complexity of training programs pose ongoing challenges for (1) their timely delivery and effectiveness in responding to new and emerging policy priorities; (2) maintaining partnerships that are essential for high-quality training program development, delivery, and evaluation; (3) keeping pace with the evolving demands of clients and with new learning technology.

--- a/frontend/src/components/eMIB/markdown_files/OrganizationalInformation_fr.md
+++ b/frontend/src/components/eMIB/markdown_files/OrganizationalInformation_fr.md
@@ -1,0 +1,14 @@
+## Renseignements sur le Conseil du Développement Organisationnel (CDO)
+
+Le CDO est un organisme gouvernemental indépendant qui œuvre à la promotion du développement organisationnel au sein de la fonction publique. Le mandat du CDO est d’offrir de la formation à tous les employés de la fonction publique afin de maintenir une main-d’œuvre productive et digne d’éloges. L’organisme est responsable de : (1) la création et l’évaluation des programmes de formation; (2) la recherche et l’innovation dans les domaines de l’apprentissage, du transfert de formation et de la technologie; (3) la réalisation de vérifications en matière de comportements en milieu de travail, conformément aux normes d’éthique et de conduite professionnelle de la fonction publique. Le CDO, dont l’administration centrale est située dans la région de la capitale nationale, compte actuellement environ 100 employés.
+
+### Priorités
+
+- Veiller à ce que l’organisme continue d’améliorer les comportements productifs au travail par la mise en place de politiques en matière de comportement éthique et professionnel.
+- Évaluer de façon continue l’efficacité et l’utilité des programmes de formation au sein de la fonction publique.
+- Offrir à l’échelle de la fonction publique des programmes de qualité supérieure qui appuient les priorités du gouvernement du Canada.
+- Gérer la documentation et la communication des activités de formation des clients.
+
+### Risques
+
+- La portée et la complexité des programmes de formation posent des défis continuels quant à : (1) leur livraison dans les délais prévus et leur efficacité à répondre aux priorités stratégiques nouvelles ou émergentes; (2) le maintien de partenariats essentiels à l’élaboration, à la livraison et à l’évaluation de programmes de formation de haute qualité; (3) la capacité de suivre le rythme des demandes changeantes des clients et la nouvelle technologie d’apprentissage.

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -339,24 +339,7 @@ let LOCALIZE = new LocalizedStrings({
           title: "Background Information"
         },
         organizationalInformation: {
-          title: "Information about the Organizational Development Council (ODC)",
-          description:
-            "The ODC is an independent government agency that promotes organizational development across the public service. The ODC’s mandate is to provide training to all public service employees to maintain a productive and commendable workforce. The organization is responsible for: (1) the creation and evaluation of training programs; (2) research and innovation in learning, transfer of training, and technology; and (3) conducting audits on workplace behaviors in adherence to the ethical and professional standards of public service. With its headquarters located in the National Capital Region, the ODC currently employs approximately 100 individuals.",
-          prioritiesSection: {
-            title: "Priorities",
-            bullet1:
-              "To ensure that the organization continues to enhance productive workplace behaviors through policies of ethical and professional conduct.",
-            bullet2:
-              "To continuously evaluate the effectiveness and utility of training programs across the public service.",
-            bullet3:
-              "To deliver high-quality training programs across the public service, supporting the Government of Canada’s priorities.",
-            bullet4: "To manage the documentation and communication of client training activities."
-          },
-          risksSection: {
-            title: "Risks",
-            bullet1:
-              "The scope and complexity of training programs pose ongoing challenges for (1) their timely delivery and effectiveness in responding to new and emerging policy priorities; (2) maintaining partnerships that are essential for high-quality training program development, delivery, and evaluation; (3) keeping pace with the evolving demands of clients and with new learning technology."
-          }
+          title: "Information about the Organizational Development Council (ODC)"
         },
         organizationalStructure: {
           title: "Organizational Structure",
@@ -965,25 +948,7 @@ let LOCALIZE = new LocalizedStrings({
           title: "Contexte"
         },
         organizationalInformation: {
-          title: "Renseignements sur le Conseil du Développement Organisationnel  (CDO)",
-          description:
-            "Le CDO est un organisme gouvernemental indépendant qui œuvre à la promotion du développement organisationnel au sein de la fonction publique. Le mandat du CDO est d’offrir de la formation à tous les employés de la fonction publique afin de maintenir une main-d’œuvre productive et digne d’éloges. L’organisme est responsable de : (1) la création et l’évaluation des programmes de formation; (2) la recherche et l’innovation dans les domaines de l’apprentissage, du transfert de formation et de la technologie; (3) la réalisation de vérifications en matière de comportements en milieu de travail, conformément aux normes d’éthique et de conduite professionnelle de la fonction publique. Le CDO, dont l’administration centrale est située dans la région de la capitale nationale, compte actuellement environ 100 employés.",
-          prioritiesSection: {
-            title: "Priorités",
-            bullet1:
-              "Veiller à ce que l’organisme continue d’améliorer les comportements productifs au travail par la mise en place de politiques en matière de comportement éthique et professionnel.",
-            bullet2:
-              "Évaluer de façon continue l’efficacité et l’utilité des programmes de formation au sein de la fonction publique.",
-            bullet3:
-              "Offrir à l’échelle de la fonction publique des programmes de qualité supérieure qui appuient les priorités du gouvernement du Canada.",
-            bullet4:
-              "Gérer la documentation et la communication des activités de formation des clients."
-          },
-          risksSection: {
-            title: "Risques",
-            bullet1:
-              "La portée et la complexité des programmes de formation posent des défis continuels quant à : (1) leur livraison dans les délais prévus et leur efficacité à répondre aux priorités stratégiques nouvelles ou émergentes; (2) le maintien de partenariats essentiels à l’élaboration, à la livraison et à l’évaluation de programmes de formation de haute qualité; (3) la capacité de suivre le rythme des demandes changeantes des clients et la nouvelle technologie d’apprentissage."
-          }
+          title: "Renseignements sur le Conseil du Développement Organisationnel  (CDO)"
         },
         organizationalStructure: {
           title: "Structure organisationnelle",


### PR DESCRIPTION
# Description

This PR is introducing the usage of markdown files instead of LOCALIZE strings to populate the Information about the Organizational Development Council (ODC) part of the background content.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**Old Version - localize strings (EN):**

![image](https://user-images.githubusercontent.com/23021242/60122749-ddc0f180-9753-11e9-8f63-1a38631d04ef.png)

**Old Version - localize strings (FR):**

![image](https://user-images.githubusercontent.com/23021242/60122761-e44f6900-9753-11e9-9ba9-a7d1dc2f54c8.png)

**New Version - markdown files (EN):**

![image](https://user-images.githubusercontent.com/23021242/60122696-c3871380-9753-11e9-9be2-1be4bd45cc3d.png)

**New Version - markdown files (FR):**

![image](https://user-images.githubusercontent.com/23021242/60122709-caae2180-9753-11e9-82c1-c81db062d30e.png)

# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Launch the eMIB Sample Test.
2.  Start the test.
3.  Select the _Background_ tab.
4.  Make sure that you get the content when you select _Information about the Organizational Development Council (ODC)_ on the side navigation menu.

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 11+ and Chrome
