### PR TITLE
[Accessibility] H tags should be in number order

### DIFF
--- a/frontend/src/components/authentication/LoginForm.jsx
+++ b/frontend/src/components/authentication/LoginForm.jsx
@@ -98,7 +98,7 @@ class LoginForm extends Component {
         {!this.props.authenticated && (
           <div role="form">
             <div style={styles.loginContent}>
-              <h3>{LOCALIZE.authentication.login.content.title}</h3>
+              <h2>{LOCALIZE.authentication.login.content.title}</h2>
               <span>{LOCALIZE.authentication.login.content.description}</span>
               <form onSubmit={this.handleSubmit}>
                 <div>

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -581,7 +581,7 @@ class RegistrationForm extends Component {
       <div>
         <div role="form">
           <div style={styles.createAccountContent}>
-            <h3>{LOCALIZE.authentication.createAccount.content.title}</h3>
+            <h2>{LOCALIZE.authentication.createAccount.content.title}</h2>
             <span>{LOCALIZE.authentication.createAccount.content.description}</span>
             <form onSubmit={this.handleSubmit}>
               <div className="names-grid">

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -1006,9 +1006,9 @@ class RegistrationForm extends Component {
           description={
             <div>
               <section aria-labelledby="privacy-notice-statement">
-                <h3 id="privacy-notice-statement">
+                <h2 id="privacy-notice-statement">
                   {LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyNoticeStatement}
-                </h3>
+                </h2>
                 <p>
                   {LOCALIZE.formatString(
                     LOCALIZE.authentication.createAccount.privacyNoticeDialog.privacyParagraph1,
@@ -1099,17 +1099,17 @@ class RegistrationForm extends Component {
                 </p>
               </section>
               <section aria-labelledby="reproduction-notice">
-                <h3 id="reproduction-notice">
+                <h2 id="reproduction-notice">
                   {LOCALIZE.authentication.createAccount.privacyNoticeDialog.reproductionTitle}
-                </h3>
+                </h2>
                 <p>
                   {LOCALIZE.authentication.createAccount.privacyNoticeDialog.reproductionWarning}
                 </p>
               </section>
               <section aria-labelledby="cheating-notice">
-                <h3 id="cheating-notice">
+                <h2 id="cheating-notice">
                   {LOCALIZE.authentication.createAccount.privacyNoticeDialog.cheatingTitle}
-                </h3>
+                </h2>
                 <p>{LOCALIZE.authentication.createAccount.privacyNoticeDialog.cheatingWarning}</p>
               </section>
             </div>

--- a/frontend/src/components/commons/PopupBox.jsx
+++ b/frontend/src/components/commons/PopupBox.jsx
@@ -128,7 +128,7 @@ class PopupBox extends Component {
         ariaHideApp={ariaHideApp}
       >
         <div style={styles.headerPadding}>
-          <h2 id="modal-heading">{title}</h2>
+          <h1 id="modal-heading">{title}</h1>
         </div>
 
         <div id="modal-description" style={styles.contentPadding}>

--- a/frontend/src/components/commons/Settings.jsx
+++ b/frontend/src/components/commons/Settings.jsx
@@ -43,7 +43,7 @@ class Settings extends Component {
           description={
             <div>
               <section aria-labelledby="zoom-instructions">
-                <h3 id="zoom-instructions">{LOCALIZE.settings.zoom.title}</h3>
+                <h2 id="zoom-instructions">{LOCALIZE.settings.zoom.title}</h2>
                 <ol>
                   <li>{LOCALIZE.settings.zoom.instructionsListItem1}</li>
                   <li>{LOCALIZE.settings.zoom.instructionsListItem2}</li>
@@ -52,7 +52,7 @@ class Settings extends Component {
                 </ol>
               </section>
               <section aria-labelledby="text-size-instructions">
-                <h3 id="text-size-instructions">{LOCALIZE.settings.textSize.title}</h3>
+                <h2 id="text-size-instructions">{LOCALIZE.settings.textSize.title}</h2>
                 <ol>
                   <li>{LOCALIZE.settings.textSize.instructionsListItem1}</li>
                   <li>{LOCALIZE.settings.textSize.instructionsListItem2}</li>
@@ -66,7 +66,7 @@ class Settings extends Component {
                 </ol>
               </section>
               <section aria-labelledby="font-instructions">
-                <h3 id="font-instructions">{LOCALIZE.settings.fontStyle.title}</h3>
+                <h2 id="font-instructions">{LOCALIZE.settings.fontStyle.title}</h2>
                 <ol>
                   <li>{LOCALIZE.settings.fontStyle.instructionsListItem1}</li>
                   <li>{LOCALIZE.settings.fontStyle.instructionsListItem2}</li>
@@ -79,7 +79,7 @@ class Settings extends Component {
                 </ol>
               </section>
               <section aria-labelledby="color-instructions">
-                <h3 id="color-instructions">{LOCALIZE.settings.color.title}</h3>
+                <h2 id="color-instructions">{LOCALIZE.settings.color.title}</h2>
                 <ol>
                   <li>{LOCALIZE.settings.color.instructionsListItem1}</li>
                   <li>{LOCALIZE.settings.color.instructionsListItem2}</li>

--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -197,23 +197,23 @@ class EditActionDialog extends Component {
         {actionType === ACTION_TYPE.email && (
           <div style={styles.header}>
             <FontAwesomeIcon style={styles.icon} icon={faEnvelope} />
-            <h2 style={styles.title}>
+            <h1 style={styles.title}>
               {editMode === EDIT_MODE.create &&
                 LOCALIZE.emibTest.inboxPage.editActionDialog.addEmail}
               {editMode === EDIT_MODE.update &&
                 LOCALIZE.emibTest.inboxPage.editActionDialog.editEmail}
-            </h2>
+            </h1>
           </div>
         )}
         {actionType === ACTION_TYPE.task && (
           <div style={styles.header}>
             <FontAwesomeIcon style={styles.icon} icon={faTasks} />
-            <h2 style={styles.title}>
+            <h1 style={styles.title}>
               {editMode === EDIT_MODE.create &&
                 LOCALIZE.emibTest.inboxPage.editActionDialog.addTask}
               {editMode === EDIT_MODE.update &&
                 LOCALIZE.emibTest.inboxPage.editActionDialog.editTask}
-            </h2>
+            </h1>
           </div>
         )}
 
@@ -223,8 +223,7 @@ class EditActionDialog extends Component {
             body={<EmailContent email={this.props.email} />}
             iconType={ICON_TYPE.email}
           />
-          <hr style={styles.dataBodyDivider} />
-          <h4>{LOCALIZE.emibTest.inboxPage.emailCommons.yourResponse}</h4>
+          <h2>{LOCALIZE.emibTest.inboxPage.emailCommons.yourResponse}</h2>
           {actionType === ACTION_TYPE.email && (
             <EditEmail
               onChange={this.editAction}

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -86,9 +86,6 @@ const styles = {
     textAlign: "right",
     paddingRight: 12
   },
-  hr: {
-    margin: "12px 0px"
-  },
   reasonsForAction: {
     textArea: {
       padding: "6px 12px",
@@ -351,7 +348,6 @@ class EditEmail extends Component {
               </div>
             </div>
           </div>
-          <hr style={styles.hr} />
           <div>
             <div className="font-weight-bold form-group">
               <label htmlFor="reasons-for-action-text-area">

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -22,13 +22,6 @@ const styles = {
     textAlign: "right",
     paddingRight: 12
   },
-  hrOne: {
-    margin: "12px 12px 12px 0",
-    borderColor: "#00565E"
-  },
-  hrTwo: {
-    margin: "12px 12px 12px 0"
-  },
   tasks: {
     title: {
       float: "left",
@@ -103,7 +96,6 @@ class EditTask extends Component {
     return (
       <div style={styles.container}>
         <form>
-          <hr style={styles.hrOne} />
           <div>
             <div className="font-weight-bold form-group">
               <label htmlFor="your-tasks-text-area" style={styles.tasks.title}>
@@ -151,7 +143,6 @@ class EditTask extends Component {
               </div>
             </div>
           </div>
-          <hr style={styles.hrTwo} />
           <div>
             <div className="font-weight-bold form-group">
               <label htmlFor="reasons-for-action-text-area" style={styles.reasonsForAction.title}>


### PR DESCRIPTION
# Description

Fix h tags on the home page, login and accounts, and dialogs. There should always be a h1, and numbers should not be skipped.

This does change the appearance of some areas of our application because H1 is bigger than H2.

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Screenshot

<img width="1106" alt="Screen Shot 2019-06-28 at 9 47 18 AM" src="https://user-images.githubusercontent.com/4640747/60346759-d5ea9280-9989-11e9-8d4c-e008d8131f92.png">
<img width="681" alt="Screen Shot 2019-06-28 at 9 47 33 AM" src="https://user-images.githubusercontent.com/4640747/60346768-da16b000-9989-11e9-88cb-28ad294d8fea.png">
<img width="659" alt="Screen Shot 2019-06-28 at 9 47 56 AM" src="https://user-images.githubusercontent.com/4640747/60346778-dedb6400-9989-11e9-8204-e5f005757586.png">


# Testing

Manual steps to reproduce this functionality:

1.  Go to home page and notice headings with a screen reader.
2.  Open dialogs and notice headings with a screen reader.

# Checklist

Applicable for all code changes.

- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on ~~IE 11+~~ and Chrome
