### PR TITLE
[Accessibility] Replace HRs with borders in CSS on other elements

### DIFF
--- a/frontend/src/Status.jsx
+++ b/frontend/src/Status.jsx
@@ -114,7 +114,6 @@ class Status extends Component {
         <div className={"jumbotron"}>
           <h1>{LOCALIZE.statusPage.title}</h1>
           <p>{LOCALIZE.statusPage.welcomeMsg}</p>
-          <hr />
           <p>
             <a href="https://github.com/code-for-canada/project-thundercat">
               <button type="button" className="btn btn-primary">
@@ -151,7 +150,6 @@ class Status extends Component {
             </table>
           </div>
         </div>
-        <hr />
         <div>
           <h3>{LOCALIZE.statusPage.systemStatusTable.title}</h3>
           <div>

--- a/frontend/src/components/eMIB/ActionViewEmail.jsx
+++ b/frontend/src/components/eMIB/ActionViewEmail.jsx
@@ -39,14 +39,16 @@ const styles = {
       textDecoration: "underline"
     }
   },
-  hr: {
-    margin: "16px 0 16px 0"
-  },
   editButton: {
     float: "right"
   },
   preWrap: {
     whiteSpace: "pre-wrap"
+  },
+  topDivider: {
+    marginTop: 16,
+    paddingTop: 16,
+    borderTop: "1px solid rgba(0, 0, 0, 0.1)"
   }
 };
 
@@ -152,13 +154,11 @@ class ActionViewEmail extends Component {
             <span style={styles.replyAndUser}>{visibleCcNames}</span>
           </div>
         </div>
-        <hr style={styles.hr} />
-        <div>
+        <div style={styles.topDivider}>
           <div style={styles.headings}>{LOCALIZE.emibTest.inboxPage.emailResponse.response}</div>
           <p style={styles.preWrap}>{action.emailBody}</p>
         </div>
-        <hr style={styles.hr} />
-        <div>
+        <div style={styles.topDivider}>
           <div style={styles.headings}>
             {LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}
           </div>
@@ -166,8 +166,7 @@ class ActionViewEmail extends Component {
         </div>
         {!this.props.disabled && (
           <div>
-            <hr style={styles.hr} />
-            <div aria-label={LOCALIZE.ariaLabel.emailOptions}>
+            <div style={styles.topDivider} aria-label={LOCALIZE.ariaLabel.emailOptions}>
               <button
                 id="unit-test-view-email-edit-button"
                 className="btn btn-primary"

--- a/frontend/src/components/eMIB/ActionViewTask.jsx
+++ b/frontend/src/components/eMIB/ActionViewTask.jsx
@@ -20,12 +20,7 @@ const styles = {
   preWrap: {
     whiteSpace: "pre-wrap"
   },
-  optionButtons: {
-    marginTop: 16,
-    paddingTop: 16,
-    borderTop: "1px solid rgba(0, 0, 0, 0.1)"
-  },
-  reasonsForAction: {
+  topDivider: {
     marginTop: 16,
     paddingTop: 16,
     borderTop: "1px solid rgba(0, 0, 0, 0.1)"
@@ -72,7 +67,7 @@ class ActionViewTask extends Component {
           <div style={styles.headings}>{LOCALIZE.emibTest.inboxPage.taskContent.task}</div>
           <p style={styles.preWrap}>{action.task}</p>
         </div>
-        <div style={styles.reasonsForAction}>
+        <div style={styles.topDivider}>
           <div style={styles.headings}>
             {LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}
           </div>
@@ -80,7 +75,7 @@ class ActionViewTask extends Component {
         </div>
         {!this.props.disabled && (
           <div>
-            <div style={styles.optionButtons} aria-label={LOCALIZE.ariaLabel.taskOptions}>
+            <div style={styles.topDivider} aria-label={LOCALIZE.ariaLabel.taskOptions}>
               <button
                 id="unit-test-view-task-edit-button"
                 className="btn btn-primary"

--- a/frontend/src/components/eMIB/ActionViewTask.jsx
+++ b/frontend/src/components/eMIB/ActionViewTask.jsx
@@ -14,14 +14,21 @@ const styles = {
   headings: {
     fontWeight: "bold"
   },
-  hr: {
-    margin: "16px 0 16px 0"
-  },
   editButton: {
     float: "right"
   },
   preWrap: {
     whiteSpace: "pre-wrap"
+  },
+  optionButtons: {
+    marginTop: 16,
+    paddingTop: 16,
+    borderTop: "1px solid rgba(0, 0, 0, 0.1)"
+  },
+  reasonsForAction: {
+    marginTop: 16,
+    paddingTop: 16,
+    borderTop: "1px solid rgba(0, 0, 0, 0.1)"
   }
 };
 
@@ -65,8 +72,7 @@ class ActionViewTask extends Component {
           <div style={styles.headings}>{LOCALIZE.emibTest.inboxPage.taskContent.task}</div>
           <p style={styles.preWrap}>{action.task}</p>
         </div>
-        <hr style={styles.hr} />
-        <div>
+        <div style={styles.reasonsForAction}>
           <div style={styles.headings}>
             {LOCALIZE.emibTest.inboxPage.emailResponse.reasonsForAction}
           </div>
@@ -74,8 +80,7 @@ class ActionViewTask extends Component {
         </div>
         {!this.props.disabled && (
           <div>
-            <hr style={styles.hr} />
-            <div aria-label={LOCALIZE.ariaLabel.taskOptions}>
+            <div style={styles.optionButtons} aria-label={LOCALIZE.ariaLabel.taskOptions}>
               <button
                 id="unit-test-view-task-edit-button"
                 className="btn btn-primary"

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -68,6 +68,9 @@ const styles = {
       paddingRight: 4,
       marginTop: 5,
       marginBottom: 5
+    },
+    toAndCcFieldPadding: {
+      marginBottom: 20
     }
   },
   response: {
@@ -285,7 +288,6 @@ class EditEmail extends Component {
               tags={true}
             />
           </div>
-          <hr />
           <div className="font-weight-bold" style={styles.header.toAndCcFieldPadding}>
             <label htmlFor="cc-field" style={styles.header.titleStyle}>
               {LOCALIZE.emibTest.inboxPage.emailCommons.cc}
@@ -302,7 +304,6 @@ class EditEmail extends Component {
               tags={true}
             />
           </div>
-          <hr />
           <div>
             <div className="font-weight-bold form-group">
               <label htmlFor="your-response-text-area">

--- a/frontend/src/components/eMIB/Email.jsx
+++ b/frontend/src/components/eMIB/Email.jsx
@@ -14,7 +14,9 @@ import { faSignOutAlt, faEnvelope, faTasks } from "@fortawesome/free-solid-svg-i
 
 const styles = {
   header: {
-    marginBottom: 35
+    borderBottom: "1px solid #00565E",
+    marginBottom: 16,
+    paddingBottom: 35
   },
   emailId: {
     float: "left",
@@ -35,16 +37,16 @@ const styles = {
   replyIcon: {
     color: "#00565E"
   },
-  titleEmailDivider: {
-    width: "100%",
-    borderTop: "1px solid #00565E",
-    margin: "16px 0 12px 0"
-  },
   actionIcon: {
     marginRight: 5
   },
   addEmailButton: {
     marginRight: 20
+  },
+  actionArea: {
+    borderTop: "1px solid #00565E",
+    marginTop: 35,
+    paddingTop: 16
   }
 };
 
@@ -104,12 +106,10 @@ class Email extends Component {
             </div>
           )}
         </div>
-        <hr style={styles.titleEmailDivider} />
         <EmailContent email={email} />
 
         {!this.props.disabled && (
-          <div>
-            <hr style={styles.titleEmailDivider} />
+          <div style={styles.actionArea}>
             <button
               id="unit-test-email-reply-button"
               type="button"

--- a/frontend/src/components/eMIB/EmailContent.jsx
+++ b/frontend/src/components/eMIB/EmailContent.jsx
@@ -7,15 +7,16 @@ const styles = {
   replyAndUser: {
     color: "#00565E"
   },
-  dataBodyDivider: {
-    borderTop: "1px solid #96a8b2",
-    margin: "12px 0 12px 0"
-  },
   preWrap: {
     whiteSpace: "pre-wrap"
   },
   subject: {
     fontSize: 20
+  },
+  metaData: {
+    marginBottom: 12,
+    paddingBottom: 12,
+    borderBottom: "1px solid #96a8b2"
   }
 };
 
@@ -28,19 +29,21 @@ class EmailContent extends Component {
     const { email } = this.props;
     return (
       <div>
-        <div style={styles.subject}>
-          {LOCALIZE.emibTest.inboxPage.subject + ": " + email.subject}
+        <div style={styles.metaData}>
+          <div style={styles.subject}>
+            {LOCALIZE.emibTest.inboxPage.subject + ": " + email.subject}
+          </div>
+          <div>
+            {LOCALIZE.emibTest.inboxPage.from}:{" "}
+            <span style={styles.replyAndUser}>{email.from}</span>
+          </div>
+          <div>
+            {LOCALIZE.emibTest.inboxPage.to}: <span style={styles.replyAndUser}>{email.to}</span>
+          </div>
+          <div>
+            {LOCALIZE.emibTest.inboxPage.date}: {email.date}
+          </div>
         </div>
-        <div>
-          {LOCALIZE.emibTest.inboxPage.from}: <span style={styles.replyAndUser}>{email.from}</span>
-        </div>
-        <div>
-          {LOCALIZE.emibTest.inboxPage.to}: <span style={styles.replyAndUser}>{email.to}</span>
-        </div>
-        <div>
-          {LOCALIZE.emibTest.inboxPage.date}: {email.date}
-        </div>
-        <hr style={styles.dataBodyDivider} />
         <div style={styles.preWrap}>{email.body}</div>
       </div>
     );


### PR DESCRIPTION
# Description

Replace HRs with borders in CSS on other elements.
I tried to follow all the comments from @joeyhua here: https://github.com/code-for-canada/project-thundercat/pull/443

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

<img width="518" alt="Screen Shot 2019-07-10 at 10 09 18 PM" src="https://user-images.githubusercontent.com/4640747/61017003-b6774080-a35f-11e9-830a-16159a7c564f.png">
<img width="522" alt="Screen Shot 2019-07-10 at 10 09 27 PM" src="https://user-images.githubusercontent.com/4640747/61017004-b70fd700-a35f-11e9-89ed-a38087330068.png">
<img width="610" alt="Screen Shot 2019-07-10 at 10 09 39 PM" src="https://user-images.githubusercontent.com/4640747/61017005-b70fd700-a35f-11e9-8daa-63619e31c26f.png">
<img width="619" alt="Screen Shot 2019-07-10 at 10 09 45 PM" src="https://user-images.githubusercontent.com/4640747/61017006-b70fd700-a35f-11e9-8d4e-ebeff68931a6.png">
<img width="685" alt="Screen Shot 2019-07-10 at 10 09 52 PM" src="https://user-images.githubusercontent.com/4640747/61017007-b70fd700-a35f-11e9-8888-938630d314fe.png">
<img width="688" alt="Screen Shot 2019-07-10 at 10 10 15 PM" src="https://user-images.githubusercontent.com/4640747/61017008-b70fd700-a35f-11e9-91d8-bdb2cbdc4f0a.png">


# Testing

Manual steps to reproduce this functionality:

1.  Go through sample test where there are hr lines and they should still be displayed the same.

# Checklist

Applicable for all code changes.

- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on ~~IE 11+~~ and Chrome
