### PR TITLE
[WIP Accessibility] Adding Skip Navigation link

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -106,7 +106,7 @@ class App extends Component {
     return (
       <div>
         <a href="#maincontent" className="visually-hidden">
-          Skip to main content
+          {LOCALIZE.mainTabs.skipToMain}
         </a>
         {!isLanguageSelected && <SelectLanguage />}
         {isLanguageSelected && (

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -105,6 +105,9 @@ class App extends Component {
     const isLanguageSelected = this.props.currentLanguage !== "";
     return (
       <div>
+        <a href="#maincontent" className="visually-hidden">
+          Skip to main content
+        </a>
         {!isLanguageSelected && <SelectLanguage />}
         {isLanguageSelected && (
           <div>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -179,17 +179,19 @@ class App extends Component {
                     <Translation variant="outline-light" />
                   </Navbar>
                 )}
-                <Route exact path={PATH.login} component={Home} />
-                {this.props.authenticated && <Route path={PATH.dashboard} component={Home} />}
-                <Route path={PATH.status} component={Status} />
-                <Route
-                  path={PATH.emibSampleTest}
-                  component={() => <Emib testNameId={TEST_DEFINITION.emib.sampleTest} />}
-                />
-                <Route
-                  path={PATH.test}
-                  component={() => <Emib testNameId={TEST_DEFINITION.emib.pizzaTest} />}
-                />
+                <div id="maincontent">
+                  <Route exact path={PATH.login} component={Home} />
+                  {this.props.authenticated && <Route path={PATH.dashboard} component={Home} />}
+                  <Route path={PATH.status} component={Status} />
+                  <Route
+                    path={PATH.emibSampleTest}
+                    component={() => <Emib testNameId={TEST_DEFINITION.emib.sampleTest} />}
+                  />
+                  <Route
+                    path={PATH.test}
+                    component={() => <Emib testNameId={TEST_DEFINITION.emib.pizzaTest} />}
+                  />
+                </div>
               </div>
             </Router>
           </div>

--- a/frontend/src/text_resources.js
+++ b/frontend/src/text_resources.js
@@ -10,7 +10,8 @@ let LOCALIZE = new LocalizedStrings({
       sampleTest: "Sample eMIB",
       statusTabTitle: "Status",
       psc: "Public Service Commission of Canada",
-      canada: "Government of Canada"
+      canada: "Government of Canada",
+      skipToMain: "Skip to main content"
     },
 
     //HTML Page Titles
@@ -550,7 +551,8 @@ let LOCALIZE = new LocalizedStrings({
       sampleTest: "BRG-e pratique",
       statusTabTitle: "Statut",
       psc: "Commission de la fonction publique du Canada",
-      canada: "Gouvernement du canada"
+      canada: "Gouvernement du canada",
+      skipToMain: "FR Skip to main content"
     },
 
     //HTML Page Titles


### PR DESCRIPTION
# Description

Adding skip navigation link to top to jump past main header
Implemented this way so as the navigation in the test is needed to get context and navigate through the inbox.
WIP as I need to verify that this is correct with David.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

Out of test skip link:
"Skip to main content link"
![image](https://user-images.githubusercontent.com/2746350/61369447-1db05b80-a85e-11e9-83dd-a2fd7aa4e1b2.png)
"Main landmark heading level 1 E M I B..."
![image](https://user-images.githubusercontent.com/2746350/61369542-56e8cb80-a85e-11e9-8e52-026741b92804.png)

In test
"Skip to main content visited link"
![image](https://user-images.githubusercontent.com/2746350/61369640-85ff3d00-a85e-11e9-8c08-0b2dd5df0e7e.png)

"Complementary landmark tab Instructions..."
![image](https://user-images.githubusercontent.com/2746350/61369741-c65ebb00-a85e-11e9-8039-889a750ed9c1.png)

# Testing

1. Open NVDA
2. tab back from the first visible button 
3. Hear the invisible skip to main button
4. Click to skip to main

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
