### PR TITLE
[Accessibility] Remove hr from dialogs and replace with styling

### DIFF
--- a/frontend/src/components/commons/PopupBox.jsx
+++ b/frontend/src/components/commons/PopupBox.jsx
@@ -34,7 +34,9 @@ const styles = {
   contentPadding: {
     padding: "10px 15px",
     overflow: "auto",
-    maxHeight: "calc(100vh - 300px)"
+    maxHeight: "calc(100vh - 300px)",
+    borderBottom: "1px solid #CECECE",
+    borderTop: "1px solid #CECECE"
   },
   headerPadding: {
     padding: "15px 15px 5px 15px"
@@ -129,13 +131,9 @@ class PopupBox extends Component {
           <h2 id="modal-heading">{title}</h2>
         </div>
 
-        <hr style={styles.hr} />
-
         <div id="modal-description" style={styles.contentPadding}>
           {description}
         </div>
-
-        <hr style={styles.hr} />
 
         <div style={styles.footerPadding}>
           {leftButtonTitle && leftButtonType && (

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -56,7 +56,9 @@ const styles = {
     maxHeight: "calc(100vh - 300px)",
     overflow: "auto",
     width: 700,
-    padding: "10px 15px"
+    padding: "10px 15px",
+    borderBottom: "1px solid #CECECE",
+    borderTop: "1px solid #CECECE"
   },
   footer: {
     padding: 15,
@@ -238,8 +240,6 @@ class EditActionDialog extends Component {
             />
           )}
         </div>
-
-        <hr style={styles.hr} />
 
         <div style={styles.footer}>
           <button className={"btn btn-danger"} onClick={this.handleClose}>


### PR DESCRIPTION
# Description

Hrs are read out by screen readers as "blank" - this is really annoying. We should replace them with CSS borders. This PR does that for our dialogs.

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Screenshot

![image](https://user-images.githubusercontent.com/4640747/60280413-e1c64e00-98d0-11e9-8512-85c0a8a46194.png)


# Testing

Manual steps to reproduce this functionality:

1.  Open any dialog on the site with a screen reader.

# Checklist

Applicable for all code changes.

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
