### PR TITLE
[Test Content Definition - Background] Using markdown files for Background Content (4)

### DIFF
--- a/frontend/src/components/eMIB/TeamInformation.jsx
+++ b/frontend/src/components/eMIB/TeamInformation.jsx
@@ -1,6 +1,9 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
+import ReactMarkdown from "react-markdown";
+import markdown_section1_en from "./sample_test_markdown/TeamInformation_section1_en.md";
+import markdown_section1_fr from "./sample_test_markdown/TeamInformation_section1_fr.md";
 import LOCALIZE from "../../text_resources";
 import { LANGUAGES } from "../commons/Translation";
 import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
@@ -29,7 +32,9 @@ class TeamInformation extends Component {
   };
 
   state = {
-    showPopupBox: false
+    showPopupBox: false,
+    markdown_section1_en: "",
+    markdown_section1_fr: ""
   };
 
   openPopup = () => {
@@ -38,6 +43,16 @@ class TeamInformation extends Component {
 
   closePopup = () => {
     this.setState({ showPopupBox: false });
+  };
+
+  // loads the markdown files (english and french versions)
+  componentWillMount = () => {
+    fetch(markdown_section1_en)
+      .then(response => response.text())
+      .then(text => this.setState({ markdown_section1_en: text }));
+    fetch(markdown_section1_fr)
+      .then(response => response.text())
+      .then(text => this.setState({ markdown_section1_fr: text }));
   };
 
   render() {
@@ -104,76 +119,56 @@ class TeamInformation extends Component {
           rightButtonTitle={LOCALIZE.commons.close}
         />
         <div>
-          <h2>{LOCALIZE.emibTest.background.teamInformation.title}</h2>
-          <section aria-labelledby="info-about-qa-team-members">
-            <h3 id="info-about-qa-team-members">
-              {LOCALIZE.emibTest.background.teamInformation.teamMembersSection.title}
-            </h3>
-            <div>
-              <section aria-labelledby="team-members-director">
-                <h4 id="team-members-director">
-                  {LOCALIZE.emibTest.background.teamInformation.teamMembersSection.para1Title}
-                </h4>
-                <p>{LOCALIZE.emibTest.background.teamInformation.teamMembersSection.para1}</p>
-              </section>
-              <section aria-labelledby="team-members-manager">
-                <h4 id="team-members-manager">
-                  {LOCALIZE.emibTest.background.teamInformation.teamMembersSection.para2Title}
-                </h4>
-                <p>{LOCALIZE.emibTest.background.teamInformation.teamMembersSection.para2}</p>
-              </section>
-              <section aria-labelledby="team-members-qa-analyst">
-                <h4 id="team-members-qa-analyst">
-                  {LOCALIZE.emibTest.background.teamInformation.teamMembersSection.para3Title}
-                </h4>
-                <p>{LOCALIZE.emibTest.background.teamInformation.teamMembersSection.para3}</p>
-              </section>
-            </div>
-            <div>
-              <p>
-                {currentLanguage === LANGUAGES.english && (
-                  <ImageZoom
-                    longdesc="#team-image-description"
-                    image={{
-                      src: emib_sample_test_example_team_chart_en,
-                      alt: LOCALIZE.emibTest.background.teamInformation.teamChart.desciption,
-                      style: styles.testImage,
-                      className: "ie-zoom-cursor"
-                    }}
-                    zoomImage={{
-                      src: emib_sample_test_example_team_chart_en_zoomed,
-                      alt: LOCALIZE.emibTest.background.teamInformation.teamChart.desciption,
-                      className: "ie-zoom-cursor"
-                    }}
-                  />
-                )}
-                {currentLanguage === LANGUAGES.french && (
-                  <ImageZoom
-                    longdesc="#team-image-description"
-                    image={{
-                      src: emib_sample_test_example_team_chart_fr,
-                      alt: LOCALIZE.emibTest.background.teamInformation.teamChart.desciption,
-                      style: styles.testImage,
-                      className: "ie-zoom-cursor"
-                    }}
-                    zoomImage={{
-                      src: emib_sample_test_example_team_chart_fr_zoomed,
-                      alt: LOCALIZE.emibTest.background.teamInformation.teamChart.desciption,
-                      className: "ie-zoom-cursor"
-                    }}
-                  />
-                )}
-              </p>
-              <button
-                id="team-image-description"
-                onClick={this.openPopup}
-                className="btn btn-secondary"
-                style={styles.button}
-              >
-                {LOCALIZE.emibTest.background.teamInformation.teamChart.link}
-              </button>
-            </div>
-          </section>
+          {this.props.currentLanguage === LANGUAGES.english && (
+            <ReactMarkdown source={this.state.markdown_section1_en} />
+          )}
+          {this.props.currentLanguage === LANGUAGES.french && (
+            <ReactMarkdown source={this.state.markdown_section1_fr} />
+          )}
+          <div>
+            <p>
+              {currentLanguage === LANGUAGES.english && (
+                <ImageZoom
+                  longdesc="#team-image-description"
+                  image={{
+                    src: emib_sample_test_example_team_chart_en,
+                    alt: LOCALIZE.emibTest.background.teamInformation.teamChart.desciption,
+                    style: styles.testImage,
+                    className: "ie-zoom-cursor"
+                  }}
+                  zoomImage={{
+                    src: emib_sample_test_example_team_chart_en_zoomed,
+                    alt: LOCALIZE.emibTest.background.teamInformation.teamChart.desciption,
+                    className: "ie-zoom-cursor"
+                  }}
+                />
+              )}
+              {currentLanguage === LANGUAGES.french && (
+                <ImageZoom
+                  longdesc="#team-image-description"
+                  image={{
+                    src: emib_sample_test_example_team_chart_fr,
+                    alt: LOCALIZE.emibTest.background.teamInformation.teamChart.desciption,
+                    style: styles.testImage,
+                    className: "ie-zoom-cursor"
+                  }}
+                  zoomImage={{
+                    src: emib_sample_test_example_team_chart_fr_zoomed,
+                    alt: LOCALIZE.emibTest.background.teamInformation.teamChart.desciption,
+                    className: "ie-zoom-cursor"
+                  }}
+                />
+              )}
+            </p>
+            <button
+              id="team-image-description"
+              onClick={this.openPopup}
+              className="btn btn-secondary"
+              style={styles.button}
+            >
+              {LOCALIZE.emibTest.background.teamInformation.teamChart.link}
+            </button>
+          </div>
           <section aria-labelledby="qa-team-responsabilities">
             <h3 id="qa-team-responsabilities">
               {LOCALIZE.emibTest.background.teamInformation.responsibilitiesSection.title}

--- a/frontend/src/components/eMIB/TeamInformation.jsx
+++ b/frontend/src/components/eMIB/TeamInformation.jsx
@@ -4,6 +4,8 @@ import { connect } from "react-redux";
 import ReactMarkdown from "react-markdown";
 import markdown_section1_en from "./sample_test_markdown/TeamInformation_section1_en.md";
 import markdown_section1_fr from "./sample_test_markdown/TeamInformation_section1_fr.md";
+import markdown_section2_en from "./sample_test_markdown/TeamInformation_section2_en.md";
+import markdown_section2_fr from "./sample_test_markdown/TeamInformation_section2_fr.md";
 import LOCALIZE from "../../text_resources";
 import { LANGUAGES } from "../commons/Translation";
 import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
@@ -34,7 +36,9 @@ class TeamInformation extends Component {
   state = {
     showPopupBox: false,
     markdown_section1_en: "",
-    markdown_section1_fr: ""
+    markdown_section1_fr: "",
+    markdown_section2_en: "",
+    markdown_section2_fr: ""
   };
 
   openPopup = () => {
@@ -53,6 +57,12 @@ class TeamInformation extends Component {
     fetch(markdown_section1_fr)
       .then(response => response.text())
       .then(text => this.setState({ markdown_section1_fr: text }));
+    fetch(markdown_section2_en)
+      .then(response => response.text())
+      .then(text => this.setState({ markdown_section2_en: text }));
+    fetch(markdown_section2_fr)
+      .then(response => response.text())
+      .then(text => this.setState({ markdown_section2_fr: text }));
   };
 
   render() {
@@ -169,54 +179,14 @@ class TeamInformation extends Component {
               {LOCALIZE.emibTest.background.teamInformation.teamChart.link}
             </button>
           </div>
-          <section aria-labelledby="qa-team-responsabilities">
-            <h3 id="qa-team-responsabilities">
-              {LOCALIZE.emibTest.background.teamInformation.responsibilitiesSection.title}
-            </h3>
-            <div>
-              <p>
-                {
-                  LOCALIZE.emibTest.background.teamInformation.responsibilitiesSection
-                    .listDescription
-                }
-              </p>
-              <ol>
-                <li>
-                  <span className="font-weight-bold">
-                    {
-                      LOCALIZE.emibTest.background.teamInformation.responsibilitiesSection
-                        .item1Title
-                    }
-                  </span>
-                  {LOCALIZE.emibTest.background.teamInformation.responsibilitiesSection.item1}
-                </li>
-                <li>
-                  <span className="font-weight-bold">
-                    {
-                      LOCALIZE.emibTest.background.teamInformation.responsibilitiesSection
-                        .item2Title
-                    }
-                  </span>
-                  {LOCALIZE.emibTest.background.teamInformation.responsibilitiesSection.item2}
-                </li>
-                <li>
-                  <span className="font-weight-bold">
-                    {
-                      LOCALIZE.emibTest.background.teamInformation.responsibilitiesSection
-                        .item3Title
-                    }
-                  </span>
-                  {LOCALIZE.emibTest.background.teamInformation.responsibilitiesSection.item3}
-                </li>
-              </ol>
-              <section aria-labelledby="qa-team-new-initiatives">
-                <h4 id="qa-team-new-initiatives">
-                  {LOCALIZE.emibTest.background.teamInformation.responsibilitiesSection.para1Title}
-                </h4>
-                <p>{LOCALIZE.emibTest.background.teamInformation.responsibilitiesSection.para1}</p>
-              </section>
-            </div>
-          </section>
+          <div>
+            {this.props.currentLanguage === LANGUAGES.english && (
+              <ReactMarkdown source={this.state.markdown_section2_en} />
+            )}
+            {this.props.currentLanguage === LANGUAGES.french && (
+              <ReactMarkdown source={this.state.markdown_section2_fr} />
+            )}
+          </div>
         </div>
       </div>
     );

--- a/frontend/src/components/eMIB/sample_test_markdown/TeamInformation_section1_en.md
+++ b/frontend/src/components/eMIB/sample_test_markdown/TeamInformation_section1_en.md
@@ -1,0 +1,15 @@
+## Information about the Quality Assurance (QA) Team
+
+### Team Members
+
+#### Director: Nancy Ward
+
+Your Director is Nancy Ward. The director of the Services and Communications unit applies policies and oversees the creation, delivery, and evaluation of training programs and audits. The director is also responsible for overseeing all internal and external communication channels including web content.
+
+#### Manager: Claude Huard (you)
+
+Your role as manager of the Quality Assurance Team is to oversee the content review and make final recommendations for training manuals, specifications, and other related training documents. The role also involves making staffing recommendations, managing the performance of team members, as well as coordinating the sharing of information and expertise with partners and stakeholders. The manager is also responsible for ensuring compliance to policy and professional standards and for delivering executive reports that include project updates, timelines, and budgetary implications.
+
+#### Quality Assurance Analysts
+
+The members of your team are Danny McBride, Serge Duplessis, Marina Richter, Mary Woodside, Charlie Wang, and Jack Laurier. All team members are Quality Assurance Analysts and, as such, are experts in documentation and make recommendations on training documents and online content.

--- a/frontend/src/components/eMIB/sample_test_markdown/TeamInformation_section1_fr.md
+++ b/frontend/src/components/eMIB/sample_test_markdown/TeamInformation_section1_fr.md
@@ -1,0 +1,15 @@
+## Information sur l’Équipe de l’assurance de la qualité (AQ)
+
+### Membres de l’équipe
+
+#### Directrice : Nancy Ward
+
+Votre directrice est Nancy Ward. La directrice de l’Unité des services et communications veille à l’application des politiques et supervise la création, l’exécution et l’évaluation des programmes de formation ainsi que les vérifications. Elle a également la responsabilité de superviser tous les canaux de communication internes et externes, y compris le contenu Web en ligne.
+
+#### Gestionnaire : Claude Huard (vous)
+
+Votre rôle en tant que gestionnaire de l’Équipe de l’assurance de la qualité est de superviser la révision de contenu et de formuler des recommandations finales au sujet des manuels de formation, des spécifications de formation et d’autres documents de formation connexes. Votre rôle consiste également à formuler des recommandations en matière de dotation, gérer le rendement des membres de l’équipe ainsi que coordonner l’échange d’information et d’expertise avec les partenaires et les intervenants. Le gestionnaire est également responsable d’assurer la conformité à la politique et aux normes professionnelles et de présenter aux cadres des rapports, lesquels comprennent des mises à jour, des échéanciers et les incidences budgétaires des projets.
+
+#### Analystes de l’assurance de la qualité
+
+Les membres de votre équipe sont Danny McBride, Serge Duplessis, Marina Richter, Mary Woodside, Charlie Wang et Jack Laurier. Tous les membres de l’équipe sont des analystes de l’assurance de la qualité et, par conséquent, des experts en documentation qui formulent des recommandations sur les documents de formation et le contenu en ligne.

--- a/frontend/src/components/eMIB/sample_test_markdown/TeamInformation_section2_en.md
+++ b/frontend/src/components/eMIB/sample_test_markdown/TeamInformation_section2_en.md
@@ -1,0 +1,11 @@
+### QA Team Responsibilities
+
+The Quality Assurance Team is responsible for:
+
+1. **Providing information management services.** Responsibilities include ensuring that organizational development training programs across the public service are well documented. This priority includes synthesizing a large volume of information from various government organizations, ensuring adherence to information security policies, and providing appropriate accessibility to archived documents.
+2. **Reviewing online content.** Responsibilities include reviewing a large volume of information regarding organizational training programs from various clients and partners, ensuring adherence to internal and external communications policies, and making recommendations to executives for final approval before information dissemination.
+3. **Reviewing training documentation.** Responsibilities include ensuring the completeness and quality of content in all organizational development training- related documents. This priority includes reviewing training instructions, scoring manuals, training specifications, statistical reports, and other training-related materials.
+
+#### New initiatives
+
+You have been mandated to make a recommendation on the adoption of an “off-the- shelf” online request processing system. The proposed system, called Serv, provides features that would facilitate the management of client and partner requests for content review and documentation services. This includes enhanced categorization and tracking of pending requests, customizable forms applications, and various report generators. The Information Technology (IT) Team of the ODC recently facilitated a pilot test with Serv that included Danny McBride, who is a member of the Quality Assurance Team. Danny came back with positive feedback on his experience with the Serv system. Your team has been discussing the proposal to introduce this new technology in hopes of improving your services.

--- a/frontend/src/components/eMIB/sample_test_markdown/TeamInformation_section2_fr.md
+++ b/frontend/src/components/eMIB/sample_test_markdown/TeamInformation_section2_fr.md
@@ -1,0 +1,11 @@
+### Responsabilités de l’Équipe de l’AQ
+
+L’Équipe de l’assurance de la qualité doit s’acquitter de ce qui suit :
+
+1. **Fournir des services de gestion de l’information.** L’équipe doit veiller à ce que les programmes en développement organisationnel au sein de la fonction publique soient bien documentés. Cette priorité comprend : synthétiser un grand volume de renseignements provenant de divers organismes gouvernementaux, s’assurer que les politiques sur la sécurité de l’information sont respectées et donner un accès approprié aux documents archivés.
+2. **Examiner le contenu en ligne.** Les responsabilités de l’équipe comprennent les suivantes : Examiner un grand volume d’information sur les programmes de formation organisationnels de divers clients et partenaires, s’assurer que les politiques sur les communications internes et les communications externes sont respectées et formuler des recommandations aux cadres supérieurs aux fins d’approbation définitive avant la diffusion de l’information.
+3. **Examiner les documents de formation.** L’équipe doit s’assurer de l’intégralité et de la qualité du contenu de tous les documents liés à la formation en développement organisationnel. Cette priorité inclut l’examen des instructions de formation, des guides de correction, des spécifications de la formation, des rapports statistiques et d’autres documents de formation connexes.
+
+#### Nouvelles initiatives
+
+Vous avez reçu le mandat de formuler une recommandation au sujet de l’adoption d’un système commercial de traitement des demandes en ligne. Le système proposé, appelé Serv, offre des fonctionnalités qui faciliteraient la gestion des demandes des clients et des partenaires qui cherchent à obtenir des services de révision du contenu et de gestion de la documentation. Cela inclut l’amélioration du processus de catégorisation et de suivi des demandes en attente, la personnalisation des formulaires de demande et divers générateurs de rapports. L’Équipe de la technologie de l’information (TI) du CDO a récemment fait un essai pilote de Serv auquel a participé Danny McBride, un des membres de l’Équipe de l’assurance de la qualité. Danny a donné des commentaires positifs sur son expérience avec le système Serv. Votre équipe discute actuellement de la proposition visant à introduire cette nouvelle technologie afin d’améliorer vos services.

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -370,18 +370,6 @@ let LOCALIZE = new LocalizedStrings({
         },
         teamInformation: {
           title: "Information about the Quality Assurance (QA) Team",
-          teamMembersSection: {
-            title: "Team Members",
-            para1Title: "Director: Nancy Ward",
-            para1:
-              "Your Director is Nancy Ward. The director of the Services and Communications unit applies policies and oversees the creation, delivery, and evaluation of training programs and audits. The director is also responsible for overseeing all internal and external communication channels including web content.",
-            para2Title: "Manager: Claude Huard (you)",
-            para2:
-              "Your role as manager of the Quality Assurance Team is to oversee the content review and make final recommendations for training manuals, specifications, and other related training documents. The role also involves making staffing recommendations, managing the performance of team members, as well as coordinating the sharing of information and expertise with partners and stakeholders. The manager is also responsible for ensuring compliance to policy and professional standards and for delivering executive reports that include project updates, timelines, and budgetary implications.",
-            para3Title: "Quality Assurance Analysts",
-            para3:
-              "The members of your team are Danny McBride, Serge Duplessis, Marina Richter, Mary Woodside, Charlie Wang, and Jack Laurier. All team members are Quality Assurance Analysts and, as such, are experts in documentation and make recommendations on training documents and online content."
-          },
           teamChart: {
             desciption: "Organizational Chart The Quality Assurance (QA) Team",
             link: "Image Description"
@@ -971,18 +959,6 @@ let LOCALIZE = new LocalizedStrings({
         },
         teamInformation: {
           title: "Information sur l’Équipe de l’assurance de la qualité (AQ)",
-          teamMembersSection: {
-            title: "Membres de l’équipe",
-            para1Title: "Directrice : Nancy Ward",
-            para1:
-              "Votre directrice est Nancy Ward. La directrice de l’Unité des services et communications veille à l’application des politiques et supervise la création, l’exécution et l’évaluation des programmes de formation ainsi que les vérifications. Elle a également la responsabilité de superviser tous les canaux de communication internes et externes, y compris le contenu Web en ligne.",
-            para2Title: "Gestionnaire : Claude Huard (vous)",
-            para2:
-              "Votre rôle en tant que gestionnaire de l’Équipe de l’assurance de la qualité est de superviser la révision de contenu et de formuler des recommandations finales au sujet des manuels de formation, des spécifications de formation et d’autres documents de formation connexes. Votre rôle consiste également à formuler des recommandations en matière de dotation, gérer le rendement des membres de l’équipe ainsi que coordonner l’échange d’information et d’expertise avec les partenaires et les intervenants. Le gestionnaire est également responsable d’assurer la conformité à la politique et aux normes professionnelles et de présenter aux cadres des rapports, lesquels comprennent des mises à jour, des échéanciers et les incidences budgétaires des projets.",
-            para3Title: "Analystes de l’assurance de la qualité",
-            para3:
-              "Les membres de votre équipe sont Danny McBride, Serge Duplessis, Marina Richter, Mary Woodside, Charlie Wang et Jack Laurier. Tous les membres de l’équipe sont des analystes de l’assurance de la qualité et, par conséquent, des experts en documentation qui formulent des recommandations sur les documents de formation et le contenu en ligne."
-          },
           teamChart: {
             desciption: "Organigramme Équipe de l'assurance de la qualité (AQ)",
             link: "Description de l'image"

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -383,22 +383,6 @@ let LOCALIZE = new LocalizedStrings({
             analyst4: "Mary Woodside - QA Analyst",
             analyst5: "Charlie Wang - QA Analyst",
             analyst6: "Jack Laurier - QA Analyst"
-          },
-          responsibilitiesSection: {
-            title: "QA Team Responsibilities",
-            listDescription: "The Quality Assurance Team is responsible for:",
-            item1Title: "Providing information management services. ",
-            item1:
-              "Responsibilities include ensuring that organizational development training programs across the public service are well documented. This priority includes synthesizing a large volume of information from various government organizations, ensuring adherence to information security policies, and providing appropriate accessibility to archived documents.",
-            item2Title: "Reviewing online content. ",
-            item2:
-              "Responsibilities include reviewing a large volume of information regarding organizational training programs from various clients and partners, ensuring adherence to internal and external communications policies, and making recommendations to executives for final approval before information dissemination.",
-            item3Title: "Reviewing training documentation. ",
-            item3:
-              "Responsibilities include ensuring the completeness and quality of content in all organizational development training- related documents. This priority includes reviewing training instructions, scoring manuals, training specifications, statistical reports, and other training-related materials.",
-            para1Title: "New initiatives",
-            para1:
-              "You have been mandated to make a recommendation on the adoption of an “off-the- shelf” online request processing system. The proposed system, called Serv, provides features that would facilitate the management of client and partner requests for content review and documentation services. This includes enhanced categorization and tracking of pending requests, customizable forms applications, and various report generators. The Information Technology (IT) Team of the ODC recently facilitated a pilot test with Serv that included Danny McBride, who is a member of the Quality Assurance Team. Danny came back with positive feedback on his experience with the Serv system. Your team has been discussing the proposal to introduce this new technology in hopes of improving your services."
           }
         }
       },
@@ -972,23 +956,6 @@ let LOCALIZE = new LocalizedStrings({
             analyst4: "Mary Woodside - Analyste de l’assurance de la qualité",
             analyst5: "Charlie Wang - Analyste de l’assurance de la qualité",
             analyst6: "Jack Laurier - Analyste de l’assurance de la qualité"
-          },
-          responsibilitiesSection: {
-            title: "Responsabilités de l’Équipe de l’AQ",
-            listDescription:
-              "L’Équipe de l’assurance de la qualité doit s’acquitter de ce qui suit :",
-            item1Title: "Fournir des services de gestion de l’information. ",
-            item1:
-              "L’équipe doit veiller à ce que les programmes en développement organisationnel au sein de la fonction publique soient bien documentés. Cette priorité comprend : synthétiser un grand volume de renseignements provenant de divers organismes gouvernementaux, s’assurer que les politiques sur la sécurité de l’information sont respectées et donner un accès approprié aux documents archivés.",
-            item2Title: "Examiner le contenu en ligne. ",
-            item2:
-              "Les responsabilités de l’équipe comprennent les suivantes : Examiner un grand volume d’information sur les programmes de formation organisationnels de divers clients et partenaires, s’assurer que les politiques sur les communications internes et les communications externes sont respectées et formuler des recommandations aux cadres supérieurs aux fins d’approbation définitive avant la diffusion de l’information.",
-            item3Title: "Examiner les documents de formation. ",
-            item3:
-              "L’équipe doit s’assurer de l’intégralité et de la qualité du contenu de tous les documents liés à la formation en développement organisationnel. Cette priorité inclut l’examen des instructions de formation, des guides de correction, des spécifications de la formation, des rapports statistiques et d’autres documents de formation connexes.",
-            para1Title: "Nouvelles initiatives",
-            para1:
-              "Vous avez reçu le mandat de formuler une recommandation au sujet de l’adoption d’un système commercial de traitement des demandes en ligne. Le système proposé, appelé Serv, offre des fonctionnalités qui faciliteraient la gestion des demandes des clients et des partenaires qui cherchent à obtenir des services de révision du contenu et de gestion de la documentation. Cela inclut l’amélioration du processus de catégorisation et de suivi des demandes en attente, la personnalisation des formulaires de demande et divers générateurs de rapports. L’Équipe de la technologie de l’information (TI) du CDO a récemment fait un essai pilote de Serv auquel a participé Danny McBride, un des membres de l’Équipe de l’assurance de la qualité. Danny a donné des commentaires positifs sur son expérience avec le système Serv. Votre équipe discute actuellement de la proposition visant à introduire cette nouvelle technologie afin d’améliorer vos services."
           }
         }
       },


### PR DESCRIPTION
# Description

This PR is introducing the usage of markdown files instead of LOCALIZE strings to populate the Information about the Information about the Quality Assurance (QA) Team part of the background content.

However, we still have to figure out how to introduce markdown files for the image description of this section.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

**Old Version - localize strings (EN):**

![image](https://user-images.githubusercontent.com/23021242/60187428-92fab480-97fb-11e9-9f11-c69e2ed7654f.png)

![image](https://user-images.githubusercontent.com/23021242/60187441-98f09580-97fb-11e9-882b-997a025903e7.png)

**Old Version - localize strings (FR):**

![image](https://user-images.githubusercontent.com/23021242/60187466-a279fd80-97fb-11e9-8081-64ce81a4557a.png)

![image](https://user-images.githubusercontent.com/23021242/60187483-a86fde80-97fb-11e9-83f0-1c6e25f129bc.png)

**New Version - markdown files (EN):**

![image](https://user-images.githubusercontent.com/23021242/60187318-6181e900-97fb-11e9-8464-614a667e35d8.png)

![image](https://user-images.githubusercontent.com/23021242/60187360-6e9ed800-97fb-11e9-8fbc-5e1374eb6e20.png)

**New Version - markdown files (FR):**

![image](https://user-images.githubusercontent.com/23021242/60187380-7bbbc700-97fb-11e9-8ff4-70c065fbde0b.png)

![image](https://user-images.githubusercontent.com/23021242/60187392-824a3e80-97fb-11e9-80f1-4734c64b5266.png)

# Testing

Manual steps to reproduce this functionality:

1.  Launch the eMIB Sample Test.
2.  Start the test.
3.  Select the _Background_ tab.
4.  Make sure that you get the content when you select Information about the Quality Assurance (QA) Team on the side navigation menu.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 11+ and Chrome
