### PR TITLE
[Accessibility] Fixing display of 'Error' in Home page title bug

### DIFF
--- a/frontend/src/Home.jsx
+++ b/frontend/src/Home.jsx
@@ -11,15 +11,15 @@ class Home extends Component {
   static propTypes = {
     // Props from Redux
     authenticated: PropTypes.bool,
-    isRegistrationFormValid: PropTypes.bool
+    pageHasError: PropTypes.bool
   };
 
   render() {
     return (
       <div className="app">
         <Helmet>
-          {this.props.isRegistrationFormValid && <title>{LOCALIZE.titles.home}</title>}
-          {!this.props.isRegistrationFormValid && <title>{LOCALIZE.titles.homeWithError}</title>}
+          {!this.props.pageHasError && <title>{LOCALIZE.titles.home}</title>}
+          {this.props.pageHasError && <title>{LOCALIZE.titles.homeWithError}</title>}
         </Helmet>
         <ContentContainer>
           {!this.props.authenticated && (
@@ -42,7 +42,7 @@ export { Home as UnconnectedHome };
 const mapStateToProps = (state, ownProps) => {
   return {
     authenticated: state.login.authenticated,
-    isRegistrationFormValid: state.login.isRegistrationFormValid
+    pageHasError: state.login.pageHasError
   };
 };
 

--- a/frontend/src/components/authentication/LoginForm.jsx
+++ b/frontend/src/components/authentication/LoginForm.jsx
@@ -4,7 +4,7 @@ import LOCALIZE from "../../text_resources";
 import {
   loginAction,
   handleAuthResponseAndState,
-  updateIsRegistrationFormValidState
+  updatePageHasErrorState
 } from "../../modules/LoginRedux";
 import { connect } from "react-redux";
 import history from "./history";
@@ -47,7 +47,7 @@ class LoginForm extends Component {
     handleAuthResponseAndState: PropTypes.func,
     setLoginState: PropTypes.func,
     authenticated: PropTypes.bool,
-    updateIsRegistrationFormValidState: PropTypes.func
+    updatePageHasErrorState: PropTypes.func
   };
 
   state = {
@@ -66,7 +66,7 @@ class LoginForm extends Component {
           this.setState({
             wrongCredentials: true
           });
-          this.props.updateIsRegistrationFormValidState(false);
+          this.props.updatePageHasErrorState(true);
           // focus on password field
           document.getElementById("password").focus();
           // right authentication
@@ -78,7 +78,7 @@ class LoginForm extends Component {
             window.location.pathname,
             history.push
           );
-          this.props.updateIsRegistrationFormValidState(true);
+          this.props.updatePageHasErrorState(false);
         }
       });
     event.preventDefault();
@@ -170,7 +170,7 @@ const mapDispatchToProps = dispatch => ({
   loginAction: data => dispatch(loginAction(data)),
   handleAuthResponseAndState: (userData, dispatch, location, push) =>
     dispatch(handleAuthResponseAndState(userData, dispatch, location, push)),
-  updateIsRegistrationFormValidState: bool => dispatch(updateIsRegistrationFormValidState(bool)),
+  updatePageHasErrorState: bool => dispatch(updatePageHasErrorState(bool)),
   dispatch
 });
 

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -12,7 +12,7 @@ import {
   registerAction,
   handleAuthResponseAndState,
   loginAction,
-  updateIsRegistrationFormValidState
+  updatePageHasErrorState
 } from "../../modules/LoginRedux";
 import { connect } from "react-redux";
 import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
@@ -108,7 +108,7 @@ class RegistrationForm extends Component {
     registerAction: PropTypes.func,
     handleAuthResponseAndState: PropTypes.func,
     loginAction: PropTypes.func,
-    updateIsRegistrationFormValidState: PropTypes.func
+    updatePageHasErrorState: PropTypes.func
   };
 
   state = {
@@ -464,9 +464,7 @@ class RegistrationForm extends Component {
         .registerAction({
           first_name: this.state.firstNameContent,
           last_name: this.state.lastNameContent,
-          birth_date: `${this.state.dobDayContent}/${this.state.dobMonthContent}/---${
-            this.state.dobYearContent
-          }`,
+          birth_date: `${this.state.dobDayContent}/${this.state.dobMonthContent}/---${this.state.dobYearContent}`,
           email: this.state.emailContent,
           pri_or_military_nbr: this.state.priOrMilitaryNbrContent,
           password: this.state.passwordContent,
@@ -498,9 +496,9 @@ class RegistrationForm extends Component {
                   history.push
                 );
               });
-            this.props.updateIsRegistrationFormValidState(true);
+            this.props.updatePageHasErrorState(false);
           } else {
-            this.props.updateIsRegistrationFormValidState(false);
+            this.props.updatePageHasErrorState(true);
           }
           // response gets username error(s)
           if (typeof response.username !== "undefined") {
@@ -514,7 +512,7 @@ class RegistrationForm extends Component {
           }
         });
     } else {
-      this.props.updateIsRegistrationFormValidState(false);
+      this.props.updatePageHasErrorState(true);
       this.focusOnHighestErrorField();
     }
     event.preventDefault();
@@ -535,10 +533,6 @@ class RegistrationForm extends Component {
 
   changeCheckboxStatus = () => {
     this.setState({ isCheckboxChecked: !this.state.isCheckboxChecked });
-  };
-
-  componentDidMount = () => {
-    this.props.updateIsRegistrationFormValidState(true);
   };
 
   render() {
@@ -1128,7 +1122,7 @@ const mapDispatchToProps = dispatch => ({
   loginAction: data => dispatch(loginAction(data)),
   handleAuthResponseAndState: (userData, dispatch, location, push) =>
     dispatch(handleAuthResponseAndState(userData, dispatch, location, push)),
-  updateIsRegistrationFormValidState: bool => dispatch(updateIsRegistrationFormValidState(bool)),
+  updatePageHasErrorState: bool => dispatch(updatePageHasErrorState(bool)),
   dispatch
 });
 

--- a/frontend/src/modules/LoginRedux.js
+++ b/frontend/src/modules/LoginRedux.js
@@ -41,10 +41,10 @@ function registerAction(data) {
   };
 }
 
-// updates isRegistrationFormValid state
-const updateIsRegistrationFormValidState = isRegistrationFormValid => ({
+// updates pageHasError state
+const updatePageHasErrorState = pageHasError => ({
   type: REGISTRATION,
-  isRegistrationFormValid
+  pageHasError
 });
 
 // getting user's token
@@ -88,7 +88,7 @@ function logoutAction() {
 // Initial State
 const initialState = {
   authenticated: false,
-  isRegistrationFormValid: false
+  pageHasError: false
 };
 
 // Reducer
@@ -104,7 +104,7 @@ const login = (state = initialState, action) => {
     case REGISTRATION:
       return {
         ...state,
-        isRegistrationFormValid: action.isRegistrationFormValid
+        pageHasError: action.pageHasError
       };
 
     default:
@@ -121,5 +121,5 @@ export {
   handleAuthResponseAndState,
   logoutAction,
   getUserInformation,
-  updateIsRegistrationFormValidState
+  updatePageHasErrorState
 };

--- a/frontend/src/tests/modules/LoginRedux.test.js
+++ b/frontend/src/tests/modules/LoginRedux.test.js
@@ -2,7 +2,7 @@ import login, {
   authenticateAction,
   initialState,
   logoutAction,
-  updateIsRegistrationFormValidState
+  updatePageHasErrorState
 } from "../../modules/LoginRedux";
 
 // authenticateAction
@@ -11,14 +11,14 @@ describe("authenticate action", () => {
     const action = authenticateAction(true);
     expect(login(initialState, action)).toEqual({
       authenticated: true,
-      isRegistrationFormValid: false
+      pageHasError: false
     });
   });
   it("should update authenticated state to false", () => {
     const action = authenticateAction(false);
     expect(login(initialState, action)).toEqual({
       authenticated: false,
-      isRegistrationFormValid: false
+      pageHasError: false
     });
   });
 });
@@ -36,20 +36,20 @@ describe("logout action", () => {
   });
 });
 
-// updateIsRegistrationFormValidState
-describe("updateIsRegistrationFormValidState action", () => {
-  it("should update isRegistrationFormValid state to true", () => {
-    const action = updateIsRegistrationFormValidState(true);
+// updatePageHasErrorState
+describe("updatePageHasErrorState action", () => {
+  it("should update pageHasError state to true", () => {
+    const action = updatePageHasErrorState(true);
     expect(login(initialState, action)).toEqual({
       authenticated: false,
-      isRegistrationFormValid: true
+      pageHasError: true
     });
   });
-  it("should update isRegistrationFormValid state to false", () => {
-    const action = updateIsRegistrationFormValidState(false);
+  it("should update pageHasError state to false", () => {
+    const action = updatePageHasErrorState(false);
     expect(login(initialState, action)).toEqual({
       authenticated: false,
-      isRegistrationFormValid: false
+      pageHasError: false
     });
   });
 });


### PR DESCRIPTION
# Description

This PR is simply fixing the display of 'Error' in the Home page bug. Before this fix, when we were refreshing the page, the page title was becoming 'Error - CAT Home', even if there was no error on Login and Registration forms.

So this PR contains the following changes:
- Renamed the state called _isRegistrationFormValid_ for _pageHasError_.
- Renamed the function called _updateIsRegistrationFormValidState_ for _updatePageHasErrorState_.
- Refactored the logic of the usage of this function/state.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

**Before**
---
**When launching the app for the first time (everything was working as expected):**
![image](https://user-images.githubusercontent.com/23021242/61124513-157aa980-a475-11e9-8fb8-a3a7f767cea0.png)

![image](https://user-images.githubusercontent.com/23021242/61124646-625e8000-a475-11e9-977c-79b835c71d51.png)

**After refreshing the page (wrong behavior):**
![image](https://user-images.githubusercontent.com/23021242/61124620-4eb31980-a475-11e9-9f15-2dbb469f97e1.png)


**After**
---
**When launching the app for the first time:**
![image](https://user-images.githubusercontent.com/23021242/61124646-625e8000-a475-11e9-977c-79b835c71d51.png)

**When one of the forms is invalid (Login or Registration):**
![image](https://user-images.githubusercontent.com/23021242/61124689-8de16a80-a475-11e9-86e4-cd057792508e.png)

OR

![image](https://user-images.githubusercontent.com/23021242/61124722-a6518500-a475-11e9-9264-e48519ab408f.png)

![image](https://user-images.githubusercontent.com/23021242/61124620-4eb31980-a475-11e9-9f15-2dbb469f97e1.png)

# Testing

Manual steps to reproduce this functionality:

1.  Launch the app and make sure that you are in the Home Page.
2.  Refresh the page and make sure that the page title stays 'CAT Home'.
3.  Trigger invalid forms (Login and Registration) and make sure that the page title becomes 'Error - CAT Home'.

# Checklist

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~My changes generate no new accessibility errors and/or warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
