### PR TITLE
[Bug Fix] Fix home page redirect

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -53,7 +53,7 @@ class App extends Component {
 
     // if there is no token, then there is no point in trying to verify it
     if (auth_token === undefined) {
-      this.coreMountFunc(undefined);
+      this.determinePath(undefined);
       return;
     }
 
@@ -65,12 +65,12 @@ class App extends Component {
       },
       body: JSON.stringify({ token: auth_token })
     }).then(response => {
-      this.coreMountFunc(response.status);
+      this.determinePath(response.status);
     });
   };
 
   //This logic needs to be used even if auth_token is undefined
-  coreMountFunc(status) {
+  determinePath(status) {
     // if valid, update the authenticated redux state to true
     if (status === 200) {
       this.props.authenticateAction(true);

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -53,6 +53,7 @@ class App extends Component {
 
     // if there is no token, then there is no point in trying to verify it
     if (auth_token === undefined) {
+      this.coreMountFunc(undefined);
       return;
     }
 
@@ -64,32 +65,37 @@ class App extends Component {
       },
       body: JSON.stringify({ token: auth_token })
     }).then(response => {
-      // if valid, update the authenticated redux state to true
-      if (response.status === 200) {
-        this.props.authenticateAction(true);
-      }
-      // if not a valid url (part of the PATH object) or login path, redirect to dashboard page
-      const pathValues = Object.keys(PATH).map(function(e) {
-        return PATH[e];
-      });
-      if (
-        pathValues.indexOf(window.location.pathname) < 0 ||
-        window.location.pathname === PATH.login
-      ) {
-        history.push(PATH.dashboard);
-      }
-      // if not valid and not the eMIB sample url, logout and redirect to login page
-      if (
-        response.status !== 200 &&
-        window.location.pathname !== PATH.emibSampleTest &&
-        window.location.pathname !== PATH.status
-      ) {
-        this.props.authenticateAction(false);
-        this.props.logoutAction();
-        history.push(PATH.login);
-      }
+      this.coreMountFunc(response.status);
     });
   };
+
+  //This logic needs to be used even if auth_token is undefined
+  coreMountFunc(status) {
+    // if valid, update the authenticated redux state to true
+    if (status === 200) {
+      this.props.authenticateAction(true);
+    }
+    // if not a valid url (part of the PATH object) or login path, redirect to dashboard page
+    const pathValues = Object.keys(PATH).map(function(e) {
+      return PATH[e];
+    });
+    if (
+      pathValues.indexOf(window.location.pathname) < 0 ||
+      window.location.pathname === PATH.login
+    ) {
+      history.push(PATH.dashboard);
+    }
+    // if not valid and not the eMIB sample url, logout and redirect to login page
+    if (
+      status !== 200 &&
+      window.location.pathname !== PATH.emibSampleTest &&
+      window.location.pathname !== PATH.status
+    ) {
+      this.props.authenticateAction(false);
+      this.props.logoutAction();
+      history.push(PATH.login);
+    }
+  }
 
   render() {
     const { isTestActive } = this.props;


### PR DESCRIPTION
# Description

Fixes bug introduced by #442 where accessing `localhost` renders the following, rather than redirecting to `http://localhost/login`. Whether an auth_token is received or not, it uses the same logic to determine where to go:
![image](https://user-images.githubusercontent.com/2746350/60912915-4334d800-a254-11e9-85c8-11d3c1dcfb2b.png)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

Now redirects properly:
![image](https://user-images.githubusercontent.com/2746350/60912962-5e074c80-a254-11e9-956d-5852eca4209e.png)

# Testing

Go to `localhost`; verify that you are redirected to `localhost/login`

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
