### PR TITLE
[Bug Fix] Fix error when editing empty email/task

### DIFF
--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -109,10 +109,18 @@ class EditEmail extends Component {
 
   state = {
     emailType: !this.props.action ? EMAIL_TYPE.reply : this.props.action.emailType,
-    emailBody: !this.props.action ? "" : this.props.action.emailBody,
+    emailBody: !this.props.action
+      ? ""
+      : !this.props.action.emailBody
+      ? ""
+      : this.props.action.emailBody,
     emailTo: !this.props.action ? [] : this.props.action.emailTo,
     emailCc: !this.props.action ? [] : this.props.action.emailCc,
-    reasonsForAction: !this.props.action ? "" : this.props.action.reasonsForAction,
+    reasonsForAction: !this.props.action
+      ? ""
+      : !this.props.action.reasonsForAction
+      ? ""
+      : this.props.action.reasonsForAction,
     // Provided by redux
     addressBook: PropTypes.arrayOf(addressBookContactShape)
   };

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -69,8 +69,12 @@ const styles = {
 
 class EditTask extends Component {
   state = {
-    task: !this.props.action ? "" : this.props.action.task,
-    reasonsForAction: !this.props.action ? "" : this.props.action.reasonsForAction
+    task: !this.props.action ? "" : !this.props.action.task ? "" : this.props.action.task,
+    reasonsForAction: !this.props.action
+      ? ""
+      : !this.props.action.reasonsForAction
+      ? ""
+      : this.props.action.reasonsForAction
   };
 
   static propTypes = {

--- a/frontend/src/tests/components/eMIB/EditTask.test.js
+++ b/frontend/src/tests/components/eMIB/EditTask.test.js
@@ -43,4 +43,15 @@ describe("char counts", () => {
     );
     expect(wrapper.find("#unit-test-task-rfa").text()).toEqual("11/650");
   });
+
+  it("renders and displays char count of 0 when undefined", () => {
+    const wrapper = shallow(
+      <EditTask
+        onChange={() => {}}
+        action={{ actionType: ACTION_TYPE.task, reasonsForAction: undefined, task: undefined }}
+      />
+    );
+    expect(wrapper.find("#unit-test-task-response").text()).toEqual("0/650");
+    expect(wrapper.find("#unit-test-task-rfa").text()).toEqual("0/650");
+  });
 });


### PR DESCRIPTION
# Description

If a new email/task is created and saved (without any edits), when it is opened for editing, an error is thrown. This adds logic in state to default to an empty string when not defined.

This fixes:

- Email's emailBody
- Email's reasonsForAction
- Task's task
- Task's reasonsForAction

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot
### Path to trigger error:

#### Create new task (or email); save without making any changes
![image](https://user-images.githubusercontent.com/2746350/60818531-d2b28c00-a16b-11e9-9e29-53120d52777e.png)

#### Edit new task/email
![image](https://user-images.githubusercontent.com/2746350/60818574-e9f17980-a16b-11e9-8a75-af8db9b7225a.png)

#### Edit Task Dialog
##### Before the fix; error
![image](https://user-images.githubusercontent.com/2746350/60818618-ff66a380-a16b-11e9-89c9-83895a77081b.png)

##### After the fix; dialog opens as expected
![image](https://user-images.githubusercontent.com/2746350/60818653-0db4bf80-a16c-11e9-983c-0ea180509657.png)

# Testing

See screenshots

# Checklist

Applicable for all code changes.

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
