### PR TITLE
[Accessibility] Tooltip Fix

### DIFF
--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -361,6 +361,7 @@ class EditEmail extends Component {
                 }
               >
                 <Button
+                  tabIndex="-1"
                   aria-label={LOCALIZE.ariaLabel.emailResponseTooltip}
                   style={styles.tooltipButton}
                   variant="link"
@@ -412,6 +413,7 @@ class EditEmail extends Component {
                 }
               >
                 <Button
+                  tabIndex="-1"
                   aria-label={LOCALIZE.ariaLabel.reasonsForActionTooltip}
                   style={styles.tooltipButton}
                   variant="link"

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -350,7 +350,7 @@ class EditEmail extends Component {
           </div>
           <div>
             <div className="font-weight-bold form-group">
-              <label id="your-response-text-label" htmlFor="your-response-text-area">
+              <label id="your-response-text-label">
                 {LOCALIZE.formatString(
                   LOCALIZE.emibTest.inboxPage.addEmailResponse.response,
                   MAX_RESPONSE
@@ -405,7 +405,7 @@ class EditEmail extends Component {
           </div>
           <div>
             <div className="font-weight-bold form-group">
-              <label id="reasons-for-action-text-label" htmlFor="reasons-for-action-text-area">
+              <label id="reasons-for-action-text-label">
                 {LOCALIZE.formatString(
                   LOCALIZE.emibTest.inboxPage.addEmailResponse.reasonsForAction,
                   MAX_REASON

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -353,7 +353,7 @@ class EditEmail extends Component {
                 trigger="click"
                 placement="right"
                 overlay={
-                  <Popover id="reasons-for-action-tooltip">
+                  <Popover>
                     <div>
                       <p>{LOCALIZE.emibTest.inboxPage.addEmailResponse.emailResponseTooltip}</p>
                     </div>
@@ -403,7 +403,7 @@ class EditEmail extends Component {
                 trigger="click"
                 placement="right"
                 overlay={
-                  <Popover id="reasons-for-action-tooltip">
+                  <Popover>
                     <div>
                       <p>{LOCALIZE.emibTest.inboxPage.addEmailResponse.reasonsForActionTooltip}</p>
                     </div>

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -361,7 +361,6 @@ class EditEmail extends Component {
                 }
               >
                 <Button
-                  id="your-response-tooltip-button"
                   tabIndex="-1"
                   aria-label={LOCALIZE.ariaLabel.emailResponseTooltip}
                   style={styles.tooltipButton}
@@ -414,7 +413,6 @@ class EditEmail extends Component {
                 }
               >
                 <Button
-                  id="reasons-for-action-tooltip-button"
                   tabIndex="-1"
                   aria-label={LOCALIZE.ariaLabel.reasonsForActionTooltip}
                   style={styles.tooltipButton}

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -216,6 +216,13 @@ class EditEmail extends Component {
     // Convert emailTo and emailCC from array of indexes to options.
     emailTo = optionsFromIds(this.props.addressBook, emailTo);
     emailCc = optionsFromIds(this.props.addressBook, emailCc);
+    // These two constants are used by 2 seperate labels:
+    // 1 is a popover (which does not exist until clicked on;
+    // thus cannot be used for aria-labelled-by)
+    // 2 is a visual hidden label which aria-labelled by can use
+    const yourResponseTooltipText =
+      LOCALIZE.emibTest.inboxPage.addEmailResponse.emailResponseTooltip;
+    const reasonsTooltipText = LOCALIZE.emibTest.inboxPage.addEmailResponse.reasonsForActionTooltip;
     return (
       <div style={styles.container}>
         <form>
@@ -343,7 +350,7 @@ class EditEmail extends Component {
           </div>
           <div>
             <div className="font-weight-bold form-group">
-              <label htmlFor="your-response-text-area">
+              <label id="your-response-text-label" htmlFor="your-response-text-area">
                 {LOCALIZE.formatString(
                   LOCALIZE.emibTest.inboxPage.addEmailResponse.response,
                   MAX_RESPONSE
@@ -355,7 +362,7 @@ class EditEmail extends Component {
                 overlay={
                   <Popover>
                     <div>
-                      <p>{LOCALIZE.emibTest.inboxPage.addEmailResponse.emailResponseTooltip}</p>
+                      <p>{yourResponseTooltipText}</p>
                     </div>
                   </Popover>
                 }
@@ -370,10 +377,13 @@ class EditEmail extends Component {
                 </Button>
               </OverlayTrigger>
               <div>
+                <label className="visually-hidden" id="your-response-tooltip-text">
+                  {yourResponseTooltipText}
+                </label>
                 <textarea
                   id="your-response-text-area"
                   maxLength={MAX_RESPONSE}
-                  aria-label={LOCALIZE.emibTest.inboxPage.addEmailResponse.emailResponseTooltip}
+                  aria-labelledby="your-response-text-label your-response-tooltip-text"
                   style={styles.response.textArea}
                   value={emailBody}
                   onChange={this.onEmailBodyChange}
@@ -395,7 +405,7 @@ class EditEmail extends Component {
           </div>
           <div>
             <div className="font-weight-bold form-group">
-              <label htmlFor="reasons-for-action-text-area">
+              <label id="reasons-for-action-text-label" htmlFor="reasons-for-action-text-area">
                 {LOCALIZE.formatString(
                   LOCALIZE.emibTest.inboxPage.addEmailResponse.reasonsForAction,
                   MAX_REASON
@@ -407,7 +417,7 @@ class EditEmail extends Component {
                 overlay={
                   <Popover>
                     <div>
-                      <p>{LOCALIZE.emibTest.inboxPage.addEmailResponse.reasonsForActionTooltip}</p>
+                      <p>{reasonsTooltipText}</p>
                     </div>
                   </Popover>
                 }
@@ -422,10 +432,13 @@ class EditEmail extends Component {
                 </Button>
               </OverlayTrigger>
               <div>
+                <label className="visually-hidden" id="reasons-for-action-tooltip-text">
+                  {reasonsTooltipText}
+                </label>
                 <textarea
                   id="reasons-for-action-text-area"
                   maxLength={MAX_REASON}
-                  aria-label={LOCALIZE.emibTest.inboxPage.addEmailResponse.reasonsForActionTooltip}
+                  aria-labelledby="reasons-for-action-text-label reasons-for-action-tooltip-text"
                   style={styles.reasonsForAction.textArea}
                   value={reasonsForAction}
                   onChange={this.onReasonsForActionChange}

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -389,8 +389,6 @@ class EditEmail extends Component {
                   style={styles.response.textArea}
                   value={emailBody}
                   onChange={this.onEmailBodyChange}
-                  onFocus={this.triggerResponseTooltipClick}
-                  onBlur={this.triggerResponseTooltipClick}
                 />
               </div>
               {this.state.emailBody.length >= MAX_RESPONSE && (
@@ -445,8 +443,6 @@ class EditEmail extends Component {
                   style={styles.reasonsForAction.textArea}
                   value={reasonsForAction}
                   onChange={this.onReasonsForActionChange}
-                  onFocus={this.triggerReasonTooltipClick}
-                  onBlur={this.triggerReasonTooltipClick}
                 />
               </div>
               {this.state.reasonsForAction.length >= MAX_REASON && (

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -204,6 +204,16 @@ class EditEmail extends Component {
     this.props.onChange({ ...this.state, reasonsForAction: newreasonsForAction });
   };
 
+  // triggers DOB tooltip button click in order to show/hide the tooltip window
+  triggerResponseTooltipClick = () => {
+    document.getElementById("your-response-tooltip-button").click();
+  };
+
+  // triggers DOB tooltip button click in order to show/hide the tooltip window
+  triggerReasonTooltipClick = () => {
+    document.getElementById("reasons-for-action-tooltip-button").click();
+  };
+
   render() {
     let { emailTo, emailCc, emailBody, reasonsForAction } = this.state;
     const replyChecked = this.state.emailType === EMAIL_TYPE.reply;
@@ -361,10 +371,12 @@ class EditEmail extends Component {
                 }
               >
                 <Button
+                  id="your-response-tooltip-button"
                   tabIndex="-1"
                   aria-label={LOCALIZE.ariaLabel.emailResponseTooltip}
                   style={styles.tooltipButton}
                   variant="link"
+                  onBlur={this.triggerResponseTooltipClick}
                 >
                   ?
                 </Button>
@@ -377,6 +389,8 @@ class EditEmail extends Component {
                   style={styles.response.textArea}
                   value={emailBody}
                   onChange={this.onEmailBodyChange}
+                  onFocus={this.triggerResponseTooltipClick}
+                  onBlur={this.triggerResponseTooltipClick}
                 />
               </div>
               {this.state.emailBody.length >= MAX_RESPONSE && (
@@ -413,10 +427,12 @@ class EditEmail extends Component {
                 }
               >
                 <Button
+                  id="reasons-for-action-tooltip-button"
                   tabIndex="-1"
                   aria-label={LOCALIZE.ariaLabel.reasonsForActionTooltip}
                   style={styles.tooltipButton}
                   variant="link"
+                  onBlur={this.triggerReasonTooltipClick}
                 >
                   ?
                 </Button>
@@ -429,6 +445,8 @@ class EditEmail extends Component {
                   style={styles.reasonsForAction.textArea}
                   value={reasonsForAction}
                   onChange={this.onReasonsForActionChange}
+                  onFocus={this.triggerReasonTooltipClick}
+                  onBlur={this.triggerReasonTooltipClick}
                 />
               </div>
               {this.state.reasonsForAction.length >= MAX_REASON && (

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -372,6 +372,7 @@ class EditEmail extends Component {
                 <textarea
                   id="your-response-text-area"
                   maxLength={MAX_RESPONSE}
+                  aria-label={LOCALIZE.emibTest.inboxPage.addEmailResponse.emailResponseTooltip}
                   style={styles.response.textArea}
                   value={emailBody}
                   onChange={this.onEmailBodyChange}
@@ -422,6 +423,7 @@ class EditEmail extends Component {
                 <textarea
                   id="reasons-for-action-text-area"
                   maxLength={MAX_REASON}
+                  aria-label={LOCALIZE.emibTest.inboxPage.addEmailResponse.reasonsForActionTooltip}
                   style={styles.reasonsForAction.textArea}
                   value={reasonsForAction}
                   onChange={this.onReasonsForActionChange}

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -204,16 +204,6 @@ class EditEmail extends Component {
     this.props.onChange({ ...this.state, reasonsForAction: newreasonsForAction });
   };
 
-  // triggers DOB tooltip button click in order to show/hide the tooltip window
-  triggerResponseTooltipClick = () => {
-    document.getElementById("your-response-tooltip-button").click();
-  };
-
-  // triggers DOB tooltip button click in order to show/hide the tooltip window
-  triggerReasonTooltipClick = () => {
-    document.getElementById("reasons-for-action-tooltip-button").click();
-  };
-
   render() {
     let { emailTo, emailCc, emailBody, reasonsForAction } = this.state;
     const replyChecked = this.state.emailType === EMAIL_TYPE.reply;
@@ -360,7 +350,7 @@ class EditEmail extends Component {
                 )}
               </label>
               <OverlayTrigger
-                trigger="click"
+                trigger="focus"
                 placement="right"
                 overlay={
                   <Popover>
@@ -376,7 +366,6 @@ class EditEmail extends Component {
                   aria-label={LOCALIZE.ariaLabel.emailResponseTooltip}
                   style={styles.tooltipButton}
                   variant="link"
-                  onBlur={this.triggerResponseTooltipClick}
                 >
                   ?
                 </Button>
@@ -414,7 +403,7 @@ class EditEmail extends Component {
                 )}
               </label>
               <OverlayTrigger
-                trigger="click"
+                trigger="focus"
                 placement="right"
                 overlay={
                   <Popover>
@@ -430,7 +419,6 @@ class EditEmail extends Component {
                   aria-label={LOCALIZE.ariaLabel.reasonsForActionTooltip}
                   style={styles.tooltipButton}
                   variant="link"
-                  onBlur={this.triggerReasonTooltipClick}
                 >
                   ?
                 </Button>

--- a/frontend/src/components/eMIB/EditEmail.jsx
+++ b/frontend/src/components/eMIB/EditEmail.jsx
@@ -350,7 +350,7 @@ class EditEmail extends Component {
                 )}
               </label>
               <OverlayTrigger
-                trigger="focus"
+                trigger="click"
                 placement="right"
                 overlay={
                   <Popover id="reasons-for-action-tooltip">
@@ -400,7 +400,7 @@ class EditEmail extends Component {
                 )}
               </label>
               <OverlayTrigger
-                trigger="focus"
+                trigger="click"
                 placement="right"
                 overlay={
                   <Popover id="reasons-for-action-tooltip">

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -106,7 +106,7 @@ class EditTask extends Component {
                 {LOCALIZE.formatString(LOCALIZE.emibTest.inboxPage.addEmailTask.task, MAX_TASK)}
               </label>
               <OverlayTrigger
-                trigger="focus"
+                trigger="click"
                 placement="right"
                 overlay={
                   <Popover>
@@ -156,7 +156,7 @@ class EditTask extends Component {
                 )}
               </label>
               <OverlayTrigger
-                trigger="focus"
+                trigger="click"
                 placement="right"
                 overlay={
                   <Popover id="reasons-for-action-tooltip">

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -100,10 +100,9 @@ class EditTask extends Component {
     // 1 is a popover (which does not exist until clicked on;
     // thus cannot be used for aria-labelled-by)
     // 2 is a visual hidden label which aria-labelled by can use
-    //TODO yourTaskTooltipText needs to be better formatted.....
+    // Note: yourTaskTooltipText is not used for the popup label as it needs additional html
     const yourTaskTooltipText =
       LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart1 +
-      " " +
       LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart2;
     const reasonsTooltipText = LOCALIZE.emibTest.inboxPage.taskContent.reasonsForActionTooltip;
 
@@ -125,7 +124,8 @@ class EditTask extends Component {
                 overlay={
                   <Popover>
                     <div>
-                      <p>{yourTaskTooltipText}</p>
+                      <p>{LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart1}</p>
+                      <p>{LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart2}</p>
                     </div>
                   </Popover>
                 }

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -94,16 +94,6 @@ class EditTask extends Component {
     this.props.onChange({ ...this.state, reasonsForAction: newReasonForAction });
   };
 
-  // triggers DOB tooltip button click in order to show/hide the tooltip window
-  triggerTaskTooltipClick = () => {
-    document.getElementById("your-tasks-tooltip-button").click();
-  };
-
-  // triggers DOB tooltip button click in order to show/hide the tooltip window
-  triggerReasonTooltipClick = () => {
-    document.getElementById("reasons-for-action-tooltip-button").click();
-  };
-
   render() {
     const { task, reasonsForAction } = this.state;
 
@@ -116,7 +106,7 @@ class EditTask extends Component {
                 {LOCALIZE.formatString(LOCALIZE.emibTest.inboxPage.addEmailTask.task, MAX_TASK)}
               </label>
               <OverlayTrigger
-                trigger="click"
+                trigger="focus"
                 placement="right"
                 overlay={
                   <Popover>
@@ -133,7 +123,6 @@ class EditTask extends Component {
                   aria-label={LOCALIZE.ariaLabel.taskTooltip}
                   style={styles.tooltipButton}
                   variant="link"
-                  onBlur={this.triggerTaskTooltipClick}
                 >
                   ?
                 </Button>
@@ -173,7 +162,7 @@ class EditTask extends Component {
                 )}
               </label>
               <OverlayTrigger
-                trigger="click"
+                trigger="focus"
                 placement="right"
                 overlay={
                   <Popover>
@@ -189,7 +178,6 @@ class EditTask extends Component {
                   aria-label={LOCALIZE.ariaLabel.reasonsForActionTooltip}
                   style={styles.tooltipButton}
                   variant="link"
-                  onBlur={this.triggerReasonTooltipClick}
                 >
                   ?
                 </Button>

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -96,13 +96,27 @@ class EditTask extends Component {
 
   render() {
     const { task, reasonsForAction } = this.state;
+    // These two constants are used by 2 seperate labels:
+    // 1 is a popover (which does not exist until clicked on;
+    // thus cannot be used for aria-labelled-by)
+    // 2 is a visual hidden label which aria-labelled by can use
+    //TODO yourTaskTooltipText needs to be better formatted.....
+    const yourTaskTooltipText =
+      LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart1 +
+      " " +
+      LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart2;
+    const reasonsTooltipText = LOCALIZE.emibTest.inboxPage.taskContent.reasonsForActionTooltip;
 
     return (
       <div style={styles.container}>
         <form>
           <div>
             <div className="font-weight-bold form-group">
-              <label htmlFor="your-tasks-text-area" style={styles.tasks.title}>
+              <label
+                id="your-task-text-label"
+                htmlFor="your-tasks-text-area"
+                style={styles.tasks.title}
+              >
                 {LOCALIZE.formatString(LOCALIZE.emibTest.inboxPage.addEmailTask.task, MAX_TASK)}
               </label>
               <OverlayTrigger
@@ -111,8 +125,7 @@ class EditTask extends Component {
                 overlay={
                   <Popover>
                     <div>
-                      <p>{LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart1}</p>
-                      <p>{LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart2}</p>
+                      <p>{yourTaskTooltipText}</p>
                     </div>
                   </Popover>
                 }
@@ -127,13 +140,13 @@ class EditTask extends Component {
                 </Button>
               </OverlayTrigger>
               <div>
+                <label className="visually-hidden" id="your-task-tooltip-text">
+                  {yourTaskTooltipText}
+                </label>
                 <textarea
                   id="your-tasks-text-area"
                   maxLength={MAX_TASK}
-                  aria-label={
-                    LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart1 +
-                    LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart2
-                  }
+                  aria-labelledby="your-task-text-label your-task-tooltip-text"
                   style={styles.tasks.textArea}
                   value={task}
                   onChange={this.onTaskContentChange}
@@ -154,7 +167,11 @@ class EditTask extends Component {
           </div>
           <div>
             <div className="font-weight-bold form-group">
-              <label htmlFor="reasons-for-action-text-area" style={styles.reasonsForAction.title}>
+              <label
+                id="reasons-for-action-text-label"
+                htmlFor="reasons-for-action-text-area"
+                style={styles.reasonsForAction.title}
+              >
                 {LOCALIZE.formatString(
                   LOCALIZE.emibTest.inboxPage.addEmailTask.reasonsForAction,
                   MAX_REASON
@@ -166,7 +183,7 @@ class EditTask extends Component {
                 overlay={
                   <Popover>
                     <div>
-                      <p>{LOCALIZE.emibTest.inboxPage.taskContent.reasonsForActionTooltip}</p>
+                      <p>{reasonsTooltipText}</p>
                     </div>
                   </Popover>
                 }
@@ -181,10 +198,13 @@ class EditTask extends Component {
                 </Button>
               </OverlayTrigger>
               <div>
+                <label className="visually-hidden" id="reasons-for-action-tooltip-text">
+                  {reasonsTooltipText}
+                </label>
                 <textarea
                   id="reasons-for-action-text-area"
                   maxLength={MAX_REASON}
-                  aria-label={LOCALIZE.emibTest.inboxPage.taskContent.reasonsForActionTooltip}
+                  aria-labelledby="reasons-for-action-text-label reasons-for-action-tooltip-text"
                   style={styles.reasonsForAction.textArea}
                   value={reasonsForAction}
                   onChange={this.onReasonsForActionChange}

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -159,7 +159,7 @@ class EditTask extends Component {
                 trigger="click"
                 placement="right"
                 overlay={
-                  <Popover id="reasons-for-action-tooltip">
+                  <Popover>
                     <div>
                       <p>{LOCALIZE.emibTest.inboxPage.taskContent.reasonsForActionTooltip}</p>
                     </div>

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -118,7 +118,6 @@ class EditTask extends Component {
                 }
               >
                 <Button
-                  id="your-tasks-tooltip-button"
                   tabIndex="-1"
                   aria-label={LOCALIZE.ariaLabel.taskTooltip}
                   style={styles.tooltipButton}
@@ -173,7 +172,6 @@ class EditTask extends Component {
                 }
               >
                 <Button
-                  id="reasons-for-action-tooltip-button"
                   tabIndex="-1"
                   aria-label={LOCALIZE.ariaLabel.reasonsForActionTooltip}
                   style={styles.tooltipButton}

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -149,8 +149,6 @@ class EditTask extends Component {
                   style={styles.tasks.textArea}
                   value={task}
                   onChange={this.onTaskContentChange}
-                  onFocus={this.triggerTaskTooltipClick}
-                  onBlur={this.triggerTaskTooltipClick}
                 />
               </div>
               {this.state.task.length >= MAX_TASK && (
@@ -204,8 +202,6 @@ class EditTask extends Component {
                   style={styles.reasonsForAction.textArea}
                   value={reasonsForAction}
                   onChange={this.onReasonsForActionChange}
-                  onFocus={this.triggerReasonTooltipClick}
-                  onBlur={this.triggerReasonTooltipClick}
                 />
               </div>
               {this.state.reasonsForAction.length >= MAX_REASON && (

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -111,11 +111,7 @@ class EditTask extends Component {
         <form>
           <div>
             <div className="font-weight-bold form-group">
-              <label
-                id="your-task-text-label"
-                htmlFor="your-tasks-text-area"
-                style={styles.tasks.title}
-              >
+              <label id="your-task-text-label" style={styles.tasks.title}>
                 {LOCALIZE.formatString(LOCALIZE.emibTest.inboxPage.addEmailTask.task, MAX_TASK)}
               </label>
               <OverlayTrigger
@@ -167,11 +163,7 @@ class EditTask extends Component {
           </div>
           <div>
             <div className="font-weight-bold form-group">
-              <label
-                id="reasons-for-action-text-label"
-                htmlFor="reasons-for-action-text-area"
-                style={styles.reasonsForAction.title}
-              >
+              <label id="reasons-for-action-text-label" style={styles.reasonsForAction.title}>
                 {LOCALIZE.formatString(
                   LOCALIZE.emibTest.inboxPage.addEmailTask.reasonsForAction,
                   MAX_REASON

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -129,6 +129,10 @@ class EditTask extends Component {
                 <textarea
                   id="your-tasks-text-area"
                   maxLength={MAX_TASK}
+                  aria-label={
+                    LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart1 +
+                    LOCALIZE.emibTest.inboxPage.taskContent.taskTooltipPart2
+                  }
                   style={styles.tasks.textArea}
                   value={task}
                   onChange={this.onTaskContentChange}
@@ -178,6 +182,7 @@ class EditTask extends Component {
                 <textarea
                   id="reasons-for-action-text-area"
                   maxLength={MAX_REASON}
+                  aria-label={LOCALIZE.emibTest.inboxPage.taskContent.reasonsForActionTooltip}
                   style={styles.reasonsForAction.textArea}
                   value={reasonsForAction}
                   onChange={this.onReasonsForActionChange}

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -94,6 +94,16 @@ class EditTask extends Component {
     this.props.onChange({ ...this.state, reasonsForAction: newReasonForAction });
   };
 
+  // triggers DOB tooltip button click in order to show/hide the tooltip window
+  triggerTaskTooltipClick = () => {
+    document.getElementById("your-tasks-tooltip-button").click();
+  };
+
+  // triggers DOB tooltip button click in order to show/hide the tooltip window
+  triggerReasonTooltipClick = () => {
+    document.getElementById("reasons-for-action-tooltip-button").click();
+  };
+
   render() {
     const { task, reasonsForAction } = this.state;
 
@@ -118,10 +128,12 @@ class EditTask extends Component {
                 }
               >
                 <Button
+                  id="your-tasks-tooltip-button"
                   tabIndex="-1"
                   aria-label={LOCALIZE.ariaLabel.taskTooltip}
                   style={styles.tooltipButton}
                   variant="link"
+                  onBlur={this.triggerTaskTooltipClick}
                 >
                   ?
                 </Button>
@@ -137,6 +149,8 @@ class EditTask extends Component {
                   style={styles.tasks.textArea}
                   value={task}
                   onChange={this.onTaskContentChange}
+                  onFocus={this.triggerTaskTooltipClick}
+                  onBlur={this.triggerTaskTooltipClick}
                 />
               </div>
               {this.state.task.length >= MAX_TASK && (
@@ -172,10 +186,12 @@ class EditTask extends Component {
                 }
               >
                 <Button
+                  id="reasons-for-action-tooltip-button"
                   tabIndex="-1"
                   aria-label={LOCALIZE.ariaLabel.reasonsForActionTooltip}
                   style={styles.tooltipButton}
                   variant="link"
+                  onBlur={this.triggerReasonTooltipClick}
                 >
                   ?
                 </Button>
@@ -188,6 +204,8 @@ class EditTask extends Component {
                   style={styles.reasonsForAction.textArea}
                   value={reasonsForAction}
                   onChange={this.onReasonsForActionChange}
+                  onFocus={this.triggerReasonTooltipClick}
+                  onBlur={this.triggerReasonTooltipClick}
                 />
               </div>
               {this.state.reasonsForAction.length >= MAX_REASON && (

--- a/frontend/src/components/eMIB/EditTask.jsx
+++ b/frontend/src/components/eMIB/EditTask.jsx
@@ -118,6 +118,7 @@ class EditTask extends Component {
                 }
               >
                 <Button
+                  tabIndex="-1"
                   aria-label={LOCALIZE.ariaLabel.taskTooltip}
                   style={styles.tooltipButton}
                   variant="link"
@@ -171,6 +172,7 @@ class EditTask extends Component {
                 }
               >
                 <Button
+                  tabIndex="-1"
                   aria-label={LOCALIZE.ariaLabel.reasonsForActionTooltip}
                   style={styles.tooltipButton}
                   variant="link"


### PR DESCRIPTION
# Description

Corrects tooltips to behave exactly like the tooltip for the Year DOB in the RegistrationForm
- Cannot tab to ? button
- ? can be clicked to toggle the tooltip
- Tooltip reads automatically (in NVDA) when a user tabs into the textfield
- Tooltip does not visibly open when user tabs into the field
- (new in ea161a4) Tooltip closes automatically when user tabs away from ?

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Screenshot
No field selected
![image](https://user-images.githubusercontent.com/2746350/61399437-2fb0ef00-a89c-11e9-8258-62e9d73a2a1e.png)

Tabbing into field (tooltip does not open, but NVDA reads it out loud):
![image](https://user-images.githubusercontent.com/2746350/61482885-a667ee00-a969-11e9-8d0d-fc51d64e29cb.png)

Clicking on the ? button
![image](https://user-images.githubusercontent.com/2746350/61399453-38a1c080-a89c-11e9-8f92-47c0701c8f52.png)


# Testing

Open NVDA
Open the test; create/edit an email or text response
Try out the behaviors listed in the description

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new compiler warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
