### PR TITLE
[Accessibility] Fixing scroll using arrows bug

### DIFF
--- a/frontend/src/components/eMIB/Inbox.jsx
+++ b/frontend/src/components/eMIB/Inbox.jsx
@@ -13,11 +13,11 @@ const INBOX_HEIGHT = `calc(100vh - ${HEADER_HEIGHT + FOOTER_HEIGHT}px)`;
 
 const styles = {
   bodyContent: {
-    overflow: "auto",
     height: INBOX_HEIGHT
   },
   contentColumn: {
-    paddingLeft: 0
+    paddingLeft: 0,
+    overflowY: "scroll"
   },
   navIntemContainer: {
     width: "100%",

--- a/frontend/src/components/eMIB/SideNavigation.jsx
+++ b/frontend/src/components/eMIB/SideNavigation.jsx
@@ -9,7 +9,6 @@ const EVENT_KEYS = ["first", "second", "third", "fourth"];
 
 const styles = {
   bodyContent: {
-    overflow: "auto",
     paddingRight: 20,
     paddingTop: 10,
     paddingBottom: 10,
@@ -19,6 +18,9 @@ const styles = {
   nav: {
     marginTop: 10,
     marginLeft: 10
+  },
+  tabContainer: {
+    overflowY: "scroll"
   }
 };
 
@@ -48,7 +50,7 @@ class SideNavigation extends Component {
               })}
             </Nav>
           </Col>
-          <Col sm={9}>
+          <Col sm={9} style={styles.tabContainer}>
             <Tab.Content tabIndex={0}>
               {specs.map((item, index) => {
                 return (


### PR DESCRIPTION
# Description

This PR is introducing a fix that allows us to scroll using keyboard arrows in test content (Instructions, Background Info, Emails Content).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

(N/A)

# Testing

Manual steps to reproduce this functionality:

1.  Launch the Sample Test.
2.  In each section of the test (Instruction, Background Info and Inbox), make sure that you are able to scroll up and down using the keyboard arrows.

# Checklist

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
