### PR TITLE
[Start dialog] Display time allotted for the test.

### DIFF
--- a/frontend/src/components/commons/ConfirmStartTest.jsx
+++ b/frontend/src/components/commons/ConfirmStartTest.jsx
@@ -1,17 +1,26 @@
 import React, { Component } from "react";
+import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import LOCALIZE from "../../text_resources";
 import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
+import { getTotalTestTime } from "../../modules/LoadTestContentRedux";
 
 class ConfirmStartTest extends Component {
   static propTypes = {
     showDialog: PropTypes.bool.isRequired,
     handleClose: PropTypes.func.isRequired,
-    startTest: PropTypes.func.isRequired
+    startTest: PropTypes.func.isRequired,
+    // Provided by Redux
+    testTimeInMinutes: PropTypes.number
   };
 
   render() {
-    //TODO: replace `timeUnlimited` with dynamic real time value to complete the test.
+    const timePhrase = this.props.testTimeInMinutes
+      ? LOCALIZE.formatString(
+          LOCALIZE.commons.confirmStartTest.numberMinutes,
+          this.props.testTimeInMinutes
+        )
+      : LOCALIZE.commons.confirmStartTest.timeUnlimited;
     return (
       <div>
         <PopupBox
@@ -23,7 +32,7 @@ class ConfirmStartTest extends Component {
               <p>
                 {LOCALIZE.formatString(
                   LOCALIZE.commons.confirmStartTest.timerWarning,
-                  LOCALIZE.commons.confirmStartTest.timeUnlimited
+                  <b>{timePhrase}</b>
                 )}
               </p>
               <p>{LOCALIZE.commons.confirmStartTest.instructionsAccess}</p>
@@ -39,4 +48,14 @@ class ConfirmStartTest extends Component {
     );
   }
 }
-export default ConfirmStartTest;
+
+const mapStateToProps = (state, ownProps) => {
+  return {
+    testTimeInMinutes: getTotalTestTime(state)
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  null
+)(ConfirmStartTest);

--- a/frontend/src/modules/LoadTestContentRedux.js
+++ b/frontend/src/modules/LoadTestContentRedux.js
@@ -155,6 +155,11 @@ export const getBackgroundInCurrentLanguage = state => {
   return testBackground[lang].sections[0].section;
 };
 
+// Returns the time allotted for the test in minutes.
+export const getTotalTestTime = state => {
+  return state.loadTestContent.testMetaData.default_time;
+};
+
 export default loadTestContent;
 export {
   initialState,

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -508,7 +508,8 @@ let LOCALIZE = new LocalizedStrings({
           "After clicking start, you'll be taken to the 'Background' tab. You will have {0} to complete the test.",
         instructionsAccess:
           "You will have access to the instructions from within the test. Good luck!",
-        timeUnlimited: "unlimited time"
+        timeUnlimited: "unlimited time",
+        numberMinutes: "{0} minutes"
       },
       submitTestButton: "Submit test",
       quitTest: "Quit Test",
@@ -1048,7 +1049,8 @@ let LOCALIZE = new LocalizedStrings({
           "FR After clicking start, you'll be taken to the 'Background' tab. You will have {0} to complete the test.",
         instructionsAccess:
           "Vous aurez accès aux instructions et à votre bloc-notes durant le test. Bonne chance!",
-        timeUnlimited: "FR unlimited time"
+        timeUnlimited: "FR unlimited time",
+        numberMinutes: "{0} minutes"
       },
       submitTestButton: "Envoyer le test",
       quitTest: "Quitter la séance de test",


### PR DESCRIPTION
# Description

The start test dialog either displays the time allotted in minutes or "unlimited time" if no time is specified. 

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

<img width="730" alt="Screen Shot 2019-07-13 at 9 05 18 AM" src="https://user-images.githubusercontent.com/4640747/61172048-74abed00-a54d-11e9-97ca-5dee8db0a2ba.png">
<img width="725" alt="Screen Shot 2019-07-13 at 9 05 44 AM" src="https://user-images.githubusercontent.com/4640747/61172049-75448380-a54d-11e9-857e-596d36df44e4.png">

# Testing

Manual steps to reproduce this functionality:

1.  Go to the sample test instructions and click start test.
2.  Login and go to the pizza test instructions and click start test.

# Checklist

Applicable for all code changes.

- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [x] My changes generate no new accessibility errors and/or warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on ~~IE 11+~~ and Chrome
