### PR TITLE
[Accessibility Patch] Adding aria-labels to image description buttons

### DIFF
--- a/frontend/src/components/eMIB/OrganizationalStructure.jsx
+++ b/frontend/src/components/eMIB/OrganizationalStructure.jsx
@@ -197,6 +197,7 @@ class OrganizationalStructure extends Component {
               onClick={this.openPopup}
               className="btn btn-secondary"
               style={styles.button}
+              aria-label={LOCALIZE.emibTest.background.organizationalStructure.orgChart.ariaLabel}
             >
               {LOCALIZE.emibTest.background.organizationalStructure.orgChart.link}
             </button>

--- a/frontend/src/components/eMIB/TeamInformation.jsx
+++ b/frontend/src/components/eMIB/TeamInformation.jsx
@@ -172,6 +172,7 @@ class TeamInformation extends Component {
               onClick={this.openPopup}
               className="btn btn-secondary"
               style={styles.button}
+              aria-label={LOCALIZE.emibTest.background.teamInformation.teamChart.ariaLabel}
             >
               {LOCALIZE.emibTest.background.teamInformation.teamChart.link}
             </button>

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -341,7 +341,8 @@ let LOCALIZE = new LocalizedStrings({
           title: "Organizational Structure",
           orgChart: {
             desciption: "Organizational Chart (ODC)",
-            link: "Image Description"
+            link: "Image Description",
+            ariaLabel: "Image description of Organizational Chart (ODC)"
           },
           dialog: {
             title: "The Organizational Chart of the ODC",
@@ -363,7 +364,8 @@ let LOCALIZE = new LocalizedStrings({
           title: "Your team",
           teamChart: {
             desciption: "Organizational Chart The Quality Assurance (QA) Team",
-            link: "Image Description"
+            link: "Image Description",
+            ariaLabel: "Image description of Organizational Chart The Quality Assurance (QA) Team"
           },
           dialog: {
             title: "The Organizational Chart of the QA Team",
@@ -919,7 +921,8 @@ let LOCALIZE = new LocalizedStrings({
           title: "Structure organisationnelle",
           orgChart: {
             desciption: "Organigramme (CDO)",
-            link: "Description de l'image"
+            link: "Description de l'image",
+            ariaLabel: "FR Description de l'image de l'Organigramme (CDO)"
           },
           dialog: {
             title: "Organigramme (CDO)",
@@ -941,7 +944,9 @@ let LOCALIZE = new LocalizedStrings({
           title: "FR Your team",
           teamChart: {
             desciption: "Organigramme Équipe de l'assurance de la qualité (AQ)",
-            link: "Description de l'image"
+            link: "Description de l'image",
+            ariaLabel:
+              "FR Description de l'image de l'Organigramme Équipe de l'assurance de la qualité (AQ)"
           },
           dialog: {
             title: "Organigramme Équipe de l'assurance de la qualité (AQ)",


### PR DESCRIPTION
# Description

PR to add aria-labels to the image descriptions
Note: I prefixed the French translations with FR, since I was guessing at the translation.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Screenshot
EN OCD Chart:
![image](https://user-images.githubusercontent.com/2746350/60681807-9ecf2200-9e5e-11e9-9b07-c81b52e5d843.png)

FR OCD Chart
![image](https://user-images.githubusercontent.com/2746350/60681833-b27a8880-9e5e-11e9-9010-792d9fffa65b.png)

EN QA Chart
![image](https://user-images.githubusercontent.com/2746350/60681893-e9509e80-9e5e-11e9-8296-9dbd06a27c5f.png)

FR QA Chart
![image](https://user-images.githubusercontent.com/2746350/60681875-db028280-9e5e-11e9-9e55-8b958a23558a.png)

# Testing

Open NVDA
Enter the eMIB sample
Tab to the Image Descriptions buttons in the background tabs

# Checklist

Applicable for all code changes.

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
