### PR TITLE
[Accessible Org Charts] Collapsed Tree Nodes

### DIFF
--- a/frontend/src/components/commons/TreeNode.jsx
+++ b/frontend/src/components/commons/TreeNode.jsx
@@ -49,7 +49,7 @@ class TreeNode extends Component {
       }
 
       if (node.groups) {
-        node.expanded = true;
+        node.expanded = false;
       }
 
       //TODO auto generate:


### PR DESCRIPTION
# Description

Changes behavior of tree nodes to be collapsed by default; seems to fix issues David caught

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

![image](https://user-images.githubusercontent.com/2746350/60893478-fd194d80-a22e-11e9-99b8-ab1d969b5b95.png)

![image](https://user-images.githubusercontent.com/2746350/60893502-05718880-a22f-11e9-973a-aea3cb794484.png)


# Testing

Interact with either org chart, see that the tree noded work as expected

# Checklist

Applicable for all code changes.

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
