### PR TITLE
[Display Bug] Fixing emails view (Pizza Test)

### DIFF
--- a/frontend/src/components/eMIB/Inbox.jsx
+++ b/frontend/src/components/eMIB/Inbox.jsx
@@ -19,6 +19,11 @@ const styles = {
   contentColumn: {
     paddingLeft: 0
   },
+  navIntemContainer: {
+    width: "100%",
+    height: INBOX_HEIGHT,
+    overflow: "auto"
+  },
   navItem: {
     width: "100%"
   },
@@ -64,20 +69,22 @@ class Inbox extends Component {
           <Row>
             <Col role="complementary" sm={4}>
               <Nav className="flex-column">
-                {emails.map((email, index) => (
-                  <Nav.Item key={index} style={styles.navItem}>
-                    <Nav.Link eventKey={EVENT_KEYS[index]} style={styles.navLink}>
-                      <EmailPreview
-                        email={email}
-                        isRead={this.props.emailSummaries[index].isRead}
-                        isRepliedTo={
-                          emailSummaries[index].emailCount + emailSummaries[index].taskCount > 0
-                        }
-                        isSelected={index === this.props.currentEmail}
-                      />
-                    </Nav.Link>
-                  </Nav.Item>
-                ))}
+                <div style={styles.navIntemContainer}>
+                  {emails.map((email, index) => (
+                    <Nav.Item key={index} style={styles.navItem}>
+                      <Nav.Link eventKey={EVENT_KEYS[index]} style={styles.navLink}>
+                        <EmailPreview
+                          email={email}
+                          isRead={this.props.emailSummaries[index].isRead}
+                          isRepliedTo={
+                            emailSummaries[index].emailCount + emailSummaries[index].taskCount > 0
+                          }
+                          isSelected={index === this.props.currentEmail}
+                        />
+                      </Nav.Link>
+                    </Nav.Item>
+                  ))}
+                </div>
               </Nav>
             </Col>
             <Col sm={8} tabIndex={0} style={styles.contentColumn}>


### PR DESCRIPTION
# Description

This PR is introducing a fix related to the emails view when launching the Pizza Test.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

**Before:**
![image](https://user-images.githubusercontent.com/23021242/61062522-67b3c000-a3cc-11e9-8310-2b98e3ec05dd.png)

**After:**
![image](https://user-images.githubusercontent.com/23021242/61062574-7e5a1700-a3cc-11e9-94eb-d1cd56fa9759.png)

**Sample Test still looks the same too:**
![image](https://user-images.githubusercontent.com/23021242/61062652-9c277c00-a3cc-11e9-9a72-4eada491b3cb.png)

# Testing

Manual steps to reproduce this functionality:

1.  Launch the Sample/Pizza Test (See PR #461 for details on how to launch the pizza test).
2.  Make sure that the emails view is displayed as expected, meaning without any overflow bugs.

# Checklist

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 11+ and Chrome
