### PR TITLE
[Accessibility] Switching from banner to presentation

### DIFF
--- a/frontend/src/components/commons/ContentContainer.jsx
+++ b/frontend/src/components/commons/ContentContainer.jsx
@@ -19,7 +19,9 @@ const styles = {
 const ContentContainer = props => {
   return (
     <div role="main">
-      {!props.hideBanner && <img role="banner" src={mini_banner} alt="" style={styles.banner} />}
+      {!props.hideBanner && (
+        <img role="presentation" src={mini_banner} alt="" style={styles.banner} />
+      )}
       <div style={styles.container}>{props.children}</div>
     </div>
   );


### PR DESCRIPTION
# Description

Changing image role from banner to presentation.
Based on a few resources:

- role=presentation is supported in all major browsers, JAWS, NVDA, and IE 11
- role=none is supported by JAWS and most major browsers (but not NVDA or IE 11)
- Narrator in Windows supports none of the above.

Resources:
https://codepen.io/stevef/post/none-or-presentation
https://github.com/w3c/aria-practices/issues/515
 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

![image](https://user-images.githubusercontent.com/2746350/60273700-ac1b6800-98c4-11e9-83d1-7bdcab0d4a99.png)

# Testing

Look at the image role in the dev tools

# Checklist

Applicable for all code changes.

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
