### PR TITLE
[Accessibility; Notepad] Adding aria-placeholder to notepad

### DIFF
--- a/frontend/src/components/commons/Notepad.jsx
+++ b/frontend/src/components/commons/Notepad.jsx
@@ -122,6 +122,7 @@ class Notepad extends Component {
             <div style={styles.notepadSection}>
               <TextareaAutosize
                 id="text-area-notepad"
+                aria-placeholder={LOCALIZE.commons.notepad.placeholder}
                 maxLength="3000"
                 className="text-area"
                 style={styles.textArea}


### PR DESCRIPTION
# Description

Adding aria-placeholder to the notepad

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

English:
![image](https://user-images.githubusercontent.com/2746350/60267704-d23b0b00-98b8-11e9-8962-4e21cf0f1978.png)

French:
![image](https://user-images.githubusercontent.com/2746350/60267731-e41cae00-98b8-11e9-9d90-a79bf3e114af.png)



# Testing

See screenshots

# Checklist

Applicable for all code changes.

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
