### PR TITLE
[Accessibility] Side navigation bug fix

### DIFF
--- a/frontend/src/components/eMIB/SideNavigation.jsx
+++ b/frontend/src/components/eMIB/SideNavigation.jsx
@@ -65,7 +65,7 @@ class SideNavigation extends Component {
                 {specs.map((item, index) => {
                   return (
                     <Nav.Item key={index}>
-                      <Nav.Link eventKey={EVENT_KEYS[index + startIndex]}>
+                      <Nav.Link role="tab" eventKey={EVENT_KEYS[index + startIndex]}>
                         {specs[index].menuString}
                       </Nav.Link>
                     </Nav.Item>


### PR DESCRIPTION
# Description

This PR is fixing the broken side navigation. 

Before this fix, we needed to tab throughout the side navigation items, hit enter to select the desired item and then tab until the focus was on the content.

Now, you can navigate throughout the navigation items with up and down arrows and simply tab to go to the content part of the selected item.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshot

**Select the desired side navigation item using up and down arrows:**
![image](https://user-images.githubusercontent.com/23021242/61537534-65bdb280-aa05-11e9-81e1-41feb6713b70.png)

**Once the desired item is selected, hit tab once to focus on the content:**
![image](https://user-images.githubusercontent.com/23021242/61537578-7a01af80-aa05-11e9-9e5c-7c3531c96c43.png)

# Testing

Manual steps to reproduce this functionality:

1.  Start the eMIB sample test.
2.  Make sure that you can navigate throughout the side navigation items using up and down arrows.
3.  Also make sure that you can go to the content by hitting "Tab" once.

# Checklist

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new compiler warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have researched WCAG2.1 accessibility standards and met them in this PR (can be navigated using a keyboard)
- [x] My changes look good on IE 11+ and Chrome
