### PR TITLE
[Accessiblity] Fix alt text for logo

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -134,7 +134,7 @@ class App extends Component {
               <Navbar bg="dark" variant="dark">
                 <Navbar.Brand>
                   <img
-                    alt=""
+                    alt={LOCALIZE.mainTabs.psc}
                     src={psc_logo_light}
                     width="370"
                     className="d-inline-block align-top"

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -9,7 +9,7 @@ let LOCALIZE = new LocalizedStrings({
       dashboardTabTitle: "Dashboard",
       sampleTest: "Sample eMIB",
       statusTabTitle: "Status",
-      psc: "Public Service Commission",
+      psc: "Public Service Commission of Canada",
       canada: "Government of Canada"
     },
 


### PR DESCRIPTION
# Description

Adding alt text to logo. See screenshots

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot
![image](https://user-images.githubusercontent.com/2746350/60201560-88014d80-9816-11e9-80e4-66a1cda42e43.png)
![image](https://user-images.githubusercontent.com/2746350/60201586-964f6980-9816-11e9-98e3-8011c597ca5c.png)


![image](https://user-images.githubusercontent.com/2746350/60201611-ab2bfd00-9816-11e9-8cd5-6a54a837befd.png)
![image](https://user-images.githubusercontent.com/2746350/60201631-b717bf00-9816-11e9-87f0-d1cb8de54904.png)


# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

1.  Look at the alt text for the in-test and out-of-test logos

# Checklist

Applicable for all code changes.

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 11+ and Chrome
