### PR TITLE
[Content update/bug fix] Quit test dialog

### DIFF
--- a/frontend/src/components/commons/QuitTest.jsx
+++ b/frontend/src/components/commons/QuitTest.jsx
@@ -4,7 +4,6 @@ import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { Button } from "react-bootstrap";
 import PopupBox, { BUTTON_TYPE, BUTTON_STATE } from "../commons/PopupBox";
-import SystemMessage, { MESSAGE_TYPE } from "../commons/SystemMessage";
 import LOCALIZE from "../../text_resources";
 import { deactivateTest } from "../../modules/TestStatusRedux";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -95,16 +94,7 @@ class QuitTest extends Component {
               title={LOCALIZE.emibTest.testFooter.quitTestPopupBox.title}
               description={
                 <div>
-                  <div>
-                    <SystemMessage
-                      messageType={MESSAGE_TYPE.error}
-                      title={LOCALIZE.emibTest.testFooter.quitTestPopupBox.warning.title}
-                      message={LOCALIZE.emibTest.testFooter.quitTestPopupBox.warning.message}
-                    />
-                  </div>
-                  <p className="font-weight-bold">
-                    {LOCALIZE.emibTest.testFooter.quitTestPopupBox.descriptionPart1}
-                  </p>
+                  <p>{LOCALIZE.emibTest.testFooter.quitTestPopupBox.description}</p>
                   <div>
                     {this.state.quitConditions.map((condition, id) => {
                       return (
@@ -127,13 +117,6 @@ class QuitTest extends Component {
                       );
                     })}
                   </div>
-                  <hr style={styles.hr} />
-                  <p className="font-weight-bold">
-                    {LOCALIZE.emibTest.testFooter.quitTestPopupBox.descriptionPart2}
-                  </p>
-                  <p className="font-weight-bold">
-                    {LOCALIZE.emibTest.testFooter.quitTestPopupBox.descriptionPart3}
-                  </p>
                 </div>
               }
               leftButtonType={BUTTON_TYPE.danger}

--- a/frontend/src/components/commons/QuitTest.jsx
+++ b/frontend/src/components/commons/QuitTest.jsx
@@ -54,7 +54,9 @@ class QuitTest extends Component {
   };
 
   openQuitPopup = () => {
+    // Ensure language state is reset.
     this.setState({ quitConditions: quitConditions() });
+    // Open the dialog.
     this.setState({ showQuitPopup: true });
   };
 

--- a/frontend/src/components/commons/QuitTest.jsx
+++ b/frontend/src/components/commons/QuitTest.jsx
@@ -54,6 +54,7 @@ class QuitTest extends Component {
   };
 
   openQuitPopup = () => {
+    this.setState({ quitConditions: quitConditions() });
     this.setState({ showQuitPopup: true });
   };
 

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -494,20 +494,12 @@ let LOCALIZE = new LocalizedStrings({
         },
         quitTestPopupBox: {
           title: "Are you sure you want to quit this test?",
-          warning: {
-            title: "Warning! Once you exit the test, you will not be able to get back in.",
-            message:
-              "You will not be able to recover your answers, and will be withdrawn from this test session. You may be retested at a later time."
-          },
-          descriptionPart1:
-            "You are about to withdraw from this test. By proceeding, you acknowledge the following:",
+          description:
+            "All answers will be deleted. You will not be able to recover your answers, and will forfeit from this assessment. To quit, you must acknowledge the following:",
           checkboxOne: "I voluntarily withdraw from this examination",
           checkboxTwo: "My test will not be scored",
           checkboxThree:
-            "I am aware that the retest period for this test may apply, should I wish to write this test again",
-          descriptionPart2:
-            "If you are certain that you want to quit this session, click the “Quit test” button. You will be exited out of this test session and provided instructions to complete your withdrawal.",
-          descriptionPart3: "Are you sure you want to quit this test?"
+            "I am aware that the retest period for this test may apply, should I wish to write this test again"
         }
       }
     },
@@ -1075,21 +1067,12 @@ let LOCALIZE = new LocalizedStrings({
         },
         quitTestPopupBox: {
           title: "Souhaitez-vous mettre fin à cette séance de test?",
-          warning: {
-            title:
-              "Avertissement : une fois la séance de test terminée, vous ne pourrez plus y retourner.",
-            message:
-              "Vous ne pourrez pas récupérer vos réponses et n’aurez plus accès à la séance de test. Vous pourrez reprendre le test à une date ultérieure."
-          },
-          descriptionPart1:
-            "Vous êtes sur le point de mettre fin à la séance de test. Ce faisant, vous affirmez et reconnaissez :",
+          description:
+            "Vous ne pourrez pas récupérer vos réponses et n’aurez plus accès à la séance de test. Ce faisant, vous affirmez et reconnaissez :",
           checkboxOne: "Je me retire volontairement de ce test;",
           checkboxTwo: "Mon test ne sera pas noté;",
           checkboxThree:
-            "Je suis conscient(e) que la période d'attente pour ce test peut s’appliquer, si je veux écrire ce test de nouveau dans le futur.",
-          descriptionPart2:
-            "Si vous êtes certain(e) de vouloir mettre fin à cette séance, cliquez sur le bouton « Quitter la séance test ». La séance de test sera fermée et vous recevrez des instructions sur la façon de vous retirer.",
-          descriptionPart3: "Souhaitez-vous mettre fin à cette séance de test?"
+            "Je suis conscient(e) que la période d'attente pour ce test peut s’appliquer, si je veux écrire ce test de nouveau dans le futur."
         }
       }
     },


### PR DESCRIPTION
# Description

- Content update on the quit test dialog.
- Bug fix: Go to the test in english, open quit test dialog, close it, switch languages, notice the checkboxes are still in english.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

<img width="685" alt="Screen Shot 2019-06-26 at 9 26 53 PM" src="https://user-images.githubusercontent.com/4640747/60227421-447e0200-985d-11e9-81e6-8aaefc747b41.png">
<img width="675" alt="Screen Shot 2019-06-26 at 9 27 01 PM" src="https://user-images.githubusercontent.com/4640747/60227422-447e0200-985d-11e9-9e88-47eb64e9b589.png">


# Testing

Manual steps to reproduce this functionality:

1.  Go to the sample test and open the quit dialog in both languages.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on ~~IE 11+~~ and Chrome
