### PR TITLE
[Accessibility] Focus Management

### DIFF
--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -51,12 +51,12 @@ class Dashboard extends Component {
 
   // calling getUserInformation on page load to get the first name and last name
   componentDidMount = () => {
-    // focusing on welcome message
-    window.location.hash = "#user-welcome-message-div";
     // should always be defined, except for unit tests
     if (typeof this.props.getUserInformation !== "undefined") {
       this.props.getUserInformation(localStorage.auth_token).then(response => {
         this.setState({ first_name: response.first_name, last_name: response.last_name });
+        // focusing on welcome message after content load
+        document.getElementById("user-welcome-message-div").focus();
       });
     }
   };
@@ -64,7 +64,12 @@ class Dashboard extends Component {
   render() {
     return (
       <div>
-        <div id="user-welcome-message-div" role="region" aria-labelledby="user-welcome-message">
+        <div
+          id="user-welcome-message-div"
+          tabIndex={0}
+          role="region"
+          aria-labelledby="user-welcome-message"
+        >
           <h1 id="user-welcome-message" className="green-divider">
             {LOCALIZE.formatString(
               LOCALIZE.dashboard.title,

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -51,6 +51,8 @@ class Dashboard extends Component {
 
   // calling getUserInformation on page load to get the first name and last name
   componentDidMount = () => {
+    // focusing on welcome message
+    window.location.hash = "#user-welcome-message-div";
     // should always be defined, except for unit tests
     if (typeof this.props.getUserInformation !== "undefined") {
       this.props.getUserInformation(localStorage.auth_token).then(response => {
@@ -62,7 +64,7 @@ class Dashboard extends Component {
   render() {
     return (
       <div>
-        <div role="region" aria-labelledby="user-welcome-message">
+        <div id="user-welcome-message-div" role="region" aria-labelledby="user-welcome-message">
           <h1 id="user-welcome-message" className="green-divider">
             {LOCALIZE.formatString(
               LOCALIZE.dashboard.title,

--- a/frontend/src/components/commons/QuitConfirmation.jsx
+++ b/frontend/src/components/commons/QuitConfirmation.jsx
@@ -2,9 +2,13 @@ import React, { Component } from "react";
 import LOCALIZE from "../../text_resources";
 
 class QuitConfirmation extends Component {
+  componentDidMount = () => {
+    // focusing on you have quit the test div on page load
+    document.getElementById("you-have-quit-the-test-div").focus();
+  };
   render() {
     return (
-      <div>
+      <div id="you-have-quit-the-test-div" tabIndex={0}>
         <h1 className="green-divider">{LOCALIZE.emibTest.quitConfirmationPage.title}</h1>
         <p>{LOCALIZE.emibTest.quitConfirmationPage.instructionsRaiseHand}</p>
         <p>

--- a/frontend/src/components/eMIB/Background.jsx
+++ b/frontend/src/components/eMIB/Background.jsx
@@ -28,7 +28,7 @@ class Background extends Component {
     const sections = this.props.testBackground;
     return (
       <SideNavigation
-        startIndex={11}
+        startIndex={10}
         specs={sections.map(section => {
           return {
             menuString: section.title,

--- a/frontend/src/components/eMIB/Confirmation.jsx
+++ b/frontend/src/components/eMIB/Confirmation.jsx
@@ -2,29 +2,35 @@ import React, { Component } from "react";
 import LOCALIZE from "../../text_resources";
 
 class Confirmation extends Component {
+  componentDidMount = () => {
+    // focusing on your test has been submitted content section on page load
+    document.getElementById("test-submission-content").focus();
+  };
   // TODO add survey link.
   render() {
     return (
-      <div>
-        <h1 className="green-divider">
-          {LOCALIZE.emibTest.confirmationPage.submissionConfirmedTitle}
-        </h1>
-        <p style={{ fontSize: 24 }}>
-          {LOCALIZE.formatString(
-            LOCALIZE.emibTest.confirmationPage.feedbackSurvey,
-            <a href="https://www.canada.ca/home.html" target="_blank" rel="noopener noreferrer">
-              {LOCALIZE.emibTest.confirmationPage.optionalSurvey}
-            </a>
-          )}
-        </p>
-        <p>
-          {LOCALIZE.formatString(
-            LOCALIZE.emibTest.confirmationPage.logout,
-            <a href="mailto:cfp.cpp-ppc.psc@canada.ca">cfp.cpp-ppc.psc@canada.ca</a>
-          )}
-        </p>
-        <p>{LOCALIZE.emibTest.confirmationPage.thankYou}</p>
-      </div>
+      <section aria-labelledby="test-submission-content">
+        <div id="test-submission-content" tabIndex={0}>
+          <h1 className="green-divider">
+            {LOCALIZE.emibTest.confirmationPage.submissionConfirmedTitle}
+          </h1>
+          <p style={{ fontSize: 24 }}>
+            {LOCALIZE.formatString(
+              LOCALIZE.emibTest.confirmationPage.feedbackSurvey,
+              <a href="https://www.canada.ca/home.html" target="_blank" rel="noopener noreferrer">
+                {LOCALIZE.emibTest.confirmationPage.optionalSurvey}
+              </a>
+            )}
+          </p>
+          <p>
+            {LOCALIZE.formatString(
+              LOCALIZE.emibTest.confirmationPage.logout,
+              <a href="mailto:cfp.cpp-ppc.psc@canada.ca">cfp.cpp-ppc.psc@canada.ca</a>
+            )}
+          </p>
+          <p>{LOCALIZE.emibTest.confirmationPage.thankYou}</p>
+        </div>
+      </section>
     );
   }
 }

--- a/frontend/src/components/eMIB/EmibIntroductionPage.jsx
+++ b/frontend/src/components/eMIB/EmibIntroductionPage.jsx
@@ -34,6 +34,8 @@ class EmibIntroductionPage extends Component {
       : TEST_DEFINITION.emib.sampleTest;
     this.props.getTestMetaData(testNameId).then(response => {
       this.props.updateTestMetaDataState(response);
+      // focusing on test overview section after content load
+      document.getElementById("test-overview-div").focus();
     });
   };
 
@@ -49,7 +51,7 @@ class EmibIntroductionPage extends Component {
     const markdown_fr = testMetaData.meta_text.fr.overview[0];
 
     return (
-      <div>
+      <div id="test-overview-div" tabIndex={0}>
         {language === LANGUAGES.english && (
           <div>
             <h1 className="green-divider">{test_name_en}</h1>

--- a/frontend/src/components/eMIB/InTestInstructions.jsx
+++ b/frontend/src/components/eMIB/InTestInstructions.jsx
@@ -20,7 +20,7 @@ const getInstructionContent = () => {
 class InTestInstructions extends Component {
   render() {
     const specs = getInstructionContent();
-    return <SideNavigation specs={specs} startIndex={1} />;
+    return <SideNavigation specs={specs} startIndex={0} />;
   }
 }
 

--- a/frontend/src/components/eMIB/SideNavigation.jsx
+++ b/frontend/src/components/eMIB/SideNavigation.jsx
@@ -47,6 +47,11 @@ class SideNavigation extends Component {
 
   componentWillMount = () => {
     this.populateEventKeys();
+    // if background tab is rendered
+    if (this.props.startIndex === 10) {
+      // focusing on side navigation items of background tab
+      document.getElementById("navigation-items-section").focus();
+    }
   };
 
   render() {
@@ -56,15 +61,17 @@ class SideNavigation extends Component {
         <Row>
           <Col role="region" aria-label={LOCALIZE.ariaLabel.sideNavigationSections} sm={3}>
             <Nav role="navigation" variant="pills" className="flex-column" style={styles.nav}>
-              {specs.map((item, index) => {
-                return (
-                  <Nav.Item key={index}>
-                    <Nav.Link eventKey={EVENT_KEYS[index + startIndex]}>
-                      {specs[index].menuString}
-                    </Nav.Link>
-                  </Nav.Item>
-                );
-              })}
+              <div id="navigation-items-section" tabIndex={-1}>
+                {specs.map((item, index) => {
+                  return (
+                    <Nav.Item key={index}>
+                      <Nav.Link eventKey={EVENT_KEYS[index + startIndex]}>
+                        {specs[index].menuString}
+                      </Nav.Link>
+                    </Nav.Item>
+                  );
+                })}
+              </div>
             </Nav>
           </Col>
           <Col

--- a/frontend/src/modules/TestStatusRedux.js
+++ b/frontend/src/modules/TestStatusRedux.js
@@ -39,6 +39,7 @@ const testStatus = (state = initialState, action) => {
         currentPage: PAGES.confirm
       };
     case QUIT_TEST:
+      // Ensure local storage is cleaned up once the candidate quit the test.
       localStorage.removeItem("catLanguage");
       return {
         ...state,

--- a/frontend/src/modules/TestStatusRedux.js
+++ b/frontend/src/modules/TestStatusRedux.js
@@ -39,6 +39,7 @@ const testStatus = (state = initialState, action) => {
         currentPage: PAGES.confirm
       };
     case QUIT_TEST:
+      localStorage.removeItem("catLanguage");
       return {
         ...state,
         isTestActive: false,


### PR DESCRIPTION
# Description

This PR is introducing new focus management in the whole application. All pages where the focus was returning to the top navigation section are now keeping their focus.

Focus management of the following components have been updated:
- _Dashboard.jsx_
- _EmibIntroductionPage.jsx_
- _SideNavigation.jsx_
- _QuitConfirmation.jsx_
- _Confirmation.jsx_

Also, minor updates have been done to startIndex of _InTestInstructions.jsx_ and _Background.jsx_ components and "catLanguage" local storage is now removed on quit test action.

Once merged into master, I'll schedule a meeting with David to review these changes.

## Type of change

- New feature (non-breaking change which adds functionality)
- Code cleanliness or refactor

## Screenshot

**Dashboard**
---
**Before, once logged in, the focus was on the table:**
![image](https://user-images.githubusercontent.com/23021242/61322250-3d527000-a7db-11e9-8d63-166c6ac3ed79.png)

**Now, the focus is on the welcome message:**
![image](https://user-images.githubusercontent.com/23021242/61322187-1eec7480-a7db-11e9-9da4-b08e69363ae8.png)

**EmibIntroductionPage**
---
**Before, on the eMIB overview launch, the focus was on top navigation section:**
![image](https://user-images.githubusercontent.com/23021242/61322395-91f5eb00-a7db-11e9-9eb9-5e286051cad9.png)

**Now, the focus is on the overview content:**
![image](https://user-images.githubusercontent.com/23021242/61322430-a639e800-a7db-11e9-9eb4-9696aaa1c380.png)

**SideNavigation**
---
**Before, on eMIB test start, the focus was on the test footer:**
![image](https://user-images.githubusercontent.com/23021242/61322611-15174100-a7dc-11e9-92ba-dad26b542620.png)

![image](https://user-images.githubusercontent.com/23021242/61322692-4b54c080-a7dc-11e9-8d26-7528d7f56479.png)

**Now, the focus in on the background tab / side navigation items of the background:**
![image](https://user-images.githubusercontent.com/23021242/61322613-16486e00-a7dc-11e9-9673-82246b3145ec.png)

![image](https://user-images.githubusercontent.com/23021242/61322648-2ceec500-a7dc-11e9-99b8-709c5ae31778.png)

**QuitConfirmation**
---
**Before, on test quit action, the focus was on top navigation section**
![image](https://user-images.githubusercontent.com/23021242/61322792-7d662280-a7dc-11e9-80d8-f35145865b6f.png)

![image](https://user-images.githubusercontent.com/23021242/61322839-98d12d80-a7dc-11e9-83ee-90ae0a0ef6f8.png)

**Now, the focus is on the quit message content:**
![image](https://user-images.githubusercontent.com/23021242/61322807-8951e480-a7dc-11e9-83d4-12ea6856da13.png)

![image](https://user-images.githubusercontent.com/23021242/61322885-b30b0b80-a7dc-11e9-8368-7d1e4eeb2a35.png)

**Confirmation**
---
**Before, on test submission action, the focus was on the top navigation section:**
![image](https://user-images.githubusercontent.com/23021242/61322984-dfbf2300-a7dc-11e9-8d59-75519b152777.png)

![image](https://user-images.githubusercontent.com/23021242/61323033-ffeee200-a7dc-11e9-84ec-dea0446bfcf9.png)

**Now, the focus is on the test submission message content:**
![image](https://user-images.githubusercontent.com/23021242/61322985-e0f05000-a7dc-11e9-8bd2-61f61c9058f8.png)

![image](https://user-images.githubusercontent.com/23021242/61323007-ee0d3f00-a7dc-11e9-9c73-4cd8ef51b134.png)

# Testing

1.  Follow the same steps as the images above.
2.  Make sure that the screen reader reads all the content of the selected sections and that the focus is at the right place throughout the whole app.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
