### PR TITLE
Link to pizza test from the dashboard

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -24,6 +24,7 @@ import QuitTest from "./components/commons/QuitTest";
 import history from "./components/authentication/history";
 import SelectLanguage from "./SelectLanguage";
 import { LANGUAGES } from "./modules/LocalizeRedux";
+import { TEST_DEFINITION } from "./testDefinition";
 
 const styles = {
   nav: {
@@ -35,7 +36,8 @@ const PATH = {
   login: "/login",
   dashboard: "/dashboard",
   status: "/status",
-  emibSampleTest: "/emib-sample"
+  emibSampleTest: "/emib-sample",
+  test: "/test"
 };
 
 class App extends Component {
@@ -177,7 +179,14 @@ class App extends Component {
                 <Route exact path={PATH.login} component={Home} />
                 {this.props.authenticated && <Route path={PATH.dashboard} component={Home} />}
                 <Route path={PATH.status} component={Status} />
-                <Route path={PATH.emibSampleTest} component={Emib} />
+                <Route
+                  path={PATH.emibSampleTest}
+                  component={() => <Emib testNameId={TEST_DEFINITION.emib.sampleTest} />}
+                />
+                <Route
+                  path={PATH.test}
+                  component={() => <Emib testNameId={TEST_DEFINITION.emib.pizzaTest} />}
+                />
               </div>
             </Router>
           </div>

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -88,12 +88,17 @@ class Dashboard extends Component {
               </tr>
               {/* temporary - to be removed in the future when we'll get assign test functionalities */}
               <tr>
-                <td style={{ ...styles.td, ...styles.borderRight }}>e-MIB test</td>
-                <td style={{ ...styles.td, ...styles.borderRight }}>May 20, 2019</td>
+                <td style={{ ...styles.td, ...styles.borderRight }}>e-MIB Pizza Test</td>
+                <td style={{ ...styles.td, ...styles.borderRight }}>
+                  {new Date()
+                    .toJSON()
+                    .slice(0, 10)
+                    .replace(/-/g, "/")}
+                </td>
                 <td style={{ ...styles.td, ...styles.centerText }}>
-                  <button className="btn btn-primary" style={styles.viewButton}>
+                  <a href="/test" className="btn btn-primary" style={styles.viewButton}>
                     View
-                  </button>
+                  </a>
                 </td>
               </tr>
               {/* ==================================================================================== */}

--- a/frontend/src/components/eMIB/Emib.jsx
+++ b/frontend/src/components/eMIB/Emib.jsx
@@ -18,11 +18,12 @@ import {
   updateEmailsState
 } from "../../modules/EmibInboxRedux";
 import { getTestContent, updateTestBackgroundState } from "../../modules/LoadTestContentRedux";
-import { TEST_DEFINITION } from "../../testDefinition";
 import QuitConfirmation from "../commons/QuitConfirmation";
+import { TEST_DEFINITION } from "../../testDefinition";
 
 class Emib extends Component {
   static propTypes = {
+    testNameId: PropTypes.string,
     // Provided by Redux
     activateTest: PropTypes.func.isRequired,
     deactivateTest: PropTypes.func.isRequired,
@@ -45,8 +46,11 @@ class Emib extends Component {
   /* Within eMIB Tabs functions
   loading test questions from the APIs on test start */
   handleStartTest = () => {
+    const testNameId = this.props.testNameId
+      ? this.props.testNameId
+      : TEST_DEFINITION.emib.sampleTest;
     // getting questions of the sample test from the api
-    this.props.getTestContent(TEST_DEFINITION.emib.sampleTest).then(response => {
+    this.props.getTestContent(testNameId).then(response => {
       // Load emails.
       // TODO: default language is English for now, but we'll need to put the landing page selected language here instead
       this.props.updateEmailsState(response.questions.en.email);
@@ -99,7 +103,10 @@ class Emib extends Component {
         {this.props.curPage !== PAGES.emibTabs && (
           <ContentContainer hideBanner={false}>
             {this.props.curPage === PAGES.preTest && (
-              <EmibIntroductionPage nextPage={this.props.activateTest} />
+              <EmibIntroductionPage
+                testNameId={this.props.testNameId}
+                nextPage={this.props.activateTest}
+              />
             )}
 
             {this.props.curPage === PAGES.confirm && <Confirmation />}

--- a/frontend/src/components/eMIB/EmibIntroductionPage.jsx
+++ b/frontend/src/components/eMIB/EmibIntroductionPage.jsx
@@ -17,6 +17,7 @@ const styles = {
 
 class EmibIntroductionPage extends Component {
   static propTypes = {
+    testNameId: PropTypes.string,
     nextPage: PropTypes.func.isRequired,
     // Provided by Redux
     getTestMetaData: PropTypes.func.isRequired,
@@ -28,7 +29,10 @@ class EmibIntroductionPage extends Component {
 
   // Load current test markdown content.
   componentWillMount = () => {
-    this.props.getTestMetaData(TEST_DEFINITION.emib.sampleTest).then(response => {
+    const testNameId = this.props.testNameId
+      ? this.props.testNameId
+      : TEST_DEFINITION.emib.sampleTest;
+    this.props.getTestMetaData(testNameId).then(response => {
       this.props.updateTestMetaDataState(response);
     });
   };


### PR DESCRIPTION
# Description

Link to the pizza test from the dashboard after a user logs in.

This is currently hard-coded for all candidates, but in the future we'll need to make this even more dynamic.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

![pizza](https://user-images.githubusercontent.com/4640747/61163869-ff093800-a4de-11e9-9e75-f5ff6360e8b5.gif)


# Testing

Manual steps to reproduce this functionality:

1.  Login.
2. Click on view test.
3. Go through the pizza test.
4. Go through sample test.
5. There should be no errors.

# Checklist

Applicable for all code changes.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on ~~IE 11+~~ and Chrome
