### PR TITLE
[WIP Bug Fix] Edit/Delete button order (Option 2)

### DIFF
--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -165,7 +165,6 @@ class ActionViewEmail extends Component {
               <button
                 id="unit-test-view-email-edit-button"
                 className="btn btn-primary"
-                style={styles.editButton}
                 onClick={this.showEmailDialog}
               >
                 {LOCALIZE.emibTest.inboxPage.emailCommons.editButton}
@@ -173,6 +172,7 @@ class ActionViewEmail extends Component {
               <button
                 id="unit-test-view-email-delete-button"
                 className="btn btn-danger"
+                style={styles.editButton}
                 onClick={this.showDeleteConfirmationDialog}
               >
                 {LOCALIZE.emibTest.inboxPage.emailCommons.deleteButton}

--- a/frontend/src/components/eMIB/ActionViewTask.jsx
+++ b/frontend/src/components/eMIB/ActionViewTask.jsx
@@ -79,7 +79,6 @@ class ActionViewTask extends Component {
               <button
                 id="unit-test-view-task-edit-button"
                 className="btn btn-primary"
-                style={styles.editButton}
                 onClick={this.showTaskDialog}
               >
                 {LOCALIZE.emibTest.inboxPage.emailCommons.editButton}
@@ -87,6 +86,7 @@ class ActionViewTask extends Component {
               <button
                 id="unit-test-view-task-delete-button"
                 className="btn btn-danger"
+                style={styles.editButton}
                 onClick={this.showDeleteConfirmationDialog}
               >
                 {LOCALIZE.emibTest.inboxPage.emailCommons.deleteButton}


### PR DESCRIPTION
# Description

Option 1 to fix the ordering of the buttons in the ActionViews: Change the button locations

Currently tabbing through the options jumps from top of view -> edit button (on the right) -> delete button (on the left)

NOTE: in this PR, edit is tabbed to first, but the buttons are the reverse of the usual location (for cancel/delete/quit vs save/edit)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

Selection order using tab key:
Top of expandible view
![image](https://user-images.githubusercontent.com/2746350/60667608-ee4e2780-9e37-11e9-89d5-692d62edcda1.png)

Edit button
![image](https://user-images.githubusercontent.com/2746350/60667593-df677500-9e37-11e9-8e99-b83845c4c174.png)

Delete button
![image](https://user-images.githubusercontent.com/2746350/60667634-fc03ad00-9e37-11e9-8a74-b5de1b9d9c31.png)


# Testing

Save an email/task
Tab through the buttons in the view

# Checklist

Applicable for all code changes.

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
