### PR TITLE
[Accessibility] Add sections for settings and privacy content

### DIFF
--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -1005,101 +1005,113 @@ class RegistrationForm extends Component {
           title={LOCALIZE.authentication.createAccount.privacyNoticeDialog.title}
           description={
             <div>
-              <h3>
-                {LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyNoticeStatement}
-              </h3>
-              <p>
-                {LOCALIZE.formatString(
-                  LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyParagraph1,
-                  <a
-                    href="https://laws-lois.justice.gc.ca/eng/acts/p-33.01/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {
-                      LOCALIZE.authentication.createAccount.privacyNoticeDialog
-                        .publicServiceEmploymentActLink
-                    }
-                  </a>,
-                  <a
-                    href="https://laws-lois.justice.gc.ca/eng/acts/P-21/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyActLink}
-                  </a>
-                )}
-              </p>
-              <p>
-                {LOCALIZE.formatString(
-                  LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyParagraph2,
-                  <a href="https://www.priv.gc.ca/en/" target="_blank" rel="noopener noreferrer">
-                    {
-                      LOCALIZE.authentication.createAccount.privacyNoticeDialog
-                        .privacyCommissionerLink
-                    }
-                  </a>
-                )}
-              </p>
-              <p>{LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyParagraph3}</p>
-              <p>
-                {LOCALIZE.formatString(
-                  LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyParagraph4,
-                  <a
-                    href="https://laws-lois.justice.gc.ca/eng/acts/P-21/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyActLink}
-                  </a>
-                )}
-              </p>
-              <p>{LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyParagraph5}</p>
-              <p>
-                {LOCALIZE.formatString(
-                  LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyParagraph6,
-                  <a
-                    href="https://www.canada.ca/en/public-service-commission/corporate/about-us/access-information-privacy-office.html"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {
-                      LOCALIZE.authentication.createAccount.privacyNoticeDialog
-                        .accessToInformationLink
-                    }
-                  </a>
-                )}
-              </p>
-              <p>
-                {LOCALIZE.formatString(
-                  LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyParagraph7,
-                  <a
-                    href="https://www.canada.ca/en/public-service-commission/corporate/about-us/access-information-privacy-office/info-source-sources-federal-government-employee-information.html"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {
-                      LOCALIZE.authentication.createAccount.privacyNoticeDialog
-                        .infoSourceChapterLink
-                    }
-                  </a>
-                )}
-              </p>
-              <p>
-                {LOCALIZE.formatString(
-                  LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyParagraph8,
-                  <a href="https://www.priv.gc.ca/en/" target="_blank" rel="noopener noreferrer">
-                    {
-                      LOCALIZE.authentication.createAccount.privacyNoticeDialog
-                        .privacyCommissionerLink
-                    }
-                  </a>
-                )}
-              </p>
-              <h3>{LOCALIZE.authentication.createAccount.privacyNoticeDialog.reproductionTitle}</h3>
-              <p>{LOCALIZE.authentication.createAccount.privacyNoticeDialog.reproductionWarning}</p>
-              <h3>{LOCALIZE.authentication.createAccount.privacyNoticeDialog.cheatingTitle}</h3>
-              <p>{LOCALIZE.authentication.createAccount.privacyNoticeDialog.cheatingWarning}</p>
+              <section aria-labelledby="privacy-notice-statement">
+                <h3 id="privacy-notice-statement">
+                  {LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyNoticeStatement}
+                </h3>
+                <p>
+                  {LOCALIZE.formatString(
+                    LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyParagraph1,
+                    <a
+                      href="https://laws-lois.justice.gc.ca/eng/acts/p-33.01/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {
+                        LOCALIZE.authentication.createAccount.privacyNoticeDialog
+                          .publicServiceEmploymentActLink
+                      }
+                    </a>,
+                    <a
+                      href="https://laws-lois.justice.gc.ca/eng/acts/P-21/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyActLink}
+                    </a>
+                  )}
+                </p>
+                <p>
+                  {LOCALIZE.formatString(
+                    LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyParagraph2,
+                    <a href="https://www.priv.gc.ca/en/" target="_blank" rel="noopener noreferrer">
+                      {
+                        LOCALIZE.authentication.createAccount.privacyNoticeDialog
+                          .privacyCommissionerLink
+                      }
+                    </a>
+                  )}
+                </p>
+                <p>{LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyParagraph3}</p>
+                <p>
+                  {LOCALIZE.formatString(
+                    LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyParagraph4,
+                    <a
+                      href="https://laws-lois.justice.gc.ca/eng/acts/P-21/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyActLink}
+                    </a>
+                  )}
+                </p>
+                <p>{LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyParagraph5}</p>
+                <p>
+                  {LOCALIZE.formatString(
+                    LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyParagraph6,
+                    <a
+                      href="https://www.canada.ca/en/public-service-commission/corporate/about-us/access-information-privacy-office.html"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {
+                        LOCALIZE.authentication.createAccount.privacyNoticeDialog
+                          .accessToInformationLink
+                      }
+                    </a>
+                  )}
+                </p>
+                <p>
+                  {LOCALIZE.formatString(
+                    LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyParagraph7,
+                    <a
+                      href="https://www.canada.ca/en/public-service-commission/corporate/about-us/access-information-privacy-office/info-source-sources-federal-government-employee-information.html"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {
+                        LOCALIZE.authentication.createAccount.privacyNoticeDialog
+                          .infoSourceChapterLink
+                      }
+                    </a>
+                  )}
+                </p>
+                <p>
+                  {LOCALIZE.formatString(
+                    LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyParagraph8,
+                    <a href="https://www.priv.gc.ca/en/" target="_blank" rel="noopener noreferrer">
+                      {
+                        LOCALIZE.authentication.createAccount.privacyNoticeDialog
+                          .privacyCommissionerLink
+                      }
+                    </a>
+                  )}
+                </p>
+              </section>
+              <section aria-labelledby="reproduction-notice">
+                <h3 id="reproduction-notice">
+                  {LOCALIZE.authentication.createAccount.privacyNoticeDialog.reproductionTitle}
+                </h3>
+                <p>
+                  {LOCALIZE.authentication.createAccount.privacyNoticeDialog.reproductionWarning}
+                </p>
+              </section>
+              <section aria-labelledby="cheating-notice">
+                <h3 id="cheating-notice">
+                  {LOCALIZE.authentication.createAccount.privacyNoticeDialog.cheatingTitle}
+                </h3>
+                <p>{LOCALIZE.authentication.createAccount.privacyNoticeDialog.cheatingWarning}</p>
+              </section>
             </div>
           }
           rightButtonType={BUTTON_TYPE.primary}

--- a/frontend/src/components/commons/Settings.jsx
+++ b/frontend/src/components/commons/Settings.jsx
@@ -42,47 +42,55 @@ class Settings extends Component {
           title={LOCALIZE.settings.systemSettings}
           description={
             <div>
-              <h3>{LOCALIZE.settings.zoom.title}</h3>
-              <ol>
-                <li>{LOCALIZE.settings.zoom.instructionsListItem1}</li>
-                <li>{LOCALIZE.settings.zoom.instructionsListItem2}</li>
-                <li>{LOCALIZE.settings.zoom.instructionsListItem3}</li>
-                <li>{LOCALIZE.settings.zoom.instructionsListItem4}</li>
-              </ol>
-              <h3>{LOCALIZE.settings.textSize.title}</h3>
-              <ol>
-                <li>{LOCALIZE.settings.textSize.instructionsListItem1}</li>
-                <li>{LOCALIZE.settings.textSize.instructionsListItem2}</li>
-                <li>{LOCALIZE.settings.textSize.instructionsListItem3}</li>
-              </ol>
-              {LOCALIZE.settings.textSize.notChanged}
-              <ol>
-                <li>{LOCALIZE.settings.textSize.instructionsListItem4}</li>
-                <li>{LOCALIZE.settings.textSize.instructionsListItem5}</li>
-                <li>{LOCALIZE.settings.textSize.instructionsListItem6}</li>
-              </ol>
-              <h3>{LOCALIZE.settings.fontStyle.title}</h3>
-              <ol>
-                <li>{LOCALIZE.settings.fontStyle.instructionsListItem1}</li>
-                <li>{LOCALIZE.settings.fontStyle.instructionsListItem2}</li>
-                <li>{LOCALIZE.settings.fontStyle.instructionsListItem3}</li>
-                <li>{LOCALIZE.settings.fontStyle.instructionsListItem4}</li>
-                <li>{LOCALIZE.settings.fontStyle.instructionsListItem5}</li>
-                <li>{LOCALIZE.settings.fontStyle.instructionsListItem6}</li>
-                <li>{LOCALIZE.settings.fontStyle.instructionsListItem7}</li>
-                <li>{LOCALIZE.settings.fontStyle.instructionsListItem8}</li>
-              </ol>
-              <h3>{LOCALIZE.settings.color.title}</h3>
-              <ol>
-                <li>{LOCALIZE.settings.color.instructionsListItem1}</li>
-                <li>{LOCALIZE.settings.color.instructionsListItem2}</li>
-                <li>{LOCALIZE.settings.color.instructionsListItem3}</li>
-                <li>{LOCALIZE.settings.color.instructionsListItem4}</li>
-                <li>{LOCALIZE.settings.color.instructionsListItem5}</li>
-                <li>{LOCALIZE.settings.color.instructionsListItem6}</li>
-                <li>{LOCALIZE.settings.color.instructionsListItem7}</li>
-                <li>{LOCALIZE.settings.color.instructionsListItem8}</li>
-              </ol>
+              <section aria-labelledby="zoom-instructions">
+                <h3 id="zoom-instructions">{LOCALIZE.settings.zoom.title}</h3>
+                <ol>
+                  <li>{LOCALIZE.settings.zoom.instructionsListItem1}</li>
+                  <li>{LOCALIZE.settings.zoom.instructionsListItem2}</li>
+                  <li>{LOCALIZE.settings.zoom.instructionsListItem3}</li>
+                  <li>{LOCALIZE.settings.zoom.instructionsListItem4}</li>
+                </ol>
+              </section>
+              <section aria-labelledby="text-size-instructions">
+                <h3 id="text-size-instructions">{LOCALIZE.settings.textSize.title}</h3>
+                <ol>
+                  <li>{LOCALIZE.settings.textSize.instructionsListItem1}</li>
+                  <li>{LOCALIZE.settings.textSize.instructionsListItem2}</li>
+                  <li>{LOCALIZE.settings.textSize.instructionsListItem3}</li>
+                </ol>
+                {LOCALIZE.settings.textSize.notChanged}
+                <ol>
+                  <li>{LOCALIZE.settings.textSize.instructionsListItem4}</li>
+                  <li>{LOCALIZE.settings.textSize.instructionsListItem5}</li>
+                  <li>{LOCALIZE.settings.textSize.instructionsListItem6}</li>
+                </ol>
+              </section>
+              <section aria-labelledby="font-instructions">
+                <h3 id="font-instructions">{LOCALIZE.settings.fontStyle.title}</h3>
+                <ol>
+                  <li>{LOCALIZE.settings.fontStyle.instructionsListItem1}</li>
+                  <li>{LOCALIZE.settings.fontStyle.instructionsListItem2}</li>
+                  <li>{LOCALIZE.settings.fontStyle.instructionsListItem3}</li>
+                  <li>{LOCALIZE.settings.fontStyle.instructionsListItem4}</li>
+                  <li>{LOCALIZE.settings.fontStyle.instructionsListItem5}</li>
+                  <li>{LOCALIZE.settings.fontStyle.instructionsListItem6}</li>
+                  <li>{LOCALIZE.settings.fontStyle.instructionsListItem7}</li>
+                  <li>{LOCALIZE.settings.fontStyle.instructionsListItem8}</li>
+                </ol>
+              </section>
+              <section aria-labelledby="color-instructions">
+                <h3 id="color-instructions">{LOCALIZE.settings.color.title}</h3>
+                <ol>
+                  <li>{LOCALIZE.settings.color.instructionsListItem1}</li>
+                  <li>{LOCALIZE.settings.color.instructionsListItem2}</li>
+                  <li>{LOCALIZE.settings.color.instructionsListItem3}</li>
+                  <li>{LOCALIZE.settings.color.instructionsListItem4}</li>
+                  <li>{LOCALIZE.settings.color.instructionsListItem5}</li>
+                  <li>{LOCALIZE.settings.color.instructionsListItem6}</li>
+                  <li>{LOCALIZE.settings.color.instructionsListItem7}</li>
+                  <li>{LOCALIZE.settings.color.instructionsListItem8}</li>
+                </ol>
+              </section>
             </div>
           }
           rightButtonType={BUTTON_TYPE.primary}


### PR DESCRIPTION
# Description

Recommendation from @fnormand01 in previous PR
Add sections around long content like in the privacy notice and settings dialog.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Testing
Manual steps to reproduce this functionality:

1.  View settings or privacy notice with a screen reader and skip content.

# Checklist

Applicable for all code changes.

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
~~- [ ] My changes look good on IE 11+ and Chrome~~
