### PR TITLE
Frontend redux refactor to reduce API calls

### DIFF
--- a/frontend/src/components/eMIB/BackgroundInformation.jsx
+++ b/frontend/src/components/eMIB/BackgroundInformation.jsx
@@ -1,42 +1,24 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { bindActionCreators } from "redux";
 import ReactMarkdown from "react-markdown";
-import { getTestContent } from "../../modules/LoadTestContentRedux";
-import { TEST_DEFINITION } from "../../testDefinition";
 import { LANGUAGES } from "../../modules/LocalizeRedux";
 
 class BackgroundInformation extends Component {
   static propTypes = {
     // Provided by Redux
-    getTestContent: PropTypes.func
-  };
-
-  state = {
-    markdown_en: "",
-    markdown_fr: ""
-  };
-
-  // loads the markdown content (english and french versions)
-  componentWillMount = () => {
-    this.props.getTestContent(TEST_DEFINITION.emib.sampleTest).then(response => {
-      // saving the background information markdown content in local states
-      this.setState({
-        markdown_en: response.background.en.background[0].markdown[0].text,
-        markdown_fr: response.background.fr.background[0].markdown[0].text
-      });
-    });
+    testBackground: PropTypes.object,
+    language: PropTypes.string
   };
 
   render() {
     return (
       <div>
         {this.props.language === LANGUAGES.english && (
-          <ReactMarkdown source={this.state.markdown_en} />
+          <ReactMarkdown source={this.props.testBackground.en.background[0].markdown[0].text} />
         )}
         {this.props.language === LANGUAGES.french && (
-          <ReactMarkdown source={this.state.markdown_fr} />
+          <ReactMarkdown source={this.props.testBackground.fr.background[0].markdown[0].text} />
         )}
       </div>
     );
@@ -45,19 +27,12 @@ class BackgroundInformation extends Component {
 
 const mapStateToProps = (state, ownProps) => {
   return {
-    language: state.localize.language
+    language: state.localize.language,
+    testBackground: state.loadTestContent.testBackground
   };
 };
 
-const mapDispatchToProps = dispatch =>
-  bindActionCreators(
-    {
-      getTestContent
-    },
-    dispatch
-  );
-
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  null
 )(BackgroundInformation);

--- a/frontend/src/components/eMIB/BackgroundInformation.jsx
+++ b/frontend/src/components/eMIB/BackgroundInformation.jsx
@@ -12,13 +12,14 @@ class BackgroundInformation extends Component {
   };
 
   render() {
+    const { testBackground, language } = this.props;
     return (
       <div>
-        {this.props.language === LANGUAGES.english && (
-          <ReactMarkdown source={this.props.testBackground.en.background[0].markdown[0].text} />
+        {language === LANGUAGES.english && (
+          <ReactMarkdown source={testBackground.en.background[0].markdown[0].text} />
         )}
-        {this.props.language === LANGUAGES.french && (
-          <ReactMarkdown source={this.props.testBackground.fr.background[0].markdown[0].text} />
+        {language === LANGUAGES.french && (
+          <ReactMarkdown source={testBackground.fr.background[0].markdown[0].text} />
         )}
       </div>
     );

--- a/frontend/src/components/eMIB/BackgroundInformation.jsx
+++ b/frontend/src/components/eMIB/BackgroundInformation.jsx
@@ -3,14 +3,14 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import ReactMarkdown from "react-markdown";
-import { getTestQuestions } from "../../modules/LoadTestContentRedux";
+import { getTestContent } from "../../modules/LoadTestContentRedux";
 import { TEST_DEFINITION } from "../../testDefinition";
 import { LANGUAGES } from "../../modules/LocalizeRedux";
 
 class BackgroundInformation extends Component {
   static propTypes = {
     // Provided by Redux
-    getTestQuestions: PropTypes.func
+    getTestContent: PropTypes.func
   };
 
   state = {
@@ -20,7 +20,7 @@ class BackgroundInformation extends Component {
 
   // loads the markdown content (english and french versions)
   componentWillMount = () => {
-    this.props.getTestQuestions(TEST_DEFINITION.emib.sampleTest).then(response => {
+    this.props.getTestContent(TEST_DEFINITION.emib.sampleTest).then(response => {
       // saving the background information markdown content in local states
       this.setState({
         markdown_en: response.background.en.background[0].markdown[0].text,
@@ -52,7 +52,7 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
-      getTestQuestions
+      getTestContent
     },
     dispatch
   );

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -17,7 +17,7 @@ import {
   updateEmailsFrState,
   updateEmailsState
 } from "../../modules/EmibInboxRedux";
-import { getTestQuestions } from "../../modules/LoadTestContentRedux";
+import { getTestContent, updateTestBackgroundState } from "../../modules/LoadTestContentRedux";
 import { TEST_DEFINITION } from "../../testDefinition";
 import QuitConfirmation from "../commons/QuitConfirmation";
 
@@ -30,7 +30,8 @@ class Emib extends Component {
     updateEmailsEnState: PropTypes.func,
     updateEmailsFrState: PropTypes.func,
     updateEmailsState: PropTypes.func,
-    getTestQuestions: PropTypes.func
+    getTestContent: PropTypes.func,
+    updateTestQuestionsState: PropTypes.func
   };
 
   state = {
@@ -45,13 +46,18 @@ class Emib extends Component {
   loading test questions from the APIs on test start */
   handleStartTest = () => {
     // getting questions of the sample test from the api
-    this.props.getTestQuestions(TEST_DEFINITION.emib.sampleTest).then(response => {
+    this.props.getTestContent(TEST_DEFINITION.emib.sampleTest).then(response => {
+      // Load emails.
       // TODO: default language is English for now, but we'll need to put the landing page selected language here instead
       this.props.updateEmailsState(response.questions.en.email);
       // saving questions content in emails, emailsEN and emailsFR states
       this.props.updateEmailsEnState(response.questions.en.email);
       this.props.updateEmailsFrState(response.questions.fr.email);
 
+      // Load background info.
+      this.props.updateTestBackgroundState(response.background);
+
+      // Update state.
       this.setState({ testIsStarted: true, disabledTabs: [], currentTab: "background" });
     });
   };
@@ -151,7 +157,8 @@ const mapDispatchToProps = dispatch =>
       updateEmailsEnState,
       updateEmailsFrState,
       updateEmailsState,
-      getTestQuestions
+      getTestContent,
+      updateTestBackgroundState
     },
     dispatch
   );

--- a/frontend/src/components/eMIB/OrganizationalInformation.jsx
+++ b/frontend/src/components/eMIB/OrganizationalInformation.jsx
@@ -1,42 +1,25 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { bindActionCreators } from "redux";
 import ReactMarkdown from "react-markdown";
-import { getTestContent } from "../../modules/LoadTestContentRedux";
-import { TEST_DEFINITION } from "../../testDefinition";
 import { LANGUAGES } from "../../modules/LocalizeRedux";
 
 class OrganizationalInformation extends Component {
   static propTypes = {
     // Provided by Redux
-    getTestContent: PropTypes.func
-  };
-
-  state = {
-    markdown_en: "",
-    markdown_fr: ""
-  };
-
-  // loads the markdown content (english and french versions)
-  componentWillMount = () => {
-    this.props.getTestContent(TEST_DEFINITION.emib.sampleTest).then(response => {
-      // saving the organizational information markdown content in local states
-      this.setState({
-        markdown_en: response.background.en.background[0].markdown[1].text,
-        markdown_fr: response.background.fr.background[0].markdown[1].text
-      });
-    });
+    testBackground: PropTypes.object,
+    language: PropTypes.string
   };
 
   render() {
+    const { testBackground, language } = this.props;
     return (
       <div>
-        {this.props.language === LANGUAGES.english && (
-          <ReactMarkdown source={this.state.markdown_en} />
+        {language === LANGUAGES.english && (
+          <ReactMarkdown source={testBackground.en.background[0].markdown[1].text} />
         )}
-        {this.props.language === LANGUAGES.french && (
-          <ReactMarkdown source={this.state.markdown_fr} />
+        {language === LANGUAGES.french && (
+          <ReactMarkdown source={testBackground.fr.background[0].markdown[1].text} />
         )}
       </div>
     );
@@ -45,19 +28,12 @@ class OrganizationalInformation extends Component {
 
 const mapStateToProps = (state, ownProps) => {
   return {
-    language: state.localize.language
+    language: state.localize.language,
+    testBackground: state.loadTestContent.testBackground
   };
 };
 
-const mapDispatchToProps = dispatch =>
-  bindActionCreators(
-    {
-      getTestContent
-    },
-    dispatch
-  );
-
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  null
 )(OrganizationalInformation);

--- a/frontend/src/components/eMIB/OrganizationalInformation.jsx
+++ b/frontend/src/components/eMIB/OrganizationalInformation.jsx
@@ -3,14 +3,14 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import ReactMarkdown from "react-markdown";
-import { getTestQuestions } from "../../modules/LoadTestContentRedux";
+import { getTestContent } from "../../modules/LoadTestContentRedux";
 import { TEST_DEFINITION } from "../../testDefinition";
 import { LANGUAGES } from "../../modules/LocalizeRedux";
 
 class OrganizationalInformation extends Component {
   static propTypes = {
     // Provided by Redux
-    getTestQuestions: PropTypes.func
+    getTestContent: PropTypes.func
   };
 
   state = {
@@ -20,7 +20,7 @@ class OrganizationalInformation extends Component {
 
   // loads the markdown content (english and french versions)
   componentWillMount = () => {
-    this.props.getTestQuestions(TEST_DEFINITION.emib.sampleTest).then(response => {
+    this.props.getTestContent(TEST_DEFINITION.emib.sampleTest).then(response => {
       // saving the organizational information markdown content in local states
       this.setState({
         markdown_en: response.background.en.background[0].markdown[1].text,
@@ -52,7 +52,7 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
-      getTestQuestions
+      getTestContent
     },
     dispatch
   );

--- a/frontend/src/components/eMIB/OrganizationalStructure.jsx
+++ b/frontend/src/components/eMIB/OrganizationalStructure.jsx
@@ -13,7 +13,7 @@ import emib_sample_test_example_org_chart_fr_zoomed from "../../images/emib_samp
 import ImageZoom from "react-medium-image-zoom";
 import "../../css/react-medium-image-zoom.css";
 import TreeNode from "../commons/TreeNode";
-import { getTestQuestions } from "../../modules/LoadTestContentRedux";
+import { getTestContent } from "../../modules/LoadTestContentRedux";
 import { TEST_DEFINITION } from "../../testDefinition";
 import { processTreeContent } from "../../helpers/transformations";
 
@@ -31,7 +31,7 @@ class OrganizationalStructure extends Component {
   static propTypes = {
     // Props from Redux
     currentLanguage: PropTypes.string,
-    getTestQuestions: PropTypes.func
+    getTestContent: PropTypes.func
   };
 
   state = {
@@ -57,7 +57,7 @@ class OrganizationalStructure extends Component {
 
   // loads the markdown and tree view content (english and french versions)
   componentDidMount = () => {
-    this.props.getTestQuestions(TEST_DEFINITION.emib.sampleTest).then(response => {
+    this.props.getTestContent(TEST_DEFINITION.emib.sampleTest).then(response => {
       // Save the organizational structure markdown and tree view content in local states.
       this.setState({
         markdown_en: response.background.en.background[0].markdown[2].text,
@@ -179,7 +179,7 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
-      getTestQuestions
+      getTestContent
     },
     dispatch
   );

--- a/frontend/src/components/eMIB/OrganizationalStructure.jsx
+++ b/frontend/src/components/eMIB/OrganizationalStructure.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { bindActionCreators } from "redux";
 import ReactMarkdown from "react-markdown";
 import LOCALIZE from "../../text_resources";
 import { LANGUAGES } from "../../modules/LocalizeRedux";
@@ -13,8 +12,6 @@ import emib_sample_test_example_org_chart_fr_zoomed from "../../images/emib_samp
 import ImageZoom from "react-medium-image-zoom";
 import "../../css/react-medium-image-zoom.css";
 import TreeNode from "../commons/TreeNode";
-import { getTestContent } from "../../modules/LoadTestContentRedux";
-import { TEST_DEFINITION } from "../../testDefinition";
 import { processTreeContent } from "../../helpers/transformations";
 
 const styles = {
@@ -29,22 +26,13 @@ const styles = {
 
 class OrganizationalStructure extends Component {
   static propTypes = {
-    // Props from Redux
-    currentLanguage: PropTypes.string,
-    getTestContent: PropTypes.func
+    // Provided by Redux
+    testBackground: PropTypes.object,
+    currentLanguage: PropTypes.string
   };
 
   state = {
-    showPopupBox: false,
-    isLoadingComplete: false,
-    markdown_en: "",
-    markdown_fr: "",
-    popupMarkdownTitle_en: "",
-    popupMarkdownTitle_fr: "",
-    popupMarkdownDescription_en: "",
-    popupMarkdownDescription_fr: "",
-    treeViewContent_en: [],
-    treeViewContent_fr: []
+    showPopupBox: false
   };
 
   openPopup = () => {
@@ -55,39 +43,26 @@ class OrganizationalStructure extends Component {
     this.setState({ showPopupBox: false });
   };
 
-  // loads the markdown and tree view content (english and french versions)
-  componentDidMount = () => {
-    this.props.getTestContent(TEST_DEFINITION.emib.sampleTest).then(response => {
-      // Save the organizational structure markdown and tree view content in local states.
-      this.setState({
-        markdown_en: response.background.en.background[0].markdown[2].text,
-        markdown_fr: response.background.fr.background[0].markdown[2].text,
-        popupMarkdownTitle_en: response.background.en.background[0].markdown[5].text,
-        popupMarkdownTitle_fr: response.background.fr.background[0].markdown[5].text,
-        popupMarkdownDescription_en: response.background.en.background[0].markdown[6].text,
-        popupMarkdownDescription_fr: response.background.fr.background[0].markdown[6].text,
-        treeViewContent_en:
-          response.background.en.background[0].tree_view[0].organizational_structure_tree_child,
-        treeViewContent_fr:
-          response.background.fr.background[0].tree_view[0].organizational_structure_tree_child,
-        isLoadingComplete: true
-      });
-    });
-  };
-
   render() {
-    const { currentLanguage } = this.props;
-    const { treeViewContent_en, treeViewContent_fr } = this.state;
-    let treeView = [];
-    // waiting for tree view content data loading
-    if (this.state.isLoadingComplete) {
-      treeView = processTreeContent(
-        currentLanguage,
-        treeViewContent_en,
-        treeViewContent_fr,
-        "organizational_structure_tree_child"
-      );
-    }
+    const { currentLanguage, testBackground } = this.props;
+
+    const treeViewContent_en =
+      testBackground.en.background[0].tree_view[0].organizational_structure_tree_child;
+    const treeViewContent_fr =
+      testBackground.fr.background[0].tree_view[0].organizational_structure_tree_child;
+    const markdown_en = testBackground.en.background[0].markdown[2].text;
+    const markdown_fr = testBackground.fr.background[0].markdown[2].text;
+    const popupMarkdownTitle_en = testBackground.en.background[0].markdown[5].text;
+    const popupMarkdownTitle_fr = testBackground.fr.background[0].markdown[5].text;
+    const popupMarkdownDescription_en = testBackground.en.background[0].markdown[6].text;
+    const popupMarkdownDescription_fr = testBackground.fr.background[0].markdown[6].text;
+
+    const treeView = processTreeContent(
+      currentLanguage,
+      treeViewContent_en,
+      treeViewContent_fr,
+      "organizational_structure_tree_child"
+    );
 
     return (
       <div>
@@ -97,16 +72,16 @@ class OrganizationalStructure extends Component {
           // only using the states here (without markdown), since the title must be a string
           title={
             this.props.currentLanguage === LANGUAGES.english
-              ? this.state.popupMarkdownTitle_en
-              : this.state.popupMarkdownTitle_fr
+              ? popupMarkdownTitle_en
+              : popupMarkdownTitle_fr
           }
           description={
             <div>
               {this.props.currentLanguage === LANGUAGES.english && (
-                <ReactMarkdown source={this.state.popupMarkdownDescription_en} />
+                <ReactMarkdown source={popupMarkdownDescription_en} />
               )}
               {this.props.currentLanguage === LANGUAGES.french && (
-                <ReactMarkdown source={this.state.popupMarkdownDescription_fr} />
+                <ReactMarkdown source={popupMarkdownDescription_fr} />
               )}
               <TreeNode nodes={treeView} />
             </div>
@@ -117,10 +92,10 @@ class OrganizationalStructure extends Component {
         <div>
           <div>
             {this.props.currentLanguage === LANGUAGES.english && (
-              <ReactMarkdown source={this.state.markdown_en} />
+              <ReactMarkdown source={markdown_en} />
             )}
             {this.props.currentLanguage === LANGUAGES.french && (
-              <ReactMarkdown source={this.state.markdown_fr} />
+              <ReactMarkdown source={markdown_fr} />
             )}
             <p>
               {currentLanguage === LANGUAGES.english && (
@@ -172,19 +147,12 @@ class OrganizationalStructure extends Component {
 
 const mapStateToProps = (state, ownProps) => {
   return {
-    currentLanguage: state.localize.language
+    currentLanguage: state.localize.language,
+    testBackground: state.loadTestContent.testBackground
   };
 };
 
-const mapDispatchToProps = dispatch =>
-  bindActionCreators(
-    {
-      getTestContent
-    },
-    dispatch
-  );
-
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  null
 )(OrganizationalStructure);

--- a/frontend/src/components/eMIB/TeamInformation.jsx
+++ b/frontend/src/components/eMIB/TeamInformation.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { bindActionCreators } from "redux";
 import ReactMarkdown from "react-markdown";
 import LOCALIZE from "../../text_resources";
 import { LANGUAGES } from "../../modules/LocalizeRedux";
@@ -13,8 +12,6 @@ import emib_sample_test_example_team_chart_fr_zoomed from "../../images/emib_sam
 import ImageZoom from "react-medium-image-zoom";
 import "../../css/react-medium-image-zoom.css";
 import TreeNode from "../commons/TreeNode";
-import { getTestContent } from "../../modules/LoadTestContentRedux";
-import { TEST_DEFINITION } from "../../testDefinition";
 import { processTreeContent } from "../../helpers/transformations";
 
 const styles = {
@@ -31,22 +28,11 @@ class TeamInformation extends Component {
   static propTypes = {
     // Props from Redux
     currentLanguage: PropTypes.string,
-    getTestContent: PropTypes.func
+    testBackground: PropTypes.object
   };
 
   state = {
-    showPopupBox: false,
-    isLoadingComplete: false,
-    markdown_section1_en: "",
-    markdown_section1_fr: "",
-    markdown_section2_en: "",
-    markdown_section2_fr: "",
-    popupMarkdownTitle_en: "",
-    popupMarkdownTitle_fr: "",
-    popupMarkdownDescription_en: "",
-    popupMarkdownDescription_fr: "",
-    treeViewContent_en: [],
-    treeViewContent_fr: []
+    showPopupBox: false
   };
 
   openPopup = () => {
@@ -57,41 +43,28 @@ class TeamInformation extends Component {
     this.setState({ showPopupBox: false });
   };
 
-  // loads the markdown content (english and french versions)
-  componentWillMount = () => {
-    this.props.getTestContent(TEST_DEFINITION.emib.sampleTest).then(response => {
-      // Save the team information markdown content in local states.
-      this.setState({
-        markdown_section1_en: response.background.en.background[0].markdown[3].text,
-        markdown_section1_fr: response.background.fr.background[0].markdown[3].text,
-        markdown_section2_en: response.background.en.background[0].markdown[4].text,
-        markdown_section2_fr: response.background.fr.background[0].markdown[4].text,
-        popupMarkdownTitle_en: response.background.en.background[0].markdown[7].text,
-        popupMarkdownTitle_fr: response.background.fr.background[0].markdown[7].text,
-        popupMarkdownDescription_en: response.background.en.background[0].markdown[8].text,
-        popupMarkdownDescription_fr: response.background.fr.background[0].markdown[8].text,
-        treeViewContent_en:
-          response.background.en.background[0].tree_view[1].team_information_tree_child,
-        treeViewContent_fr:
-          response.background.fr.background[0].tree_view[1].team_information_tree_child,
-        isLoadingComplete: true
-      });
-    });
-  };
-
   render() {
-    const { currentLanguage } = this.props;
-    const { treeViewContent_en, treeViewContent_fr } = this.state;
-    let treeView = [];
-    // waiting for tree view content data loading
-    if (this.state.isLoadingComplete) {
-      treeView = processTreeContent(
-        currentLanguage,
-        treeViewContent_en,
-        treeViewContent_fr,
-        "team_information_tree_child"
-      );
-    }
+    const { currentLanguage, testBackground } = this.props;
+
+    const markdown_section1_en = testBackground.en.background[0].markdown[3].text;
+    const markdown_section1_fr = testBackground.fr.background[0].markdown[3].text;
+    const markdown_section2_en = testBackground.en.background[0].markdown[4].text;
+    const markdown_section2_fr = testBackground.fr.background[0].markdown[4].text;
+    const popupMarkdownTitle_en = testBackground.en.background[0].markdown[7].text;
+    const popupMarkdownTitle_fr = testBackground.fr.background[0].markdown[7].text;
+    const popupMarkdownDescription_en = testBackground.en.background[0].markdown[8].text;
+    const popupMarkdownDescription_fr = testBackground.fr.background[0].markdown[8].text;
+    const treeViewContent_en =
+      testBackground.en.background[0].tree_view[1].team_information_tree_child;
+    const treeViewContent_fr =
+      testBackground.fr.background[0].tree_view[1].team_information_tree_child;
+
+    const treeView = processTreeContent(
+      currentLanguage,
+      treeViewContent_en,
+      treeViewContent_fr,
+      "team_information_tree_child"
+    );
 
     return (
       <div>
@@ -100,17 +73,15 @@ class TeamInformation extends Component {
           handleClose={this.closePopup}
           // only using the states here (without markdown), since the title must be a string
           title={
-            this.props.currentLanguage === LANGUAGES.english
-              ? this.state.popupMarkdownTitle_en
-              : this.state.popupMarkdownTitle_fr
+            currentLanguage === LANGUAGES.english ? popupMarkdownTitle_en : popupMarkdownTitle_fr
           }
           description={
             <div>
-              {this.props.currentLanguage === LANGUAGES.english && (
-                <ReactMarkdown source={this.state.popupMarkdownDescription_en} />
+              {currentLanguage === LANGUAGES.english && (
+                <ReactMarkdown source={popupMarkdownDescription_en} />
               )}
-              {this.props.currentLanguage === LANGUAGES.french && (
-                <ReactMarkdown source={this.state.popupMarkdownDescription_fr} />
+              {currentLanguage === LANGUAGES.french && (
+                <ReactMarkdown source={popupMarkdownDescription_fr} />
               )}
               <TreeNode nodes={treeView} />
             </div>
@@ -119,12 +90,8 @@ class TeamInformation extends Component {
           rightButtonTitle={LOCALIZE.commons.close}
         />
         <div>
-          {this.props.currentLanguage === LANGUAGES.english && (
-            <ReactMarkdown source={this.state.markdown_section1_en} />
-          )}
-          {this.props.currentLanguage === LANGUAGES.french && (
-            <ReactMarkdown source={this.state.markdown_section1_fr} />
-          )}
+          {currentLanguage === LANGUAGES.english && <ReactMarkdown source={markdown_section1_en} />}
+          {currentLanguage === LANGUAGES.french && <ReactMarkdown source={markdown_section1_fr} />}
           <div>
             <p>
               {currentLanguage === LANGUAGES.english && (
@@ -171,11 +138,11 @@ class TeamInformation extends Component {
             </button>
           </div>
           <div>
-            {this.props.currentLanguage === LANGUAGES.english && (
-              <ReactMarkdown source={this.state.markdown_section2_en} />
+            {currentLanguage === LANGUAGES.english && (
+              <ReactMarkdown source={markdown_section2_en} />
             )}
-            {this.props.currentLanguage === LANGUAGES.french && (
-              <ReactMarkdown source={this.state.markdown_section2_fr} />
+            {currentLanguage === LANGUAGES.french && (
+              <ReactMarkdown source={markdown_section2_fr} />
             )}
           </div>
         </div>
@@ -186,19 +153,12 @@ class TeamInformation extends Component {
 
 const mapStateToProps = (state, ownProps) => {
   return {
-    currentLanguage: state.localize.language
+    currentLanguage: state.localize.language,
+    testBackground: state.loadTestContent.testBackground
   };
 };
 
-const mapDispatchToProps = dispatch =>
-  bindActionCreators(
-    {
-      getTestContent
-    },
-    dispatch
-  );
-
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  null
 )(TeamInformation);

--- a/frontend/src/components/eMIB/TeamInformation.jsx
+++ b/frontend/src/components/eMIB/TeamInformation.jsx
@@ -13,7 +13,7 @@ import emib_sample_test_example_team_chart_fr_zoomed from "../../images/emib_sam
 import ImageZoom from "react-medium-image-zoom";
 import "../../css/react-medium-image-zoom.css";
 import TreeNode from "../commons/TreeNode";
-import { getTestQuestions } from "../../modules/LoadTestContentRedux";
+import { getTestContent } from "../../modules/LoadTestContentRedux";
 import { TEST_DEFINITION } from "../../testDefinition";
 import { processTreeContent } from "../../helpers/transformations";
 
@@ -31,7 +31,7 @@ class TeamInformation extends Component {
   static propTypes = {
     // Props from Redux
     currentLanguage: PropTypes.string,
-    getTestQuestions: PropTypes.func
+    getTestContent: PropTypes.func
   };
 
   state = {
@@ -59,7 +59,7 @@ class TeamInformation extends Component {
 
   // loads the markdown content (english and french versions)
   componentWillMount = () => {
-    this.props.getTestQuestions(TEST_DEFINITION.emib.sampleTest).then(response => {
+    this.props.getTestContent(TEST_DEFINITION.emib.sampleTest).then(response => {
       // Save the team information markdown content in local states.
       this.setState({
         markdown_section1_en: response.background.en.background[0].markdown[3].text,
@@ -193,7 +193,7 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
-      getTestQuestions
+      getTestContent
     },
     dispatch
   );

--- a/frontend/src/modules/LoadTestContentRedux.js
+++ b/frontend/src/modules/LoadTestContentRedux.js
@@ -1,10 +1,13 @@
 // Action Types
 const UPDATE_TEST_META_DATA = "emibInbox/UPDATE_TEST_META_DATA";
-const UPDATE_TEST_INSTRUCTIONS = "emibInbox/UPDATE_TEST_INSTRUCTIONS";
-const UPDATE_TEST_QUESTIONS = "emibInbox/UPDATE_TEST_QUESTIONS";
+const UPDATE_TEST_BACKGROUND = "emibInbox/UPDATE_TEST_BACKGROUND";
 
 // Action Creators
 const updateTestMetaDataState = testMetaData => ({ type: UPDATE_TEST_META_DATA, testMetaData });
+const updateTestBackgroundState = testBackground => ({
+  type: UPDATE_TEST_BACKGROUND,
+  testBackground
+});
 
 const getTestMetaData = testName => {
   return async function() {
@@ -18,45 +21,22 @@ const getTestMetaData = testName => {
   };
 };
 
-const updateTestInstructionsState = testInstructions => ({
-  type: UPDATE_TEST_INSTRUCTIONS,
-  testInstructions
-});
-
-const getTestInstructions = testName => {
+const getTestContent = testName => {
   return async function() {
-    let testInstructionsContent = await fetch(`/api/test-instructions/?test_name=${testName}`, {
+    let testContent = await fetch(`/api/test-questions/?test_name=${testName}`, {
       method: "GET",
       Accept: "application/json",
       "Content-Type": "application/json",
       cache: "default"
     });
-    return await testInstructionsContent.json();
-  };
-};
-
-const updateTestQuestionsState = testQuestions => ({
-  type: UPDATE_TEST_QUESTIONS,
-  testQuestions
-});
-
-const getTestQuestions = testName => {
-  return async function() {
-    let testQuestionsContent = await fetch(`/api/test-questions/?test_name=${testName}`, {
-      method: "GET",
-      Accept: "application/json",
-      "Content-Type": "application/json",
-      cache: "default"
-    });
-    return await testQuestionsContent.json();
+    return await testContent.json();
   };
 };
 
 // Initial State
 const initialState = {
   testMetaData: {},
-  testInstructions: {},
-  testQuestions: {}
+  testBackground: {}
 };
 
 // Reducer
@@ -67,15 +47,10 @@ const loadTestContent = (state = initialState, action) => {
         ...state,
         testMetaData: action.testMetaData
       };
-    case UPDATE_TEST_INSTRUCTIONS:
+    case UPDATE_TEST_BACKGROUND:
       return {
         ...state,
-        testInstructions: action.testInstructions
-      };
-    case UPDATE_TEST_QUESTIONS:
-      return {
-        ...state,
-        testQuestions: action.testQuestions
+        testBackground: action.testBackground
       };
 
     default:
@@ -88,8 +63,6 @@ export {
   initialState,
   updateTestMetaDataState,
   getTestMetaData,
-  updateTestInstructionsState,
-  getTestInstructions,
-  updateTestQuestionsState,
-  getTestQuestions
+  updateTestBackgroundState,
+  getTestContent
 };

--- a/frontend/src/modules/LoadTestContentRedux.js
+++ b/frontend/src/modules/LoadTestContentRedux.js
@@ -34,7 +34,10 @@ const getTestContent = testName => {
 };
 
 // Initial State
+// testMetaData contains the name of the test and the overview page content
+// testBackground contains all the background information
 const initialState = {
+  isMetaLoading: true,
   testMetaData: {},
   testBackground: {}
 };
@@ -45,7 +48,8 @@ const loadTestContent = (state = initialState, action) => {
     case UPDATE_TEST_META_DATA:
       return {
         ...state,
-        testMetaData: action.testMetaData
+        testMetaData: action.testMetaData,
+        isMetaLoading: false
       };
     case UPDATE_TEST_BACKGROUND:
       return {

--- a/frontend/src/tests/modules/LoadTestContentRedux.test.js
+++ b/frontend/src/tests/modules/LoadTestContentRedux.test.js
@@ -1,18 +1,17 @@
 import loadTestContent, {
   initialState,
   updateTestMetaDataState,
-  updateTestInstructionsState,
-  updateTestQuestionsState
+  updateTestBackgroundState
 } from "../../modules/LoadTestContentRedux";
 
-// updateTestQuestionsState
-describe("updateTestQuestionsState action", () => {
+// updateTestBackgroundState
+describe("updateTestBackgroundState action", () => {
   it("should update testQuestions state with given data", () => {
-    const action = updateTestQuestionsState("Hello World");
+    const action = updateTestBackgroundState("Hello World");
     expect(loadTestContent(initialState, action)).toEqual({
       testMetaData: {},
-      testInstructions: {},
-      testQuestions: "Hello World"
+      isMetaLoading: true,
+      testBackground: "Hello World"
     });
   });
 });
@@ -23,20 +22,8 @@ describe("updateTestMetaDataState action", () => {
     const action = updateTestMetaDataState("Hello World");
     expect(loadTestContent(initialState, action)).toEqual({
       testMetaData: "Hello World",
-      testInstructions: {},
-      testQuestions: {}
-    });
-  });
-});
-
-// updateTestInstructionsState
-describe("updateTestInstructionsState action", () => {
-  it("should update testInstructions state with given data", () => {
-    const action = updateTestInstructionsState("Hello World");
-    expect(loadTestContent(initialState, action)).toEqual({
-      testMetaData: {},
-      testInstructions: "Hello World",
-      testQuestions: {}
+      isMetaLoading: false,
+      testBackground: {}
     });
   });
 });


### PR DESCRIPTION
# Description

We called the API in each component. Instead, we should call it once, load everything into redux, and then have everything connected to redux.

This PR also removes a call for instructions from redux because that is not loaded from the backend so the code was never called.

I didn't fix everything I'd like to, including some naming, but this PR is big enough.

## Type of change

- Code cleanliness or refactor

## Screenshot
Before
![image](https://user-images.githubusercontent.com/4640747/60909787-22b54f80-a24d-11e9-9107-5447039f507b.png)
After
![image](https://user-images.githubusercontent.com/4640747/60909813-3365c580-a24d-11e9-8cea-8c6392fe9466.png)


# Testing

Manual steps to reproduce this functionality:

1.  All background and overview pages should have content when navigating through the test.

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
