### PR TITLE
Feature - auto-fill the to field based on the reply/replyall/fwd selection

### DIFF
--- a/frontend/src/components/eMIB/EditActionDialog.jsx
+++ b/frontend/src/components/eMIB/EditActionDialog.jsx
@@ -225,6 +225,9 @@ class EditActionDialog extends Component {
             <EditEmail
               onChange={this.editAction}
               action={editMode === EDIT_MODE.update ? this.props.action : null}
+              originalFrom={this.props.email.from}
+              originalTo={this.props.email.to}
+              editMode={editMode}
             />
           )}
           {actionType === ACTION_TYPE.task && (

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -144,19 +144,19 @@ class EditEmail extends Component {
 
   onEmailTypeChange = event => {
     const newEmailType = event.target.value;
+
+    // Names sent in the original email.
     const { originalTo, originalFrom } = this.props;
+
+    // By default (and forwarding) should have a blank to field.
     let replyList = [];
     if (newEmailType === EMAIL_TYPE.reply) {
-      replyList = originalFrom.split(", ").map(name => {
-        return this.props.addressBook.indexOf(name);
-      });
+      // Reply to the person that sent you this email.
+      replyList = this.generateToIds(originalFrom);
     } else if (newEmailType === EMAIL_TYPE.replyAll) {
-      const toList = originalTo.split(", ").map(name => {
-        return this.props.addressBook.indexOf(name);
-      });
-      const fromList = originalFrom.split(", ").map(name => {
-        return this.props.addressBook.indexOf(name);
-      });
+      // Reply all to everyone this email was from and sent to.
+      const toList = this.generateToIds(originalTo);
+      const fromList = this.generateToIds(originalFrom);
       replyList = toList.concat(fromList);
     }
 

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -116,6 +116,12 @@ class EditEmail extends Component {
     addressBook: PropTypes.arrayOf(PropTypes.string)
   };
 
+  componentDidMount() {
+    // After generating the initial state, update the parent with it.
+    // This allows defaults to be set.
+    this.props.onChange(this.state);
+  }
+
   generateToIds = contactsString => {
     return contactsString.split(", ").map(name => {
       return this.props.addressBook.indexOf(name);

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -122,6 +122,8 @@ class EditEmail extends Component {
     this.props.onChange(this.state);
   }
 
+  // Generate an array of ids, representing contacts
+  // based on a string of names in a to or from field.
   generateToIds = contactsString => {
     return contactsString.split(", ").map(name => {
       return this.props.addressBook.indexOf(name);


### PR DESCRIPTION
# Description

Auto-fill in the `to` field based on the reply/replyall/fwd selection. This defaults to the reply field being selected.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

![reply](https://user-images.githubusercontent.com/4640747/61097268-abd4ae00-a428-11e9-9571-ff97b1f2033f.gif)


# Testing

Manual steps to reproduce this functionality:

1.  Go to the inbox.
2. Click "Add email response"
3. Should by default reply to whoever sent the email.
4. Selecting other email types should change recipients.

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
