### PR TITLE
[WIP Bug Fix] Edit/Delete button order (Option 1)

### DIFF
--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -163,19 +163,19 @@ class ActionViewEmail extends Component {
             <hr style={styles.hr} />
             <div aria-label={LOCALIZE.ariaLabel.emailOptions}>
               <button
+                id="unit-test-view-email-delete-button"
+                className="btn btn-danger"
+                onClick={this.showDeleteConfirmationDialog}
+              >
+                {LOCALIZE.emibTest.inboxPage.emailCommons.deleteButton}
+              </button>
+              <button
                 id="unit-test-view-email-edit-button"
                 className="btn btn-primary"
                 style={styles.editButton}
                 onClick={this.showEmailDialog}
               >
                 {LOCALIZE.emibTest.inboxPage.emailCommons.editButton}
-              </button>
-              <button
-                id="unit-test-view-email-delete-button"
-                className="btn btn-danger"
-                onClick={this.showDeleteConfirmationDialog}
-              >
-                {LOCALIZE.emibTest.inboxPage.emailCommons.deleteButton}
               </button>
               <PopupBox
                 show={this.state.showDeleteConfirmationDialog}

--- a/frontend/src/components/eMIB/ActionViewTask.jsx
+++ b/frontend/src/components/eMIB/ActionViewTask.jsx
@@ -77,19 +77,19 @@ class ActionViewTask extends Component {
             <hr style={styles.hr} />
             <div aria-label={LOCALIZE.ariaLabel.taskOptions}>
               <button
+                id="unit-test-view-task-delete-button"
+                className="btn btn-danger"
+                onClick={this.showDeleteConfirmationDialog}
+              >
+                {LOCALIZE.emibTest.inboxPage.emailCommons.deleteButton}
+              </button>
+              <button
                 id="unit-test-view-task-edit-button"
                 className="btn btn-primary"
                 style={styles.editButton}
                 onClick={this.showTaskDialog}
               >
                 {LOCALIZE.emibTest.inboxPage.emailCommons.editButton}
-              </button>
-              <button
-                id="unit-test-view-task-delete-button"
-                className="btn btn-danger"
-                onClick={this.showDeleteConfirmationDialog}
-              >
-                {LOCALIZE.emibTest.inboxPage.emailCommons.deleteButton}
               </button>
               <PopupBox
                 show={this.state.showDeleteConfirmationDialog}


### PR DESCRIPTION
# Description

Option 1 to fix the ordering of the buttons in the ActionViews: Change the tab order

Currently tabbing through the options jumps from top of view -> edit button (on the right) -> delete button (on the left)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

Selection order using tab key:
Top of expandible view
![image](https://user-images.githubusercontent.com/2746350/60666332-c90bea00-9e34-11e9-90f6-a75e5be895b6.png)

Delete button
![image](https://user-images.githubusercontent.com/2746350/60666359-d88b3300-9e34-11e9-9531-68d5328189a8.png)

Edit button
![image](https://user-images.githubusercontent.com/2746350/60666406-f9538880-9e34-11e9-992d-e170d4f9fbd9.png)


# Testing

Save an email/task
Tab through the buttons in the view

# Checklist

Applicable for all code changes.

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
