### PR TITLE
Changed language variable in background org charts to constant

### DIFF
--- a/frontend/src/components/eMIB/BackgroundSection.jsx
+++ b/frontend/src/components/eMIB/BackgroundSection.jsx
@@ -8,6 +8,7 @@ import PopupBox, { BUTTON_TYPE } from "../commons/PopupBox";
 import "../../css/react-medium-image-zoom.css";
 import TreeNode from "../commons/TreeNode";
 import { processTreeContent } from "../../helpers/transformations";
+import { LANGUAGES } from "../../modules/LocalizeRedux";
 
 const styles = {
   testImage: {
@@ -59,13 +60,13 @@ class BackgroundSection extends Component {
             // you don't need to have any authentication to access org chart images.
             let imageSource = `/orgCharts/${testNameId}/`;
             if (treeType === "organizational_structure_tree_child") {
-              if (currentLanguage === "en") {
+              if (currentLanguage === LANGUAGES.english) {
                 imageSource = imageSource + "org_chart_en.png";
               } else {
                 imageSource = imageSource + "org_chart_fr.png";
               }
             } else if (treeType === "team_information_tree_child") {
-              if (currentLanguage === "en") {
+              if (currentLanguage === LANGUAGES.english) {
                 imageSource = imageSource + "team_chart_en.png";
               } else {
                 imageSource = imageSource + "team_chart_fr.png";


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

## Type of change

Please delete options that are not relevant.

- Code cleanliness or refactor

## Screenshot

N/A

# Testing

Manual steps to reproduce this functionality:

1.  Go to Background Information page.
2.  View Org charts in both languages.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
~~[ ] I have added tests that prove my fix is effective or that my feature works~~
~~[ ] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)~~
- [x] My changes look good on IE 11+ and Chrome
