### PR TITLE
[Accessibility] Remove underline from reply replyall forward

### DIFF
--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -50,7 +50,6 @@ const styles = {
     },
     radioTextSelected: {
       fontWeight: "bold",
-      textDecoration: "underline",
       cursor: "pointer",
       paddingRight: 20,
       color: "#00565E"


### PR DESCRIPTION
# Description

Remove underline from radio button text because it's not a link and causes problems for accessibility.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

<img width="442" alt="Screen Shot 2019-06-28 at 9 21 42 AM" src="https://user-images.githubusercontent.com/4640747/60345091-34ae0d00-9986-11e9-8030-b0abe856fd05.png">


# Testing

Applicable for all code changes.

Manual steps to reproduce this functionality:

# Checklist

Applicable for all code changes.

- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on ~~IE 11+~~ and Chrome
