### PR TITLE
[Accessibility] Add supporting test to valid fields in login

### DIFF
--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -592,7 +592,7 @@ class RegistrationForm extends Component {
                   {isValidFirstName && (
                     <div style={styles.iconForNames}>
                       <FontAwesomeIcon style={styles.checkMark} icon={faCheckCircle} />
-                      valid
+                      {LOCALIZE.authentication.createAccount.content.inputs.valid}
                     </div>
                   )}
 
@@ -625,6 +625,7 @@ class RegistrationForm extends Component {
                   {isValidLastName && (
                     <div style={styles.iconForNames}>
                       <FontAwesomeIcon style={styles.checkMark} icon={faCheckCircle} />
+                      {LOCALIZE.authentication.createAccount.content.inputs.valid}
                     </div>
                   )}
                   <input

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -50,13 +50,18 @@ const styles = {
   tooltipButton: {
     padding: 8
   },
+  checkMark: {
+    marginRight: 6
+  },
   iconForNames: {
     color: "#278400",
     position: "absolute",
     margin: "8px 0 0 175px"
   },
-  checkMark: {
-    marginRight: 6
+  iconForDates: {
+    color: "#278400",
+    position: "absolute",
+    margin: "8px 0 0 150px"
   },
   iconForOtherFields: {
     color: "#278400",
@@ -673,7 +678,7 @@ class RegistrationForm extends Component {
                   </OverlayTrigger>
                 </div>
                 {isValidDobDay && isValidDobMonth && isValidDobYear && (
-                  <div style={styles.iconForNames}>
+                  <div style={styles.iconForDates}>
                     <FontAwesomeIcon style={styles.checkMark} icon={faCheckCircle} />
                     {LOCALIZE.authentication.createAccount.content.inputs.valid}
                   </div>

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -53,7 +53,10 @@ const styles = {
   iconForNames: {
     color: "#278400",
     position: "absolute",
-    margin: "8px 0 0 220px"
+    margin: "8px 0 0 175px"
+  },
+  checkMark: {
+    marginRight: 6
   },
   iconForOtherFields: {
     color: "#278400",
@@ -587,7 +590,10 @@ class RegistrationForm extends Component {
                     <span style={styles.mandatoryMark}>{MANDATORY_MARK}</span>
                   </div>
                   {isValidFirstName && (
-                    <FontAwesomeIcon style={styles.iconForNames} icon={faCheckCircle} />
+                    <div style={styles.iconForNames}>
+                      <FontAwesomeIcon style={styles.checkMark} icon={faCheckCircle} />
+                      valid
+                    </div>
                   )}
 
                   <input
@@ -617,7 +623,9 @@ class RegistrationForm extends Component {
                     <span style={styles.mandatoryMark}>{MANDATORY_MARK}</span>
                   </div>
                   {isValidLastName && (
-                    <FontAwesomeIcon style={styles.iconForNames} icon={faCheckCircle} />
+                    <div style={styles.iconForNames}>
+                      <FontAwesomeIcon style={styles.checkMark} icon={faCheckCircle} />
+                    </div>
                   )}
                   <input
                     className={isValidLastName || isFirstLoad ? validFieldClass : invalidFieldClass}

--- a/frontend/src/components/authentication/RegistrationForm.jsx
+++ b/frontend/src/components/authentication/RegistrationForm.jsx
@@ -61,7 +61,7 @@ const styles = {
   iconForOtherFields: {
     color: "#278400",
     position: "absolute",
-    margin: "8px 0 0 484px"
+    margin: "8px 0 0 439px"
   },
   loginBtn: {
     width: 150,
@@ -672,6 +672,12 @@ class RegistrationForm extends Component {
                     </Button>
                   </OverlayTrigger>
                 </div>
+                {isValidDobDay && isValidDobMonth && isValidDobYear && (
+                  <div style={styles.iconForNames}>
+                    <FontAwesomeIcon style={styles.checkMark} icon={faCheckCircle} />
+                    {LOCALIZE.authentication.createAccount.content.inputs.valid}
+                  </div>
+                )}
                 <input
                   aria-label={this.dobDayAriaLabelCondition()}
                   aria-invalid={!this.state.isValidDobDay && !isFirstLoad}
@@ -731,7 +737,10 @@ class RegistrationForm extends Component {
                   <span style={styles.mandatoryMark}>{MANDATORY_MARK}</span>
                 </div>
                 {isValidEmail && (
-                  <FontAwesomeIcon style={styles.iconForOtherFields} icon={faCheckCircle} />
+                  <div style={styles.iconForOtherFields}>
+                    <FontAwesomeIcon style={styles.checkMark} icon={faCheckCircle} />
+                    {LOCALIZE.authentication.createAccount.content.inputs.valid}
+                  </div>
                 )}
                 <input
                   className={isValidEmail || isFirstLoad ? validFieldClass : invalidFieldClass}
@@ -764,7 +773,10 @@ class RegistrationForm extends Component {
                   </label>
                 </div>
                 {isValidPriOrMilitaryNbr && (
-                  <FontAwesomeIcon style={styles.iconForOtherFields} icon={faCheckCircle} />
+                  <div style={styles.iconForOtherFields}>
+                    <FontAwesomeIcon style={styles.checkMark} icon={faCheckCircle} />
+                    {LOCALIZE.authentication.createAccount.content.inputs.valid}
+                  </div>
                 )}
                 <input
                   className={
@@ -848,7 +860,10 @@ class RegistrationForm extends Component {
                   </OverlayTrigger>
                 </div>
                 {isValidPassword && (
-                  <FontAwesomeIcon style={styles.iconForOtherFields} icon={faCheckCircle} />
+                  <div style={styles.iconForOtherFields}>
+                    <FontAwesomeIcon style={styles.checkMark} icon={faCheckCircle} />
+                    {LOCALIZE.authentication.createAccount.content.inputs.valid}
+                  </div>
                 )}
                 <input
                   className={isValidPassword || isFirstLoad ? validFieldClass : invalidFieldClass}
@@ -936,7 +951,10 @@ class RegistrationForm extends Component {
                   <span style={styles.mandatoryMark}>{MANDATORY_MARK}</span>
                 </div>
                 {isValidPasswordConfirmation && (
-                  <FontAwesomeIcon style={styles.iconForOtherFields} icon={faCheckCircle} />
+                  <div style={styles.iconForOtherFields}>
+                    <FontAwesomeIcon style={styles.checkMark} icon={faCheckCircle} />
+                    {LOCALIZE.authentication.createAccount.content.inputs.valid}
+                  </div>
                 )}
                 <input
                   className={

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -48,6 +48,7 @@ let LOCALIZE = new LocalizedStrings({
           description:
             "An account is required to proceed further. To create an account, fill out the following.",
           inputs: {
+            valid: "valid",
             firstNameTitle: "First name:",
             firstNameError: "Must be a valid first name",
             lastNameTitle: "Last name:",
@@ -582,6 +583,7 @@ let LOCALIZE = new LocalizedStrings({
           description:
             "FR Un compte est nécessaire pour continuer. To create an account, fill out the following.",
           inputs: {
+            valid: "FR valid",
             firstNameTitle: "Prénom :",
             firstNameError: "FR Must be a valid first name",
             lastNameTitle: "Nom de famille :",


### PR DESCRIPTION
# Description

Adding "valid" next to check mark to further reinforce valid fields

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshot

With missing 2nd password:
![image](https://user-images.githubusercontent.com/2746350/61230708-91385880-a6f8-11e9-8722-041fc23789ef.png)

With invalid date:
![image](https://user-images.githubusercontent.com/2746350/61230742-a44b2880-a6f8-11e9-9c12-d0bb293b2998.png)


# Testing

Open login page.
Fill out fields and see what the valid text appears

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
