### PR TITLE
[Content update] Convert okay buttons to close buttons

### DIFF
--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -1103,7 +1103,7 @@ class RegistrationForm extends Component {
             </div>
           }
           rightButtonType={BUTTON_TYPE.primary}
-          rightButtonTitle={LOCALIZE.commons.ok}
+          rightButtonTitle={LOCALIZE.commons.close}
           rightButtonAction={this.closePrivacyNoticePopup}
         />
       </div>

--- a/frontend/src/components/commons/Settings.jsx
+++ b/frontend/src/components/commons/Settings.jsx
@@ -86,7 +86,7 @@ class Settings extends Component {
             </div>
           }
           rightButtonType={BUTTON_TYPE.primary}
-          rightButtonTitle={LOCALIZE.commons.ok}
+          rightButtonTitle={LOCALIZE.commons.close}
           rightButtonAction={this.toggleDialog}
         />
       </div>


### PR DESCRIPTION
# Description

Change text to close dialogs from okay to close on the privacy and settings dialogs.

## Type of change
- Bug fix (non-breaking change which fixes an issue

## Screenshot

<img width="739" alt="Screen Shot 2019-06-26 at 8 24 24 PM" src="https://user-images.githubusercontent.com/4640747/60224486-9ec49600-9850-11e9-84bc-7feb217fe97f.png">
<img width="724" alt="Screen Shot 2019-06-26 at 8 24 35 PM" src="https://user-images.githubusercontent.com/4640747/60224487-9ec49600-9850-11e9-813a-bde6426338bb.png">

